### PR TITLE
feat: Add plugin poc

### DIFF
--- a/starport/chainconfig/config.go
+++ b/starport/chainconfig/config.go
@@ -56,6 +56,7 @@ var DefaultConf = Config{
 // during serve.
 type Config struct {
 	Accounts  []Account              `yaml:"accounts"`
+	Plugins   []Plugin               `yaml:"plugins"`
 	Validator Validator              `yaml:"validator"`
 	Faucet    Faucet                 `yaml:"faucet"`
 	Client    Client                 `yaml:"client"`
@@ -91,6 +92,12 @@ type Account struct {
 type Validator struct {
 	Name   string `yaml:"name"`
 	Staked string `yaml:"staked"`
+}
+
+// Plugin holds info related to plugin settings.
+type Plugin struct {
+	Name string `yaml:"name"`
+	Repo string `yaml:"repo"`
 }
 
 // Build holds build configs.
@@ -219,6 +226,7 @@ func validate(conf Config) error {
 	if conf.Validator.Name == "" {
 		return &ValidationError{"validator is required"}
 	}
+
 	return nil
 }
 

--- a/starport/cmd/cmd.go
+++ b/starport/cmd/cmd.go
@@ -68,6 +68,7 @@ starport scaffold chain github.com/cosmonaut/mars`,
 	c.AddCommand(NewTools())
 	c.AddCommand(NewDocs())
 	c.AddCommand(NewVersion())
+	c.AddCommand(NewPlugins())
 	c.AddCommand(deprecated()...)
 
 	return c

--- a/starport/cmd/plugins.go
+++ b/starport/cmd/plugins.go
@@ -1,0 +1,17 @@
+package starportcmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewPlugins() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "plugins",
+		Short: "plugins for starport",
+	}
+
+	c.AddCommand(NewPluginsInstall())
+	c.AddCommand(NewPluginsUse())
+
+	return c
+}

--- a/starport/cmd/plugins_install.go
+++ b/starport/cmd/plugins_install.go
@@ -1,0 +1,69 @@
+package starportcmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/chainconfig"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
+)
+
+func NewPluginsInstall() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "install",
+		Short: "install plugins listed in config",
+		RunE:  pluginsInstallHandler,
+	}
+
+	flagSetPath(c)
+
+	return c
+}
+
+func pluginsInstallHandler(cmd *cobra.Command, args []string) error {
+	appPath := flagGetPath(cmd)
+	confpath, err := chainconfig.LocateDefault(appPath)
+	if err != nil {
+		return err
+	}
+	conf, err := chainconfig.ParseFile(confpath)
+	if err != nil {
+		return err
+	}
+
+	pluginsPath := filepath.Join(appPath, "plugins")
+	os.RemoveAll(pluginsPath)
+
+	for _, plugin := range conf.Plugins {
+		pluginPath := filepath.Join(pluginsPath, plugin.Name)
+		url := "https://" + plugin.Repo
+
+		_, err := git.PlainClone(pluginPath, false, &git.CloneOptions{
+			URL:      url,
+			Progress: os.Stdout,
+		})
+		if err != nil {
+			return err
+		}
+
+		ctx := context.Background()
+		return cmdrunner.
+			New(
+				cmdrunner.DefaultWorkdir(pluginPath),
+			).
+			Run(ctx,
+				step.New(
+					step.Exec(
+						"make",
+						"plugin",
+					),
+				),
+			)
+	}
+
+	return nil
+}

--- a/starport/cmd/plugins_use.go
+++ b/starport/cmd/plugins_use.go
@@ -1,0 +1,45 @@
+package starportcmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"plugin"
+
+	"github.com/spf13/cobra"
+)
+
+func NewPluginsUse() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "use",
+		Short: "use a plugin listed in config",
+		RunE:  pluginsUseHandler,
+	}
+
+	flagSetPath(c)
+
+	return c
+}
+
+func pluginsUseHandler(cmd *cobra.Command, args []string) error {
+	appPath := flagGetPath(cmd)
+	pluginPath := filepath.Join(appPath, fmt.Sprintf("plugins/%s/main.so", args[0]))
+
+	plug, err := plugin.Open(pluginPath)
+	if err != nil {
+		return err
+	}
+
+	newCmdsSymbol, err := plug.Lookup("NewCmds")
+	if err != nil {
+		return err
+	}
+
+	c := newCmdsSymbol.(func() *cobra.Command)()
+	c.SetArgs(args[1:])
+	_, err = c.ExecuteC()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/starport/templates/app/stargate/.gitignore
+++ b/starport/templates/app/stargate/.gitignore
@@ -1,6 +1,7 @@
 vue/node_modules
 vue/dist
 release/
+plugins/
 .idea/
 .vscode/
 .DS_Store


### PR DESCRIPTION
I utilize go plugin. Each plugin will be a git repo, which will require a main package implements `func NewCmds() *cobra.Command` and a Makefile with plugin build command. I also added `plugins install`  and `plugins use` to Starport. `plugins install` will read `config.yml` in the user's project to download and compile plugins. Then users are able to use `plugins use` to load and use specific plugin.  