### PR TITLE
feat(docs): add Sonr to the Projects building with

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -61,3 +61,4 @@ Many projects already showcase the Tendermint BFT consensus engine and the Cosmo
 * [Finding Imposter](https://github.com/chantmk/Finding-imposter)
 * [Flares payment network](https://github.com/wangfeiping/flares)
 * [FirmaChain](https://github.com/firmachain/firmachain)
+* [Sonr](https://github.com/sonr-io/sonr)


### PR DESCRIPTION
Add github.com/sonr-io/sonr to the projects being built with Ignite in the root of the docs.