### PR TITLE
feat: make go dependency validation during build optional

### DIFF
--- a/ignite/cmd/chain_build.go
+++ b/ignite/cmd/chain_build.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 
 	"github.com/ignite/cli/ignite/pkg/chaincmd"
 	"github.com/ignite/cli/ignite/pkg/cliui/colors"
@@ -12,10 +13,11 @@ import (
 )
 
 const (
-	flagOutput         = "output"
-	flagRelease        = "release"
-	flagReleaseTargets = "release.targets"
-	flagReleasePrefix  = "release.prefix"
+	flagCheckDependencies = "check-dependencies"
+	flagOutput            = "output"
+	flagRelease           = "release"
+	flagReleasePrefix     = "release.prefix"
+	flagReleaseTargets    = "release.targets"
 )
 
 // NewChainBuild returns a new build command to build a blockchain app.
@@ -42,6 +44,7 @@ Sample usages:
 	flagSetClearCache(c)
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().AddFlagSet(flagSetProto3rdParty("Available only without the --release flag"))
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	c.Flags().Bool(flagRelease, false, "build for a release")
 	c.Flags().StringSliceP(flagReleaseTargets, "t", []string{}, "release targets. Available only with --release flag")
 	c.Flags().String(flagReleasePrefix, "", "tarball prefix for each release target. Available only with --release flag")
@@ -66,6 +69,10 @@ func chainBuildHandler(cmd *cobra.Command, _ []string) error {
 
 	if flagGetProto3rdParty(cmd) {
 		chainOption = append(chainOption, chain.EnableThirdPartyModuleCodegen())
+	}
+
+	if flagGetCheckDependencies(cmd) {
+		chainOption = append(chainOption, chain.CheckDependencies())
 	}
 
 	c, err := newChainWithHomeFlags(cmd, chainOption...)
@@ -102,4 +109,16 @@ func chainBuildHandler(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func flagSetCheckDependencies() *flag.FlagSet {
+	usage := "Verify that cached dependencies have not been modified since they were downloaded"
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.Bool(flagCheckDependencies, false, usage)
+	return fs
+}
+
+func flagGetCheckDependencies(cmd *cobra.Command) (check bool) {
+	check, _ = cmd.Flags().GetBool(flagCheckDependencies)
+	return
 }

--- a/ignite/cmd/chain_init.go
+++ b/ignite/cmd/chain_init.go
@@ -21,6 +21,7 @@ func NewChainInit() *cobra.Command {
 	flagSetPath(c)
 	flagSetClearCache(c)
 	c.Flags().AddFlagSet(flagSetHome())
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 
 	return c
 }
@@ -29,6 +30,10 @@ func chainInitHandler(cmd *cobra.Command, _ []string) error {
 	chainOption := []chain.Option{
 		chain.LogLevel(logLevel(cmd)),
 		chain.KeyringBackend(chaincmd.KeyringBackendTest),
+	}
+
+	if flagGetCheckDependencies(cmd) {
+		chainOption = append(chainOption, chain.CheckDependencies())
 	}
 
 	c, err := newChainWithHomeFlags(cmd, chainOption...)

--- a/ignite/cmd/chain_serve.go
+++ b/ignite/cmd/chain_serve.go
@@ -26,6 +26,7 @@ func NewChainServe() *cobra.Command {
 	flagSetClearCache(c)
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().AddFlagSet(flagSetProto3rdParty(""))
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	c.Flags().BoolP("verbose", "v", false, "Verbose output")
 	c.Flags().BoolP(flagForceReset, "f", false, "Force reset of the app state on start and every source change")
 	c.Flags().BoolP(flagResetOnce, "r", false, "Reset of the app state on first start")
@@ -41,6 +42,10 @@ func chainServeHandler(cmd *cobra.Command, args []string) error {
 
 	if flagGetProto3rdParty(cmd) {
 		chainOption = append(chainOption, chain.EnableThirdPartyModuleCodegen())
+	}
+
+	if flagGetCheckDependencies(cmd) {
+		chainOption = append(chainOption, chain.CheckDependencies())
 	}
 
 	// check if custom config is defined

--- a/ignite/cmd/network_chain_init.go
+++ b/ignite/cmd/network_chain_init.go
@@ -48,6 +48,7 @@ func NewNetworkChainInit() *cobra.Command {
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	c.Flags().AddFlagSet(flagSetYes())
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	return c
 }
 
@@ -104,7 +105,13 @@ func networkChainInitHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch))
+	var networkOptions []networkchain.Option
+
+	if flagGetCheckDependencies(cmd) {
+		networkOptions = append(networkOptions, networkchain.CheckDependencies())
+	}
+
+	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch), networkOptions...)
 	if err != nil {
 		return err
 	}

--- a/ignite/cmd/network_chain_install.go
+++ b/ignite/cmd/network_chain_install.go
@@ -24,6 +24,7 @@ func NewNetworkChainInstall() *cobra.Command {
 
 	flagSetClearCache(c)
 	c.Flags().AddFlagSet(flagNetworkFrom())
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	return c
 }
 
@@ -57,7 +58,13 @@ func networkChainInstallHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch))
+	var networkOptions []networkchain.Option
+
+	if flagGetCheckDependencies(cmd) {
+		networkOptions = append(networkOptions, networkchain.CheckDependencies())
+	}
+
+	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch), networkOptions...)
 	if err != nil {
 		return err
 	}

