### PR TITLE
fix(docs): change starport build sample usage

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -236,8 +236,8 @@ source. Specify the release targets with GOOS:GOARCH build tags.
 If the optional --release.targets is not specified, a binary is created for your current environment.
 
 Sample usages:
-	- starport build
-	- starport build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64
+	- starport chain build
+	- starport chain build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64
 
 ```
 starport chain build [flags]

--- a/starport/cmd/chain_build.go
+++ b/starport/cmd/chain_build.go
@@ -30,8 +30,8 @@ source. Specify the release targets with GOOS:GOARCH build tags.
 If the optional --release.targets is not specified, a binary is created for your current environment.
 
 Sample usages:
-	- starport build
-	- starport build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64`,
+	- starport chain build
+	- starport chain build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64`,
 		Args: cobra.ExactArgs(0),
 		RunE: chainBuildHandler,
 	}


### PR DESCRIPTION
Hi. When I run "starport chain build -h" command, I can see starport build sample usage based on old version.
So, I change sample usage info.

before
```
starport chain build -h

Sample usages:
	- starport build
	- starport build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64

Usage:
  starport chain build [flags]

```

after
```
starport chain build -h

Sample usages:
	- starport chain build
	- starport chain build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64

Usage:
  starport chain build [flags]

```

Thanks!
