### PR TITLE
feat: expose config for generating plain ts client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ apps/
 .vscode
 docs/.vuepress/dist
 build/
+# vim swap files
+*.swp

--- a/scripts/data/gen-nodetime/package-lock.json
+++ b/scripts/data/gen-nodetime/package-lock.json
@@ -20,7 +20,7 @@
 				"pkg": "^4.4.9",
 				"protobufjs": "^6.10.2",
 				"swagger-combine": "^1.3.0",
-				"swagger-typescript-api": "^5.1.7",
+				"swagger-typescript-api": "^9.1.1",
 				"ts-proto": "^1.68.0"
 			},
 			"bin": {
@@ -1559,6 +1559,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
+		"node_modules/lodash.toarray": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+		},
 		"node_modules/logform": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
@@ -1677,14 +1682,22 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.20",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-			"integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+			"version": "3.1.23",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/node-emoji": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+			"integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+			"dependencies": {
+				"lodash.toarray": "^4.4.0"
 			}
 		},
 		"node_modules/node-fetch": {
@@ -2397,22 +2410,23 @@
 			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
 		},
 		"node_modules/swagger-typescript-api": {
-			"version": "5.1.7",
-			"resolved": "https://registry.npmjs.org/swagger-typescript-api/-/swagger-typescript-api-5.1.7.tgz",
-			"integrity": "sha512-SxGg0V1PTbcGFtK3ADlnJ9CsQJz+JrgjUm1/wjpzlDx+Ek00IP61CsjZEcMHr7n8ZztCyvihDsexX7gC2mWWkw==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/swagger-typescript-api/-/swagger-typescript-api-9.1.1.tgz",
+			"integrity": "sha512-Ho11UEPO9WSnhGHtiuy4YbSBri37pdEa2jJPDmTwbMbhRtIFp5M1rlT3nEoyVrfDZ+k4l+oXcQZ+xcZ1mlWO3A==",
 			"dependencies": {
 				"@types/swagger-schema-official": "2.0.21",
 				"axios": "^0.21.1",
 				"commander": "^6.2.1",
 				"eta": "^1.12.1",
 				"js-yaml": "^4.0.0",
-				"lodash": "^4.17.20",
+				"lodash": "^4.17.21",
 				"make-dir": "^3.1.0",
-				"nanoid": "^3.1.20",
+				"nanoid": "^3.1.22",
+				"node-emoji": "^1.10.0",
 				"prettier": "^2.2.1",
 				"swagger-schema-official": "2.0.0-bab6bed",
 				"swagger2openapi": "^7.0.5",
-				"typescript": "^4.1.3"
+				"typescript": "^4.2.4"
 			},
 			"bin": {
 				"sta": "index.js",
@@ -4177,6 +4191,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
+		"lodash.toarray": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+		},
 		"logform": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
@@ -4277,9 +4296,17 @@
 			}
 		},
 		"nanoid": {
-			"version": "3.1.20",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-			"integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
+			"version": "3.1.23",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+		},
+		"node-emoji": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+			"integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+			"requires": {
+				"lodash.toarray": "^4.4.0"
+			}
 		},
 		"node-fetch": {
 			"version": "2.6.1",
@@ -4871,22 +4898,23 @@
 			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
 		},
 		"swagger-typescript-api": {
-			"version": "5.1.7",
-			"resolved": "https://registry.npmjs.org/swagger-typescript-api/-/swagger-typescript-api-5.1.7.tgz",
-			"integrity": "sha512-SxGg0V1PTbcGFtK3ADlnJ9CsQJz+JrgjUm1/wjpzlDx+Ek00IP61CsjZEcMHr7n8ZztCyvihDsexX7gC2mWWkw==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/swagger-typescript-api/-/swagger-typescript-api-9.1.1.tgz",
+			"integrity": "sha512-Ho11UEPO9WSnhGHtiuy4YbSBri37pdEa2jJPDmTwbMbhRtIFp5M1rlT3nEoyVrfDZ+k4l+oXcQZ+xcZ1mlWO3A==",
 			"requires": {
 				"@types/swagger-schema-official": "2.0.21",
 				"axios": "^0.21.1",
 				"commander": "^6.2.1",
 				"eta": "^1.12.1",
 				"js-yaml": "^4.0.0",
-				"lodash": "^4.17.20",
+				"lodash": "^4.17.21",
 				"make-dir": "^3.1.0",
-				"nanoid": "^3.1.20",
+				"nanoid": "^3.1.22",
+				"node-emoji": "^1.10.0",
 				"prettier": "^2.2.1",
 				"swagger-schema-official": "2.0.0-bab6bed",
 				"swagger2openapi": "^7.0.5",
-				"typescript": "^4.1.3"
+				"typescript": "^4.2.4"
 			}
 		},
 		"swagger2openapi": {

--- a/scripts/data/gen-nodetime/package.json
+++ b/scripts/data/gen-nodetime/package.json
@@ -22,7 +22,7 @@
 		"pkg": "^4.4.9",
 		"protobufjs": "^6.10.2",
 		"swagger-combine": "^1.3.0",
-		"swagger-typescript-api": "^5.1.7",
+		"swagger-typescript-api": "^9.1.1",
 		"ts-proto": "^1.68.0"
 	},
 	"pkg": {

--- a/starport/chainconf/config.go
+++ b/starport/chainconf/config.go
@@ -107,8 +107,8 @@ type Client struct {
 	// OpenAPI configures OpenAPI spec generation for API.
 	OpenAPI OpenAPI `yaml:"openapi"`
 
-	// JS configures code generation for a plain js/ts API client.
-	JS JS `yaml:"js"`
+	// Typescript configures code generation for a plain ts API client.
+	Typescript Typescript `yaml:"typescript"`
 }
 
 // Vuex configures code generation for Vuex.
@@ -122,13 +122,9 @@ type OpenAPI struct {
 	Path string `yaml:"path"`
 }
 
-// JS configures code generation for a plain js/ts API client.
-type JS struct {
+// Typescript configures code generation for a plain ts API client.
+type Typescript struct {
 	Path string `yaml:"path"`
-	// Additional field for specifying whether to emit *js files.
-	// Execution engines like ts-node do not like finding overlapping
-	// js files in mixed js/ts repos.
-	NoEmit bool `yaml:"noEmit"`
 }
 
 // Faucet configuration.

--- a/starport/chainconf/config.go
+++ b/starport/chainconf/config.go
@@ -106,6 +106,9 @@ type Client struct {
 
 	// OpenAPI configures OpenAPI spec generation for API.
 	OpenAPI OpenAPI `yaml:"openapi"`
+
+	// JS configures code generation for a plain js/ts API client.
+	JS JS `yaml:"js"`
 }
 
 // Vuex configures code generation for Vuex.
@@ -117,6 +120,15 @@ type Vuex struct {
 // OpenAPI configures OpenAPI spec generation for API.
 type OpenAPI struct {
 	Path string `yaml:"path"`
+}
+
+// JS configures code generation for a plain js/ts API client.
+type JS struct {
+	Path string `yaml:"path"`
+	// Additional field for specifying whether to emit *js files.
+	// Execution engines like ts-node do not like finding overlapping
+	// js files in mixed js/ts repos.
+	NoEmit bool `yaml:"noEmit"`
 }
 
 // Faucet configuration.

--- a/starport/pkg/cosmosgen/cosmosgen.go
+++ b/starport/pkg/cosmosgen/cosmosgen.go
@@ -15,10 +15,6 @@ type generateOptions struct {
 	jsIncludeThirdParty bool
 	specOut             string
 	vuexStoreRootPath   string
-	// Additional field for specifying whether to emit *.js files or not.
-	// Execution engines like ts-node do not like finding overlapping js
-	// files in mixed js/ts repos.
-	noEmit bool
 }
 
 // TODO add WithInstall.
@@ -30,11 +26,10 @@ type Option func(*generateOptions)
 // retrieve the path that should be used to place generated js code inside for a given module.
 // if includeThirdPartyModules set to true, code generation will be made for the 3rd party modules
 // used by the app -including the SDK- as well.
-func WithJSGeneration(includeThirdPartyModules bool, out func(module.Module) (path string), noEmit bool) Option {
+func WithJSGeneration(includeThirdPartyModules bool, out func(module.Module) (path string)) Option {
 	return func(o *generateOptions) {
 		o.jsOut = out
 		o.jsIncludeThirdParty = includeThirdPartyModules
-		o.noEmit = noEmit
 	}
 }
 

--- a/starport/pkg/cosmosgen/cosmosgen.go
+++ b/starport/pkg/cosmosgen/cosmosgen.go
@@ -23,27 +23,21 @@ type generateOptions struct {
 // Option configures code generation.
 type Option func(*generateOptions)
 
-// WithJSGeneration adds JS code generation. out hook is called for each module to
+// WithTSGeneration adds TS code generation. out hook is called for each module to
 // retrieve the path that should be used to place generated js code inside for a given module.
 // if includeThirdPartyModules set to true, code generation will be made for the 3rd party modules
 // used by the app -including the SDK- as well.
-func WithJSGeneration(includeThirdPartyModules bool, out func(module.Module) (path string)) Option {
+func WithTSGeneration(includeThirdPartyModules bool, out func(module.Module) (path string)) Option {
 	return func(o *generateOptions) {
 		o.jsOut = out
 		o.jsIncludeThirdParty = includeThirdPartyModules
-	}
-}
-
-// WithTSGeneration specifies that we're only generating typescript client files (tsc `noEmit` flag set to `true`).
-func WithTSGeneration() Option {
-	return func(o *generateOptions) {
 		o.typescript = true
 	}
 }
 
 // WithVuexGeneration adds Vuex code generation. storeRootPath is used to determine the root path of generated
 // Vuex stores. includeThirdPartyModules and out configures the underlying JS lib generation which is
-// documented in WithJSGeneration.
+// documented in WithTSGeneration.
 func WithVuexGeneration(includeThirdPartyModules bool, out func(module.Module) (path string), storeRootPath string) Option {
 	return func(o *generateOptions) {
 		o.jsOut = out

--- a/starport/pkg/cosmosgen/cosmosgen.go
+++ b/starport/pkg/cosmosgen/cosmosgen.go
@@ -15,6 +15,7 @@ type generateOptions struct {
 	jsIncludeThirdParty bool
 	specOut             string
 	vuexStoreRootPath   string
+	typescript          bool
 }
 
 // TODO add WithInstall.
@@ -30,6 +31,13 @@ func WithJSGeneration(includeThirdPartyModules bool, out func(module.Module) (pa
 	return func(o *generateOptions) {
 		o.jsOut = out
 		o.jsIncludeThirdParty = includeThirdPartyModules
+	}
+}
+
+// WithTSGeneration specifies that we're only generating typescript client files (tsc `noEmit` flag set to `true`).
+func WithTSGeneration() Option {
+	return func(o *generateOptions) {
+		o.typescript = true
 	}
 }
 

--- a/starport/pkg/cosmosgen/cosmosgen.go
+++ b/starport/pkg/cosmosgen/cosmosgen.go
@@ -15,6 +15,10 @@ type generateOptions struct {
 	jsIncludeThirdParty bool
 	specOut             string
 	vuexStoreRootPath   string
+	// Additional field for specifying whether to emit *.js files or not.
+	// Execution engines like ts-node do not like finding overlapping js
+	// files in mixed js/ts repos.
+	noEmit bool
 }
 
 // TODO add WithInstall.
@@ -26,10 +30,11 @@ type Option func(*generateOptions)
 // retrieve the path that should be used to place generated js code inside for a given module.
 // if includeThirdPartyModules set to true, code generation will be made for the 3rd party modules
 // used by the app -including the SDK- as well.
-func WithJSGeneration(includeThirdPartyModules bool, out func(module.Module) (path string)) Option {
+func WithJSGeneration(includeThirdPartyModules bool, out func(module.Module) (path string), noEmit bool) Option {
 	return func(o *generateOptions) {
 		o.jsOut = out
 		o.jsIncludeThirdParty = includeThirdPartyModules
+		o.noEmit = noEmit
 	}
 }
 

--- a/starport/pkg/cosmosgen/generate_javascript.go
+++ b/starport/pkg/cosmosgen/generate_javascript.go
@@ -161,7 +161,7 @@ func (g *jsGenerator) generateModule(ctx context.Context, tsprotoPluginPath, app
 		}
 	}
 	// generate .js and .d.ts files for all ts files.
-	return tsc.Generate(g.g.ctx, tscConfig(storeDirPath+"/**/*.ts"))
+	return tsc.Generate(g.g.ctx, tscConfig(g.g.o.typescript, storeDirPath+"/**/*.ts"))
 }
 
 func (g *jsGenerator) generateVuexModuleLoader() error {
@@ -222,14 +222,15 @@ func (g *jsGenerator) generateVuexModuleLoader() error {
 		return err
 	}
 
-	return tsc.Generate(g.g.ctx, tscConfig(loaderPath))
+	return tsc.Generate(g.g.ctx, tscConfig(g.g.o.typescript, loaderPath))
 }
 
-func tscConfig(include ...string) tsc.Config {
+func tscConfig(noEmit bool, include ...string) tsc.Config {
 	return tsc.Config{
 		Include: include,
 		CompilerOptions: tsc.CompilerOptions{
 			Declaration: true,
+			NoEmit:      noEmit,
 		},
 	}
 }

--- a/starport/pkg/cosmosgen/generate_javascript.go
+++ b/starport/pkg/cosmosgen/generate_javascript.go
@@ -49,8 +49,10 @@ func (g *generator) generateJS() error {
 		return err
 	}
 
-	if err := jsg.generateVuexModuleLoader(); err != nil {
-		return err
+	if g.o.vuexStoreRootPath != "" {
+		if err := jsg.generateVuexModuleLoader(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -159,7 +161,7 @@ func (g *jsGenerator) generateModule(ctx context.Context, tsprotoPluginPath, app
 		}
 	}
 	// generate .js and .d.ts files for all ts files.
-	return tsc.Generate(g.g.ctx, tscConfig(storeDirPath+"/**/*.ts"))
+	return tsc.Generate(g.g.ctx, tscConfig(g.g.o.noEmit, storeDirPath+"/**/*.ts"))
 }
 
 func (g *jsGenerator) generateVuexModuleLoader() error {
@@ -220,14 +222,16 @@ func (g *jsGenerator) generateVuexModuleLoader() error {
 		return err
 	}
 
-	return tsc.Generate(g.g.ctx, tscConfig(loaderPath))
+	return tsc.Generate(g.g.ctx, tscConfig(g.g.o.noEmit, loaderPath))
 }
 
-func tscConfig(include ...string) tsc.Config {
+func tscConfig(noEmit bool, include ...string) tsc.Config {
 	return tsc.Config{
 		Include: include,
 		CompilerOptions: tsc.CompilerOptions{
 			Declaration: true,
+			// Don't emit *.js files.
+			NoEmit: noEmit,
 		},
 	}
 }

--- a/starport/pkg/cosmosgen/generate_javascript.go
+++ b/starport/pkg/cosmosgen/generate_javascript.go
@@ -161,7 +161,7 @@ func (g *jsGenerator) generateModule(ctx context.Context, tsprotoPluginPath, app
 		}
 	}
 	// generate .js and .d.ts files for all ts files.
-	return tsc.Generate(g.g.ctx, tscConfig(g.g.o.noEmit, storeDirPath+"/**/*.ts"))
+	return tsc.Generate(g.g.ctx, tscConfig(storeDirPath+"/**/*.ts"))
 }
 
 func (g *jsGenerator) generateVuexModuleLoader() error {
@@ -222,16 +222,14 @@ func (g *jsGenerator) generateVuexModuleLoader() error {
 		return err
 	}
 
-	return tsc.Generate(g.g.ctx, tscConfig(g.g.o.noEmit, loaderPath))
+	return tsc.Generate(g.g.ctx, tscConfig(loaderPath))
 }
 
-func tscConfig(noEmit bool, include ...string) tsc.Config {
+func tscConfig(include ...string) tsc.Config {
 	return tsc.Config{
 		Include: include,
 		CompilerOptions: tsc.CompilerOptions{
 			Declaration: true,
-			// Don't emit *.js files.
-			NoEmit: noEmit,
 		},
 	}
 }

--- a/starport/pkg/cosmosgen/templates/js/index.ts.tpl
+++ b/starport/pkg/cosmosgen/templates/js/index.ts.tpl
@@ -47,7 +47,7 @@ interface QueryClientOptions {
 }
 
 const queryClient = async ({ addr: addr }: QueryClientOptions = { addr: "http://localhost:1317" }) => {
-  return new Api({ baseUrl: addr });
+  return new Api({ baseURL: addr });
 };
 
 export {

--- a/starport/pkg/nodetime/sta/sta.go
+++ b/starport/pkg/nodetime/sta/sta.go
@@ -30,6 +30,8 @@ func Generate(ctx context.Context, outPath, specPath, moduleNameIndex string) er
 		dir,
 		"-n",
 		file,
+		// NB: Use axios client since it works for both nodejs and web.
+		"--axios",
 	}...)
 
 	// execute the command.

--- a/starport/pkg/nodetime/tsc/tsc.go
+++ b/starport/pkg/nodetime/tsc/tsc.go
@@ -23,7 +23,9 @@ var (
 				Module:           "es2020",
 				TypeRoots:        []string{filepath.Join(nodeModulesPath, "@types")},
 				SkipLibCheck:     true,
-				NoEmit:           false,
+				// Default to not emitting JS client files.
+				// NB: Will need to be configurable to support generating plain js clients in the future.
+				NoEmit: true,
 			},
 		}
 	}

--- a/starport/pkg/nodetime/tsc/tsc.go
+++ b/starport/pkg/nodetime/tsc/tsc.go
@@ -23,9 +23,6 @@ var (
 				Module:           "es2020",
 				TypeRoots:        []string{filepath.Join(nodeModulesPath, "@types")},
 				SkipLibCheck:     true,
-				// Default to not emitting JS client files.
-				// NB: Will need to be configurable to support generating plain js clients in the future.
-				NoEmit: true,
 			},
 		}
 	}

--- a/starport/pkg/nodetime/tsc/tsc.go
+++ b/starport/pkg/nodetime/tsc/tsc.go
@@ -23,6 +23,7 @@ var (
 				Module:           "es2020",
 				TypeRoots:        []string{filepath.Join(nodeModulesPath, "@types")},
 				SkipLibCheck:     true,
+				NoEmit:           false,
 			},
 		}
 	}
@@ -44,6 +45,7 @@ type CompilerOptions struct {
 	TypeRoots        []string `json:"typeRoots"`
 	Declaration      bool     `json:"declaration"`
 	SkipLibCheck     bool     `json:"skipLibCheck"`
+	NoEmit           bool     `json:"noEmit"`
 }
 
 // Generate transpiles TS into JS by given TS config.

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -189,7 +189,7 @@ func (c *Chain) buildProto(ctx context.Context) error {
 
 	enableThirdPartyModuleCodegen := !c.protoBuiltAtLeastOnce && c.options.isThirdPartyModuleCodegenEnabled
 
-	options := services.GetClientGenerationOptions(c.app.Path, c.app.ImportPath, enableThirdPartyModuleCodegen, conf)
+	options := services.CodegenOptions(c.app.Path, c.app.ImportPath, enableThirdPartyModuleCodegen, conf)
 
 	if err := cosmosgen.Generate(ctx, c.app.Path, conf.Build.Proto.Path, options...); err != nil {
 		return &CannotBuildAppError{err}

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -209,6 +209,23 @@ func (c *Chain) buildProto(ctx context.Context) error {
 			),
 		)
 	}
+
+	// generate JS client code as well if it is enabled.
+	// NB: Vuex generates JS client code as well but within a vuex store.
+	if conf.Client.JS.Path != "" {
+		jsRootPath := filepath.Join(c.app.Path, conf.Client.JS.Path, "generated")
+		options = append(options,
+			cosmosgen.WithJSGeneration(
+				enableThirdPartyModuleCodegen,
+				func(m module.Module) string {
+					parsedGitURL, _ := giturl.Parse(m.Pkg.GoImportName)
+					return filepath.Join(jsRootPath, parsedGitURL.UserAndRepo(), m.Pkg.Name, "module")
+				},
+				conf.Client.JS.NoEmit,
+			),
+		)
+
+	}
 	if conf.Client.OpenAPI.Path != "" {
 		options = append(options, cosmosgen.WithOpenAPIGeneration(conf.Client.OpenAPI.Path))
 	}

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -210,18 +210,17 @@ func (c *Chain) buildProto(ctx context.Context) error {
 		)
 	}
 
-	// generate JS client code as well if it is enabled.
+	// generate ts client code as well if it is enabled.
 	// NB: Vuex generates JS client code as well but within a vuex store.
-	if conf.Client.JS.Path != "" {
-		jsRootPath := filepath.Join(c.app.Path, conf.Client.JS.Path, "generated")
+	if conf.Client.Typescript.Path != "" {
+		tsRootPath := filepath.Join(c.app.Path, conf.Client.Typescript.Path, "generated")
 		options = append(options,
 			cosmosgen.WithJSGeneration(
 				enableThirdPartyModuleCodegen,
 				func(m module.Module) string {
 					parsedGitURL, _ := giturl.Parse(m.Pkg.GoImportName)
-					return filepath.Join(jsRootPath, parsedGitURL.UserAndRepo(), m.Pkg.Name, "module")
+					return filepath.Join(tsRootPath, parsedGitURL.UserAndRepo(), m.Pkg.Name, "module")
 				},
-				conf.Client.JS.NoEmit,
 			),
 		)
 

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -211,9 +211,10 @@ func (c *Chain) buildProto(ctx context.Context) error {
 	}
 
 	// generate ts client code as well if it is enabled.
-	// NB: Vuex generates JS client code as well but within a vuex store.
+	// NB: Vuex generates JS/TS client code as well but in addtion to a vuex store.
+	// Path options will conflict with each other.
 	if conf.Client.Typescript.Path != "" {
-		tsRootPath := filepath.Join(c.app.Path, conf.Client.Typescript.Path, "generated")
+		tsRootPath := filepath.Join(c.app.Path, conf.Client.Typescript.Path)
 		options = append(options,
 			cosmosgen.WithJSGeneration(
 				enableThirdPartyModuleCodegen,
@@ -222,6 +223,8 @@ func (c *Chain) buildProto(ctx context.Context) error {
 					return filepath.Join(tsRootPath, parsedGitURL.UserAndRepo(), m.Pkg.Name, "module")
 				},
 			),
+			// Only generate typescript client files.
+			cosmosgen.WithTSGeneration(),
 		)
 
 	}

--- a/starport/services/codegen_options.go
+++ b/starport/services/codegen_options.go
@@ -34,7 +34,7 @@ func CodegenOptions(
 	}
 
 	// generate ts client code as well if it is enabled.
-	// NB: Vuex generates JS/TS client code as well but in addtion to a vuex store.
+	// NB: Vuex generates JS/TS client code as well but in addition to a vuex store.
 	// Path options will conflict with each other.
 	if conf.Client.Typescript.Path != "" {
 		tsRootPath := filepath.Join(projecPath, conf.Client.Typescript.Path)

--- a/starport/services/codegen_options.go
+++ b/starport/services/codegen_options.go
@@ -9,8 +9,8 @@ import (
 	"github.com/tendermint/starport/starport/pkg/giturl"
 )
 
-// GetClientGenerationOptions gets client generation options.
-func GetClientGenerationOptions(
+// CodegenOptions gets client code generation options.
+func CodegenOptions(
 	projecPath string,
 	goModPath string,
 	enableThirdPartyModuleCodegen bool,
@@ -39,12 +39,10 @@ func GetClientGenerationOptions(
 	if conf.Client.Typescript.Path != "" {
 		tsRootPath := filepath.Join(projecPath, conf.Client.Typescript.Path)
 		options = append(options,
-			cosmosgen.WithJSGeneration(
+			cosmosgen.WithTSGeneration(
 				enableThirdPartyModuleCodegen,
 				getModulePathFn(tsRootPath),
 			),
-			// Only generate typescript client files.
-			cosmosgen.WithTSGeneration(),
 		)
 
 	}

--- a/starport/services/common.go
+++ b/starport/services/common.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"path/filepath"
+
+	starportconf "github.com/tendermint/starport/starport/chainconf"
+	"github.com/tendermint/starport/starport/pkg/cosmosanalysis/module"
+	"github.com/tendermint/starport/starport/pkg/cosmosgen"
+	"github.com/tendermint/starport/starport/pkg/giturl"
+)
+
+// GetClientGenerationOptions gets client generation options.
+func GetClientGenerationOptions(
+	projecPath string,
+	goModPath string,
+	enableThirdPartyModuleCodegen bool,
+	conf starportconf.Config,
+) []cosmosgen.Option {
+	options := []cosmosgen.Option{
+		cosmosgen.WithGoGeneration(goModPath),
+		cosmosgen.IncludeDirs(conf.Build.Proto.ThirdPartyPaths),
+	}
+
+	// generate Vuex code as well if it is enabled.
+	if conf.Client.Vuex.Path != "" {
+		storeRootPath := filepath.Join(projecPath, conf.Client.Vuex.Path, "generated")
+		options = append(options,
+			cosmosgen.WithVuexGeneration(
+				enableThirdPartyModuleCodegen,
+				getModulePathFn(storeRootPath),
+				storeRootPath,
+			),
+		)
+	}
+
+	// generate ts client code as well if it is enabled.
+	// NB: Vuex generates JS/TS client code as well but in addtion to a vuex store.
+	// Path options will conflict with each other.
+	if conf.Client.Typescript.Path != "" {
+		tsRootPath := filepath.Join(projecPath, conf.Client.Typescript.Path)
+		options = append(options,
+			cosmosgen.WithJSGeneration(
+				enableThirdPartyModuleCodegen,
+				getModulePathFn(tsRootPath),
+			),
+			// Only generate typescript client files.
+			cosmosgen.WithTSGeneration(),
+		)
+
+	}
+
+	if conf.Client.OpenAPI.Path != "" {
+		options = append(options, cosmosgen.WithOpenAPIGeneration(conf.Client.OpenAPI.Path))
+	}
+
+	return options
+}
+
+func getModulePathFn(path string) func(m module.Module) string {
+	return func(m module.Module) string {
+		parsedGitURL, _ := giturl.Parse(m.Pkg.GoImportName)
+		return filepath.Join(path, parsedGitURL.UserAndRepo(), m.Pkg.Name, "module")
+	}
+}

--- a/starport/services/scaffolder/scaffolder.go
+++ b/starport/services/scaffolder/scaffolder.go
@@ -106,7 +106,7 @@ func protoc(projectPath, gomodPath string) error {
 		return err
 	}
 
-	options := services.GetClientGenerationOptions(projectPath, gomodPath, false, conf)
+	options := services.CodegenOptions(projectPath, gomodPath, false, conf)
 
 	return cosmosgen.Generate(context.Background(), projectPath, conf.Build.Proto.Path, options...)
 }


### PR DESCRIPTION
- Exposes config option for generating plain js client (minus vuex code)
- Hardcodes`noEmit` to `true` in tsc config to omit generating js client files (ts-node doesn't like overlapping ts/js files in mixed ts/js repos)