--- a/ignite/cmd/network_chain_join.go
+++ b/ignite/cmd/network_chain_join.go
@@ -40,6 +40,7 @@ func NewNetworkChainJoin() *cobra.Command {
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	c.Flags().AddFlagSet(flagSetYes())
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 
 	return c
 }
@@ -91,7 +92,13 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch))
+	var networkOptions []networkchain.Option
+
+	if flagGetCheckDependencies(cmd) {
+		networkOptions = append(networkOptions, networkchain.CheckDependencies())
+	}
+
+	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch), networkOptions...)
 	if err != nil {
 		return err
 	}

--- a/ignite/cmd/network_chain_prepare.go
+++ b/ignite/cmd/network_chain_prepare.go
@@ -34,6 +34,7 @@ func NewNetworkChainPrepare() *cobra.Command {
 	c.Flags().AddFlagSet(flagNetworkFrom())
 	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	c.Flags().AddFlagSet(flagSetHome())
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 
 	return c
 }
@@ -75,7 +76,13 @@ func networkChainPrepareHandler(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("chain %d launch has not been triggered yet. use --force to prepare anyway", launchID)
 	}
 
-	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch))
+	var networkOptions []networkchain.Option
+
+	if flagGetCheckDependencies(cmd) {
+		networkOptions = append(networkOptions, networkchain.CheckDependencies())
+	}
+
+	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch), networkOptions...)
 	if err != nil {
 		return err
 	}

--- a/ignite/cmd/network_chain_publish.go
+++ b/ignite/cmd/network_chain_publish.go
@@ -58,6 +58,7 @@ func NewNetworkChainPublish() *cobra.Command {
 	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().AddFlagSet(flagSetYes())
+	c.Flags().AddFlagSet(flagSetCheckDependencies())
 
 	return c
 }
@@ -215,6 +216,12 @@ func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 		}
 
 		publishOptions = append(publishOptions, network.WithPercentageShares(sharePercentages))
+	}
+
+	// TODO: Issue an error or warning when this flag is used with "no-check"?
+	//       The "check-dependencies" flag is ignored when the "no-check" one is present.
+	if flagGetCheckDependencies(cmd) {
+		initOptions = append(initOptions, networkchain.CheckDependencies())
 	}
 
 	// init the chain.

--- a/ignite/services/chain/build.go
+++ b/ignite/services/chain/build.go
@@ -206,8 +206,12 @@ func (c *Chain) preBuild(ctx context.Context, cacheStorage cache.Storage) (build
 	}
 
 	if modChanged {
-		if err := gocmd.ModVerify(ctx, c.app.Path); err != nil {
-			return nil, err
+		// By default no dependencies are checked to avoid issues with module
+		// ziphash files in case a Go workspace is being used.
+		if c.options.checkDependencies {
+			if err := gocmd.ModVerify(ctx, c.app.Path); err != nil {
+				return nil, err
+			}
 		}
 
 		if err := dirchange.SaveDirChecksum(dirCache, modChecksumKey, c.app.Path, "go.mod"); err != nil {

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -83,6 +83,10 @@ type chainOptions struct {
 	// for 3rd party modules. SDK modules are also considered as a 3rd party.
 	isThirdPartyModuleCodegenEnabled bool
 
+	// checkDependencies checks that cached Go dependencies of the chain have not
+	// been modified since they were downloaded.
+	checkDependencies bool
+
 	// path of a custom config file
 	ConfigFile string
 }
@@ -130,6 +134,15 @@ func ConfigFile(configFile string) Option {
 func EnableThirdPartyModuleCodegen() Option {
 	return func(c *Chain) {
 		c.options.isThirdPartyModuleCodegenEnabled = true
+	}
+}
+
+// CheckDependencies checks that cached Go dependencies of the chain have not
+// been modified since they were downloaded. Dependencies are checked by
+// running `go mod verify`.
+func CheckDependencies() Option {
+	return func(c *Chain) {
+		c.options.checkDependencies = true
 	}
 }
 


### PR DESCRIPTION
Resolves #137

These changes makes `go mod verify` during build optional. The default behaviour is not to verify during build.

App dependencies verification is a good practice but is not really required for the build.

By default, these changes bypass the verification to avoid the missing ziphash files for local modules that can happen when a workspace is used. The real issue seems to be a Go tooling issue that happens when `go mod verify` is run within a Go workspace context.