### PR TITLE
docs: change title from Reference to CLI Reference

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -6,7 +6,7 @@ parent:
   title: CLI Reference
 ---
 
-# CLI Reference
+# Reference
 
 Documentation for Starport CLI.
 


### PR DESCRIPTION
Changing the docs title from Reference to CLI Reference
Fixing issue #1673 