### PR TITLE
feat(`network`): check no gentx are present in the initial genesis

### DIFF
--- a/ignite/pkg/cosmosutil/genesis.go
+++ b/ignite/pkg/cosmosutil/genesis.go
@@ -50,6 +50,9 @@ type (
 					BondDenom string `json:"bond_denom"`
 				} `json:"params"`
 			} `json:"staking"`
+			GenUtil struct {
+				GenTxs []struct{} `json:"gen_txs"`
+			} `json:"genutil""`
 		} `json:"app_state"`
 	}
 
@@ -59,7 +62,7 @@ type (
 	GenesisField func(fields)
 )
 
-// HasAccount check if account exist into the genesis account
+// HasAccount checks if account exist into the genesis account
 func (g Genesis) HasAccount(address string) bool {
 	for _, account := range g.Accounts {
 		if account == address {
@@ -67,6 +70,11 @@ func (g Genesis) HasAccount(address string) bool {
 		}
 	}
 	return false
+}
+
+// GenTxCount returns the number of gentxs inside the genesis
+func (cg ChainGenesis) GenTxCount() int {
+	return len(cg.AppState.GenUtil.GenTxs)
 }
 
 // WithKeyValue sets key and value field to genesis file

--- a/ignite/pkg/cosmosutil/genesis.go
+++ b/ignite/pkg/cosmosutil/genesis.go
@@ -50,7 +50,7 @@ type (
 					BondDenom string `json:"bond_denom"`
 				} `json:"params"`
 			} `json:"staking"`
-			GenUtil struct {
+			Genutil struct {
 				GenTxs []struct{} `json:"gen_txs"`
 			} `json:"genutil""`
 		} `json:"app_state"`
@@ -74,7 +74,7 @@ func (g Genesis) HasAccount(address string) bool {
 
 // GenTxCount returns the number of gentxs inside the genesis
 func (cg ChainGenesis) GenTxCount() int {
-	return len(cg.AppState.GenUtil.GenTxs)
+	return len(cg.AppState.Genutil.GenTxs)
 }
 
 // WithKeyValue sets key and value field to genesis file

--- a/ignite/pkg/cosmosutil/genesis.go
+++ b/ignite/pkg/cosmosutil/genesis.go
@@ -52,7 +52,7 @@ type (
 			} `json:"staking"`
 			Genutil struct {
 				GenTxs []struct{} `json:"gen_txs"`
-			} `json:"genutil""`
+			} `json:"genutil"`
 		} `json:"app_state"`
 	}
 

--- a/ignite/pkg/cosmosutil/genesis_test.go
+++ b/ignite/pkg/cosmosutil/genesis_test.go
@@ -58,12 +58,14 @@ func TestParseChainGenesis(t *testing.T) {
 		Address string `json:"address"`
 	}{{Address: "cosmos1dd246yq6z5vzjz9gh8cff46pll75yyl8ygndsj"}}
 	genesis1.AppState.Staking.Params.BondDenom = "stake"
+	genesis1.AppState.GenUtil.GenTxs = []struct{}{{}} // 1 gentx
 
 	genesis2 := cosmosutil.ChainGenesis{ChainID: "earth-1"}
 	genesis2.AppState.Auth.Accounts = []struct {
 		Address string `json:"address"`
 	}{{Address: "cosmos1mmlqwyqk7neqegffp99q86eckpm4pjah3ytlpa"}}
 	genesis2.AppState.Staking.Params.BondDenom = "stake"
+	genesis2.AppState.GenUtil.GenTxs = []struct{}{{}} // 1 gentx
 
 	tests := []struct {
 		name        string
@@ -336,6 +338,39 @@ func TestUpdateGenesis(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, val, value)
 			}
+		})
+	}
+}
+
+func TestChainGenesis_GenTxCount(t *testing.T) {
+	// create a genesis with 10 gentx
+	testChainGenesis := cosmosutil.ChainGenesis{}
+	for i := 0; i < 10; i++ {
+		testChainGenesis.AppState.GenUtil.GenTxs = append(
+			testChainGenesis.AppState.GenUtil.GenTxs,
+			struct{}{},
+		)
+	}
+
+	tests := []struct {
+		name         string
+		chainGenesis cosmosutil.ChainGenesis
+		expected     int
+	}{
+		{
+			name:         "should return 0 for initialized chain genesis",
+			chainGenesis: cosmosutil.ChainGenesis{},
+			expected:     0,
+		},
+		{
+			name:         "should return the number of gentxs",
+			chainGenesis: testChainGenesis,
+			expected:     10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualValues(t, tt.expected, tt.chainGenesis.GenTxCount())
 		})
 	}
 }

--- a/ignite/pkg/cosmosutil/genesis_test.go
+++ b/ignite/pkg/cosmosutil/genesis_test.go
@@ -58,14 +58,14 @@ func TestParseChainGenesis(t *testing.T) {
 		Address string `json:"address"`
 	}{{Address: "cosmos1dd246yq6z5vzjz9gh8cff46pll75yyl8ygndsj"}}
 	genesis1.AppState.Staking.Params.BondDenom = "stake"
-	genesis1.AppState.GenUtil.GenTxs = []struct{}{{}} // 1 gentx
+	genesis1.AppState.Genutil.GenTxs = []struct{}{{}} // 1 gentx
 
 	genesis2 := cosmosutil.ChainGenesis{ChainID: "earth-1"}
 	genesis2.AppState.Auth.Accounts = []struct {
 		Address string `json:"address"`
 	}{{Address: "cosmos1mmlqwyqk7neqegffp99q86eckpm4pjah3ytlpa"}}
 	genesis2.AppState.Staking.Params.BondDenom = "stake"
