### PR TITLE
chore: lint and format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,11 +22,11 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
+    # - interfacer
     # - maligned
     - misspell
     - nakedret
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - stylecheck

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ format:
 ## lint: Run Golang CI Lint.
 lint:
 	@echo Running gocilint...
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2
 	@golangci-lint run --out-format=tab --issues-exit-code=0
 
 ## test-unit: Run the unit tests.

--- a/ignite/pkg/cache/cache.go
+++ b/ignite/pkg/cache/cache.go
@@ -51,7 +51,7 @@ func Key(keyParts ...string) string {
 
 // Clear deletes all namespaces and cached values
 func (s Storage) Clear() error {
-	db, err := openDb(s.storagePath)
+	db, err := openDB(s.storagePath)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (s Storage) Clear() error {
 // Put sets key to value within the namespace
 // If the key already exists, it will be overwritten
 func (c Cache[T]) Put(key string, value T) error {
-	db, err := openDb(c.storage.storagePath)
+	db, err := openDB(c.storage.storagePath)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (c Cache[T]) Put(key string, value T) error {
 // Get fetches the value of key within the namespace.
 // If no value exists, it will return found == false
 func (c Cache[T]) Get(key string) (val T, err error) {
-	db, err := openDb(c.storage.storagePath)
+	db, err := openDB(c.storage.storagePath)
 	if err != nil {
 		return
 	}
@@ -128,7 +128,7 @@ func (c Cache[T]) Get(key string) (val T, err error) {
 
 // Delete removes a value for key within the namespace
 func (c Cache[T]) Delete(key string) error {
-	db, err := openDb(c.storage.storagePath)
+	db, err := openDB(c.storage.storagePath)
 	if err != nil {
 		return err
 	}
@@ -144,6 +144,6 @@ func (c Cache[T]) Delete(key string) error {
 	})
 }
 
-func openDb(path string) (*bolt.DB, error) {
+func openDB(path string) (*bolt.DB, error) {
 	return bolt.Open(path, 0640, &bolt.Options{Timeout: 1 * time.Minute})
 }

--- a/ignite/pkg/cliui/cliui.go
+++ b/ignite/pkg/cliui/cliui.go
@@ -172,7 +172,7 @@ func (s Session) printLoop() {
 
 		case events.StatusNeutral:
 			resume := s.PauseSpinner()
-			fmt.Fprintf(s.out, event.Text())
+			fmt.Fprint(s.out, event.Text())
 			resume()
 		}
 

--- a/ignite/pkg/cosmosanalysis/app/testdata/app_minimal.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/app_minimal.go
@@ -1,5 +1,10 @@
 package foo
 
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
 type Foo struct {
 	FooKeeper foo.keeper
 }

--- a/ignite/pkg/cosmosanalysis/app/testdata/two_app.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/two_app.go
@@ -1,5 +1,10 @@
 package foo
 
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
 type Foo struct {
 	FooKeeper foo.keeper
 }

--- a/ignite/pkg/cosmosgen/generate.go
+++ b/ignite/pkg/cosmosgen/generate.go
@@ -6,13 +6,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/ignite/cli/ignite/pkg/cache"
 	"github.com/ignite/cli/ignite/pkg/cmdrunner"
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
 	"github.com/ignite/cli/ignite/pkg/cosmosanalysis/module"
 	"github.com/ignite/cli/ignite/pkg/gomodule"
 	"github.com/ignite/cli/ignite/pkg/xfilepath"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -122,7 +122,7 @@ func parseURL(s string) (*url.URL, error) {
 
 func addressPort(s string) (string, bool) {
 	// Check that the value doesn't contain a URI path
-	if strings.Index(s, "/") != -1 {
+	if strings.Contains(s, "/") {
 		return "", false
 	}
 


### PR DESCRIPTION
What this PR does:
- update `golangci-lint` to `v1.47.2` for better go 1.18 support
- update `.golangci.yml` lint runners
- run `make lint` and make appropriate changes
- run `make format`