### PR TITLE
fix(template): client query uses tx client context

### DIFF
--- a/ignite/templates/query/stargate/x/{{moduleName}}/client/cli/query_{{queryName}}.go.plush
+++ b/ignite/templates/query/stargate/x/{{moduleName}}/client/cli/query_{{queryName}}.go.plush
@@ -20,7 +20,7 @@ func Cmd<%= QueryName.UpperCamel %>() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			<%= for (i, field) in ReqFields { %> <%= field.CLIArgs("req", i) %>
 			<% } %>
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
It should use the query client context.

Fix #2656