-	genesis2.AppState.GenUtil.GenTxs = []struct{}{{}} // 1 gentx
+	genesis2.AppState.Genutil.GenTxs = []struct{}{{}} // 1 gentx
 
 	tests := []struct {
 		name        string

--- a/ignite/pkg/cosmosutil/genesis_test.go
+++ b/ignite/pkg/cosmosutil/genesis_test.go
@@ -346,8 +346,8 @@ func TestChainGenesis_GenTxCount(t *testing.T) {
 	// create a genesis with 10 gentx
 	testChainGenesis := cosmosutil.ChainGenesis{}
 	for i := 0; i < 10; i++ {
-		testChainGenesis.AppState.GenUtil.GenTxs = append(
-			testChainGenesis.AppState.GenUtil.GenTxs,
+		testChainGenesis.AppState.Genutil.GenTxs = append(
+			testChainGenesis.AppState.Genutil.GenTxs,
 			struct{}{},
 		)
 	}

--- a/ignite/services/network/networkchain/init.go
+++ b/ignite/services/network/networkchain/init.go
@@ -2,6 +2,7 @@ package networkchain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -94,8 +95,8 @@ func (c *Chain) initGenesis(ctx context.Context) error {
 
 	}
 
-	// check the genesis is valid
-	if err := c.checkGenesis(ctx); err != nil {
+	// check the initial genesis is valid
+	if err := c.checkInitialGenesis(ctx); err != nil {
 		return err
 	}
 
@@ -104,11 +105,28 @@ func (c *Chain) initGenesis(ctx context.Context) error {
 }
 
 // checkGenesis checks the stored genesis is valid
-func (c *Chain) checkGenesis(ctx context.Context) error {
+func (c *Chain) checkInitialGenesis(ctx context.Context) error {
 	// perform static analysis of the chain with the validate-genesis command.
 	chainCmd, err := c.chain.Commands(ctx)
 	if err != nil {
 		return err
+	}
+
+	// the chain initial genesis should not contain gentx, gentxs should be added through requests
+	genesisPath, err := c.chain.GenesisPath()
+	if err != nil {
+		return err
+	}
+	genesisFile, err := os.ReadFile(genesisPath)
+	if err != nil {
+		return err
+	}
+	chainGenesis, err := cosmosutil.ParseChainGenesis(genesisFile)
+	if err != nil {
+		return err
+	}
+	if chainGenesis.GenTxCount() > 0 {
+		return errors.New("the initial genesis for the chain should not contain gentx")
 	}
 
 	return chainCmd.ValidateGenesis(ctx)

--- a/ignite/services/network/publish_test.go
+++ b/ignite/services/network/publish_test.go
@@ -247,7 +247,7 @@ func TestPublish(t *testing.T) {
 		var (
 			account              = testutil.NewTestAccount(t, testutil.TestAccountName)
 			customGenesisChainID = "test-custom-1"
-			customGenesisHash    = "72a80a32e33513cd74423354502cef035e96b0bff59c754646b453b201d12d07"
+			customGenesisHash    = "61da86775013bd18d6a019b533eedf1304b778fe8005090a0a0223720adfd8eb"
 			gts                  = startGenesisTestServer(cosmosutil.ChainGenesis{ChainID: customGenesisChainID})
 			suite, network       = newSuite(account)
 		)


### PR DESCRIPTION
- Add a method in `ChainGenesis` object to count gentxs in a genesis
- Add the check for no gentx in `initGenesis`. `initGenesis` generate the initial genesis of the chain so it makes sense to add this check here as a consideration that the initial genesis is only valid without gentx so that the condition is checked in any workflow using the initial genesis like `publish` but other command in the case a coordinator published a chain without the CLI

### TESTING

Run a local `spn`:
```
ignite chain serve -c config_2.yml -r
```

Chain with default genesis can be published
```
ignite n chain publish https://github.com/tendermint/spn --spn-node-address http://0.0.0.0:26661/ --spn-faucet-address http://0.0.0.0:4502/ --chain-id spn-1

✔ Source code fetched
✔ Blockchain set up
✔ Chain's binary built
✔ Blockchain initialized
✔ Genesis initialized
✔ Network published
⋆ Launch ID: 1
⋆ Campaign ID: 1
```

Chain with a custom genesis with gentxs can't be published
```
ignite n chain publish https://github.com/tendermint/spn --spn-node-address http://0.0.0.0:26661/ --spn-faucet-address http://0.0.0.0:4502/ --chain-id spn-1 --genesis "https://gist.githubusercontent.com/lubtd/5d73e336948044b75b845696ee5918ee/raw/8fd2fd805d4dbfd60b7fbb9998564029f433e2cc/genesis_with_gentxs.json"

✔ Source code fetched
✔ Blockchain set up
✔ Chain's binary built
✔ Blockchain initialized
the initial genesis for the chain should not contain gentx
```

Chain with a custom genesis with no gentx can be published
```
ignite n chain publish https://github.com/tendermint/spn --spn-node-address http://0.0.0.0:26661/ --spn-faucet-address http://0.0.0.0:4502/ --chain-id spn-1 --genesis "https://gist.githubusercontent.com/lubtd/7d52c983b3f8b7773198a3f92c8a14d8/raw/91fafc323c625e11d40e29d109a8e67574258352/genesis_without_gentx.json"

✔ Source code fetched
✔ Blockchain set up
✔ Chain's binary built
✔ Blockchain initialized
✔ Genesis initialized
✔ Network published
⋆ Launch ID: 2
⋆ Campaign ID: 2
```