### PR TITLE
chore: formatting

### DIFF
--- a/ignite/chainconfig/config.go
+++ b/ignite/chainconfig/config.go
@@ -21,12 +21,10 @@ var (
 	ConfigFileNames = []string{"config.yml", "config.yaml"}
 )
 
-var (
-	// ErrCouldntLocateConfig returned when config.yml cannot be found in the source code.
-	ErrCouldntLocateConfig = errors.New(
-		"could not locate a config.yml in your chain. please follow the link for" +
-			"how-to: https://github.com/ignite/cli/blob/develop/docs/configure/index.md")
-)
+// ErrCouldntLocateConfig returned when config.yml cannot be found in the source code.
+var ErrCouldntLocateConfig = errors.New(
+	"could not locate a config.yml in your chain. please follow the link for" +
+		"how-to: https://github.com/ignite/cli/blob/develop/docs/configure/index.md")
 
 // DefaultConf holds default configuration.
 var DefaultConf = Config{
@@ -265,5 +263,5 @@ func CreateConfigDir() error {
 		return err
 	}
 
-	return os.MkdirAll(confPath, 0755)
+	return os.MkdirAll(confPath, 0o755)
 }

--- a/ignite/cmd/account_export.go
+++ b/ignite/cmd/account_export.go
@@ -56,7 +56,7 @@ func accountExportHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := os.WriteFile(path, []byte(armored), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(armored), 0o644); err != nil {
 		return err
 	}
 

--- a/ignite/cmd/network_campaign_account.go
+++ b/ignite/cmd/network_campaign_account.go
@@ -7,9 +7,7 @@ import (
 	"github.com/ignite/cli/ignite/pkg/cliui/icons"
 )
 
-var (
-	campaignMainnetsAccSummaryHeader = []string{"Mainnet Account", "Shares"}
-)
+var campaignMainnetsAccSummaryHeader = []string{"Mainnet Account", "Shares"}
 
 // NewNetworkCampaignAccount creates a new campaign account command that holds some other
 // sub commands related to account for a campaign.

--- a/ignite/cmd/network_chain_show_genesis.go
+++ b/ignite/cmd/network_chain_show_genesis.go
@@ -81,7 +81,7 @@ func networkChainShowGenesisHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(out), 0744); err != nil {
+	if err := os.MkdirAll(filepath.Dir(out), 0o744); err != nil {
 		return err
 	}
 

--- a/ignite/cmd/network_chain_show_peers.go
+++ b/ignite/cmd/network_chain_show_peers.go
@@ -62,14 +62,14 @@ func networkChainShowPeersHandler(cmd *cobra.Command, args []string) error {
 
 	}
 
-	if err := os.MkdirAll(filepath.Dir(out), 0744); err != nil {
+	if err := os.MkdirAll(filepath.Dir(out), 0o744); err != nil {
 		return err
 	}
 
 	b := &bytes.Buffer{}
 	peerList := strings.Join(peers, ",")
 	fmt.Fprintln(b, peerList)
-	if err := os.WriteFile(out, b.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(out, b.Bytes(), 0o644); err != nil {
 		return err
 	}
 

--- a/ignite/cmd/network_chain_show_validators.go
+++ b/ignite/cmd/network_chain_show_validators.go
@@ -9,9 +9,7 @@ import (
 	"github.com/ignite/cli/ignite/services/network"
 )
 
-var (
-	chainGenesisValSummaryHeader = []string{"Genesis Validator", "Self Delegation", "Peer"}
-)
+var chainGenesisValSummaryHeader = []string{"Genesis Validator", "Self Delegation", "Peer"}
 
 func newNetworkChainShowValidators() *cobra.Command {
 	c := &cobra.Command{

--- a/ignite/cmd/network_profile.go
+++ b/ignite/cmd/network_profile.go
@@ -36,9 +36,7 @@ func networkProfileHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var (
-		campaignID uint64
-	)
+	var campaignID uint64
 	if len(args) > 0 {
 		campaignID, err = network.ParseID(args[0])
 		if err != nil {

--- a/ignite/cmd/relayer_connect.go
+++ b/ignite/cmd/relayer_connect.go
@@ -70,7 +70,6 @@ func relayerConnectHandler(cmd *cobra.Command, args []string) (err error) {
 					use = append(use, path.ID)
 					break
 				}
-
 			}
 		}
 	}

--- a/ignite/cmd/tools.go
+++ b/ignite/cmd/tools.go
@@ -89,7 +89,6 @@ func toolsProxy(ctx context.Context, command []string) error {
 }
 
 func NewToolsCompletions() *cobra.Command {
-
 	// completionCmd represents the completion command
 	c := &cobra.Command{
 		Use:   "completions",

--- a/ignite/errors/errors.go
+++ b/ignite/errors/errors.go
@@ -3,7 +3,5 @@ package sperrors
 
 import "errors"
 
-var (
-	// ErrOnlyStargateSupported is returned when underlying chain is not a stargate chain.
-	ErrOnlyStargateSupported = errors.New("this version of Cosmos SDK is no longer supported")
-)
+// ErrOnlyStargateSupported is returned when underlying chain is not a stargate chain.
+var ErrOnlyStargateSupported = errors.New("this version of Cosmos SDK is no longer supported")

--- a/ignite/internal/tools/gen-cli-docs/main.go
+++ b/ignite/internal/tools/gen-cli-docs/main.go
@@ -39,10 +39,10 @@ func main() {
 }
 
 func generate(cmd *cobra.Command, outPath string) error {
-	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(outPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(outPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/ignite/pkg/cache/cache.go
+++ b/ignite/pkg/cache/cache.go
@@ -29,7 +29,7 @@ type Cache[T any] struct {
 // path is the full path (including filename) to the database file to ues
 // It does not need to be closed as this happens automatically in each call to the cache
 func NewStorage(path string) (Storage, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return Storage{}, err
 	}
 
@@ -145,5 +145,5 @@ func (c Cache[T]) Delete(key string) error {
 }
 
 func openDB(path string) (*bolt.DB, error) {
-	return bolt.Open(path, 0640, &bolt.Options{Timeout: 1 * time.Minute})
+	return bolt.Open(path, 0o640, &bolt.Options{Timeout: 1 * time.Minute})
 }

--- a/ignite/pkg/chaincmd/runner/chain.go
+++ b/ignite/pkg/chaincmd/runner/chain.go
@@ -239,7 +239,7 @@ func (r Runner) WaitTx(ctx context.Context, txHash string, retryDelay time.Durat
 func (r Runner) Export(ctx context.Context, exportedFile string) error {
 	// Make sure the path exists
 	dir := filepath.Dir(exportedFile)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
@@ -257,7 +257,7 @@ func (r Runner) Export(ctx context.Context, exportedFile string) error {
 	}
 
 	// Save the new state
-	return os.WriteFile(exportedFile, exportedState, 0644)
+	return os.WriteFile(exportedFile, exportedState, 0o644)
 }
 
 // EventSelector is used to query events.

--- a/ignite/pkg/checksum/checksum.go
+++ b/ignite/pkg/checksum/checksum.go
@@ -38,7 +38,7 @@ func Sum(dirPath, outPath string) error {
 		}
 	}
 
-	return os.WriteFile(outPath, b.Bytes(), 0666)
+	return os.WriteFile(outPath, b.Bytes(), 0o666)
 }
 
 // Binary returns SHA256 hash of executable file, file is searched by name in PATH

--- a/ignite/pkg/confile/confile.go
+++ b/ignite/pkg/confile/confile.go
@@ -38,10 +38,10 @@ func (c *ConfigFile) Load(v interface{}) error {
 // Save saves v into config file by overwriting the previous content it also creates the
 // config file if it wasn't exist.
 func (c *ConfigFile) Save(v interface{}) error {
-	if err := os.MkdirAll(filepath.Dir(c.path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
 		return err
 	}
-	file, err := os.OpenFile(c.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(c.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/ignite/pkg/confile/confile_test.go
+++ b/ignite/pkg/confile/confile_test.go
@@ -26,7 +26,6 @@ func TestAll(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-
 			file, err := os.CreateTemp("", "")
 			require.NoError(t, err)
 			defer func() {
@@ -51,5 +50,4 @@ func TestAll(t *testing.T) {
 			require.Equal(t, "cosmos", d2.Hello)
 		})
 	}
-
 }

--- a/ignite/pkg/cosmosaccount/cosmosaccount.go
+++ b/ignite/pkg/cosmosaccount/cosmosaccount.go
@@ -25,9 +25,7 @@ const (
 // KeyringHome used to store account related data.
 var KeyringHome = os.ExpandEnv("$HOME/.ignite/accounts")
 
-var (
-	ErrAccountExists = errors.New("account already exists")
-)
+var ErrAccountExists = errors.New("account already exists")
 
 const (
 	AccountPrefixCosmos = "cosmos"
@@ -234,7 +232,6 @@ func (r Registry) Export(name, passphrase string) (key string, err error) {
 	}
 
 	return r.Keyring.ExportPrivKeyArmor(name, passphrase)
-
 }
 
 // ExportHex exports an account as a private key in hex.

--- a/ignite/pkg/cosmosanalysis/app/app_test.go
+++ b/ignite/pkg/cosmosanalysis/app/app_test.go
@@ -59,7 +59,7 @@ func TestCheckKeeper(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			tmpFile := filepath.Join(tmpDir, "app.go")
-			err := os.WriteFile(tmpFile, tt.appFile, 0644)
+			err := os.WriteFile(tmpFile, tt.appFile, 0o644)
 			require.NoError(t, err)
 
 			err = app.CheckKeeper(tmpDir, tt.keeperName)
@@ -77,11 +77,11 @@ func TestGetRegisteredModules(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	tmpFile := filepath.Join(tmpDir, "app.go")
-	err := os.WriteFile(tmpFile, AppFullFile, 0644)
+	err := os.WriteFile(tmpFile, AppFullFile, 0o644)
 	require.NoError(t, err)
 
 	tmpNoAppFile := filepath.Join(tmpDir, "someOtherFile.go")
-	err = os.WriteFile(tmpNoAppFile, NoAppFile, 0644)
+	err = os.WriteFile(tmpNoAppFile, NoAppFile, 0o644)
 	require.NoError(t, err)
 
 	registeredModules, err := app.FindRegisteredModules(tmpDir)

--- a/ignite/pkg/cosmosanalysis/app/testdata/app_full.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/app_full.go
@@ -45,33 +45,32 @@ func (app *App) Name() string { return app.BaseApp.Name() }
 func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }
+
 func (app *App) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 	return app.mm.EndBlock(ctx, req)
 }
 
-var (
-	ModuleBasics = sdkmodule.NewBasicManager(
-		auth.AppModuleBasic{},
-		genutil.AppModuleBasic{},
-		bank.AppModuleBasic{},
-		capability.AppModuleBasic{},
-		staking.AppModuleBasic{},
-		mint.AppModuleBasic{},
-		distr.AppModuleBasic{},
-		gov.NewAppModuleBasic(getGovProposalHandlers()...),
-		params.AppModuleBasic{},
-		crisis.AppModuleBasic{},
-		slashing.AppModuleBasic{},
-		feegrantmodule.AppModuleBasic{},
-		ibc.AppModuleBasic{},
-		upgrade.AppModuleBasic{},
-		evidence.AppModuleBasic{},
-		transfer.AppModuleBasic{},
-		vesting.AppModuleBasic{},
-		testchainmodule.AppModuleBasic{},
-		queryonlymodmodule.AppModuleBasic{},
-		// this line is used by starport scaffolding # stargate/app/moduleBasic
-	)
+var ModuleBasics = sdkmodule.NewBasicManager(
+	auth.AppModuleBasic{},
+	genutil.AppModuleBasic{},
+	bank.AppModuleBasic{},
+	capability.AppModuleBasic{},
+	staking.AppModuleBasic{},
+	mint.AppModuleBasic{},
+	distr.AppModuleBasic{},
+	gov.NewAppModuleBasic(getGovProposalHandlers()...),
+	params.AppModuleBasic{},
+	crisis.AppModuleBasic{},
+	slashing.AppModuleBasic{},
+	feegrantmodule.AppModuleBasic{},
+	ibc.AppModuleBasic{},
+	upgrade.AppModuleBasic{},
+	evidence.AppModuleBasic{},
+	transfer.AppModuleBasic{},
+	vesting.AppModuleBasic{},
+	testchainmodule.AppModuleBasic{},
+	queryonlymodmodule.AppModuleBasic{},
+	// this line is used by starport scaffolding # stargate/app/moduleBasic
 )
 
 func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig) {

--- a/ignite/pkg/cosmosanalysis/app/testdata/app_generic.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/app_generic.go
@@ -17,6 +17,7 @@ func (f Foo[T]) Name() string               { return app.BaseApp.Name() }
 func (f Foo[T]) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }
+
 func (f Foo[T]) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 	return app.mm.EndBlock(ctx, req)
 }

--- a/ignite/pkg/cosmosanalysis/app/testdata/app_generic.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/app_generic.go
@@ -1,5 +1,10 @@
 package foo
 
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
 type Foo[T any] struct {
 	FooKeeper foo.keeper
 	i         T

--- a/ignite/pkg/cosmosanalysis/app/testdata/app_minimal.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/app_minimal.go
@@ -16,6 +16,7 @@ func (f Foo) Name() string               { return app.BaseApp.Name() }
 func (f Foo) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }
+
 func (f Foo) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 	return app.mm.EndBlock(ctx, req)
 }

--- a/ignite/pkg/cosmosanalysis/app/testdata/two_app.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/two_app.go
@@ -16,6 +16,7 @@ func (f Foo) Name() string               { return app.BaseApp.Name() }
 func (f Foo) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }
+
 func (f Foo) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 	return app.mm.EndBlock(ctx, req)
 }
@@ -31,6 +32,7 @@ func (f Bar) Name() string               { return app.BaseApp.Name() }
 func (f Bar) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }
+
 func (f Bar) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 	return app.mm.EndBlock(ctx, req)
 }

--- a/ignite/pkg/cosmosanalysis/cosmosanalysis_test.go
+++ b/ignite/pkg/cosmosanalysis/cosmosanalysis_test.go
@@ -98,11 +98,11 @@ func TestFindImplementation(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	f1 := filepath.Join(tmpDir, "1.go")
-	err := os.WriteFile(f1, file1, 0644)
+	err := os.WriteFile(f1, file1, 0o644)
 	require.NoError(t, err)
 
 	f2 := filepath.Join(tmpDir, "2.go")
-	err = os.WriteFile(f2, file2, 0644)
+	err = os.WriteFile(f2, file2, 0o644)
 	require.NoError(t, err)
 
 	// find in dir
@@ -125,10 +125,10 @@ func TestFindImplementationInSpreadInMultipleFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	f1 := filepath.Join(tmpDir, "1.go")
-	err := os.WriteFile(f1, partialImplementation, 0644)
+	err := os.WriteFile(f1, partialImplementation, 0o644)
 	require.NoError(t, err)
 	f2 := filepath.Join(tmpDir, "2.go")
-	err = os.WriteFile(f2, restOfImplementation, 0644)
+	err = os.WriteFile(f2, restOfImplementation, 0o644)
 	require.NoError(t, err)
 
 	found, err := cosmosanalysis.FindImplementation(tmpDir, expectedinterface)
@@ -142,10 +142,10 @@ func TestFindImplementationNotFound(t *testing.T) {
 	tmpDir2 := t.TempDir()
 
 	noImplFile := filepath.Join(tmpDir1, "1.go")
-	err := os.WriteFile(noImplFile, noImplementation, 0644)
+	err := os.WriteFile(noImplFile, noImplementation, 0o644)
 	require.NoError(t, err)
 	partialImplFile := filepath.Join(tmpDir2, "2.go")
-	err = os.WriteFile(partialImplFile, partialImplementation, 0644)
+	err = os.WriteFile(partialImplFile, partialImplementation, 0o644)
 	require.NoError(t, err)
 
 	// No implementation
@@ -162,9 +162,9 @@ func TestFindAppFilePath(t *testing.T) {
 
 	appFolder := filepath.Join(tmpDir, "app")
 	secondaryAppFolder := filepath.Join(tmpDir, "myOwnAppDir")
-	err := os.Mkdir(appFolder, 0700)
+	err := os.Mkdir(appFolder, 0o700)
 	require.NoError(t, err)
-	err = os.Mkdir(secondaryAppFolder, 0700)
+	err = os.Mkdir(secondaryAppFolder, 0o700)
 	require.NoError(t, err)
 
 	// No file
@@ -173,7 +173,7 @@ func TestFindAppFilePath(t *testing.T) {
 
 	// Only one file with app implementation
 	myOwnAppFilePath := filepath.Join(secondaryAppFolder, "my_own_app.go")
-	err = os.WriteFile(myOwnAppFilePath, appFile, 0644)
+	err = os.WriteFile(myOwnAppFilePath, appFile, 0o644)
 	require.NoError(t, err)
 	pathFound, err := cosmosanalysis.FindAppFilePath(tmpDir)
 	require.NoError(t, err)
@@ -181,14 +181,14 @@ func TestFindAppFilePath(t *testing.T) {
 
 	// With a test file added
 	appTestFilePath := filepath.Join(secondaryAppFolder, "my_own_app_test.go")
-	err = os.WriteFile(appTestFilePath, appTestFile, 0644)
+	err = os.WriteFile(appTestFilePath, appTestFile, 0o644)
 	require.NoError(t, err)
 	pathFound, err = cosmosanalysis.FindAppFilePath(tmpDir)
 	require.Contains(t, err.Error(), "cannot locate your app.go")
 
 	// With an additional app file (that is app.go)
 	appFilePath := filepath.Join(appFolder, "app.go")
-	err = os.WriteFile(appFilePath, appFile, 0644)
+	err = os.WriteFile(appFilePath, appFile, 0o644)
 	require.NoError(t, err)
 	pathFound, err = cosmosanalysis.FindAppFilePath(tmpDir)
 	require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestFindAppFilePath(t *testing.T) {
 
 	// With two app.go files
 	extraAppFilePath := filepath.Join(secondaryAppFolder, "app.go")
-	err = os.WriteFile(extraAppFilePath, appFile, 0644)
+	err = os.WriteFile(extraAppFilePath, appFile, 0o644)
 	require.NoError(t, err)
 	pathFound, err = cosmosanalysis.FindAppFilePath(tmpDir)
 	require.NoError(t, err)

--- a/ignite/pkg/cosmosanalysis/module/module_test.go
+++ b/ignite/pkg/cosmosanalysis/module/module_test.go
@@ -32,7 +32,8 @@ var testModule = Module{
 						HTTPRules: []protoanalysis.HTTPRule{
 							{
 								Params:   []string{"mytypefield"},
-								HasQuery: false, HasBody: false},
+								HasQuery: false, HasBody: false,
+							},
 						},
 					},
 				},
@@ -48,7 +49,8 @@ var testModule = Module{
 				{
 					Params:   []string{"mytypefield"},
 					HasQuery: false,
-					HasBody:  false},
+					HasBody:  false,
+				},
 			},
 		},
 	},

--- a/ignite/pkg/cosmosanalysis/module/testdata/planet/app/app.go
+++ b/ignite/pkg/cosmosanalysis/module/testdata/planet/app/app.go
@@ -16,6 +16,7 @@ func (f Foo) Name() string { return app.BaseApp.Name() }
 func (f Foo) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }
+
 func (f Foo) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 	return app.mm.EndBlock(ctx, req)
 }

--- a/ignite/pkg/cosmosanalysis/module/testdata/planet/x/planet/types/types.go
+++ b/ignite/pkg/cosmosanalysis/module/testdata/planet/x/planet/types/types.go
@@ -1,4 +1,6 @@
 package types
 
-type QueryMyQueryRequest struct{}
-type QueryMyQueryResponse struct{}
+type (
+	QueryMyQueryRequest  struct{}
+	QueryMyQueryResponse struct{}
+)

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -323,7 +323,8 @@ func (c Client) BroadcastTx(accountName string, msgs ...sdktypes.Msg) (Response,
 var mconf sync.Mutex
 
 func (c Client) BroadcastTxWithProvision(accountName string, msgs ...sdktypes.Msg) (
-	gas uint64, broadcast func() (Response, error), err error) {
+	gas uint64, broadcast func() (Response, error), err error,
+) {
 	if err := c.prepareBroadcast(context.Background(), accountName, msgs); err != nil {
 		return 0, nil, err
 	}

--- a/ignite/pkg/cosmoscmd/root.go
+++ b/ignite/pkg/cosmoscmd/root.go
@@ -164,7 +164,6 @@ func NewRootCmd(
 
 			if err := server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig); err != nil {
 				return err
-
 			}
 
 			startProxyForTunneledPeers(initClientCtx, cmd)
@@ -387,7 +386,6 @@ func (a appCreator) appExport(
 	jailAllowedAddrs []string,
 	appOpts servertypes.AppOptions,
 ) (servertypes.ExportedApp, error) {
-
 	var exportableApp ExportableApp
 
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)

--- a/ignite/pkg/cosmosgen/cosmosgen.go
+++ b/ignite/pkg/cosmosgen/cosmosgen.go
@@ -148,7 +148,6 @@ func Generate(ctx context.Context, cacheStorage cache.Storage, appPath, protoDir
 	}
 
 	return nil
-
 }
 
 // VuexStoreModulePath generates Vuex store module paths for Cosmos SDK modules.

--- a/ignite/pkg/cosmosgen/generate.go
+++ b/ignite/pkg/cosmosgen/generate.go
@@ -21,11 +21,9 @@ const (
 	moduleCacheNamespace = "generate.setup.module"
 )
 
-var (
-	protocGlobalInclude = xfilepath.List(
-		xfilepath.JoinFromHome(xfilepath.Path("local/include")),
-		xfilepath.JoinFromHome(xfilepath.Path(".local/include")),
-	)
+var protocGlobalInclude = xfilepath.List(
+	xfilepath.JoinFromHome(xfilepath.Path("local/include")),
+	xfilepath.JoinFromHome(xfilepath.Path(".local/include")),
 )
 
 type ModulesInPath struct {

--- a/ignite/pkg/cosmosgen/generate_dart.go
+++ b/ignite/pkg/cosmosgen/generate_dart.go
@@ -16,11 +16,9 @@ import (
 	protocgendart "github.com/ignite/cli/ignite/pkg/protoc-gen-dart"
 )
 
-var (
-	dartOut = []string{
-		"--dart_out=grpc:.",
-	}
-)
+var dartOut = []string{
+	"--dart_out=grpc:.",
+}
 
 const (
 	dartExportFileName = "export.dart"
@@ -84,7 +82,7 @@ func (g *dartGenerator) generateModule(ctx context.Context, plugin, appPath stri
 	if err := os.RemoveAll(out); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(clientOut, 0766); err != nil {
+	if err := os.MkdirAll(clientOut, 0o766); err != nil {
 		return err
 	}
 
@@ -116,6 +114,6 @@ func (g *dartGenerator) generateModule(ctx context.Context, plugin, appPath stri
 		exportContent.WriteString(fmt.Sprintf("export '%s';\n", path))
 	}
 
-	err = os.WriteFile(exportOut, exportContent.Bytes(), 0644)
+	err = os.WriteFile(exportOut, exportContent.Bytes(), 0o644)
 	return errors.Wrap(err, "could not create the Dart export file for module")
 }

--- a/ignite/pkg/cosmosgen/generate_go.go
+++ b/ignite/pkg/cosmosgen/generate_go.go
@@ -11,12 +11,10 @@ import (
 	"github.com/ignite/cli/ignite/pkg/protoc"
 )
 
-var (
-	goOuts = []string{
-		"--gocosmos_out=plugins=interfacetype+grpc,Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types:.",
-		"--grpc-gateway_out=logtostderr=true:.",
-	}
-)
+var goOuts = []string{
+	"--gocosmos_out=plugins=interfacetype+grpc,Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types:.",
+	"--grpc-gateway_out=logtostderr=true:.",
+}
 
 func (g *generator) generateGo() error {
 	includePaths, err := g.resolveInclude(g.appPath)

--- a/ignite/pkg/cosmosgen/generate_javascript.go
+++ b/ignite/pkg/cosmosgen/generate_javascript.go
@@ -114,7 +114,7 @@ func (g *jsGenerator) generateModule(ctx context.Context, tsprotoPluginPath, app
 		return err
 	}
 
-	if err := os.MkdirAll(typesOut, 0766); err != nil {
+	if err := os.MkdirAll(typesOut, 0o766); err != nil {
 		return err
 	}
 

--- a/ignite/pkg/cosmosgen/generate_openapi.go
+++ b/ignite/pkg/cosmosgen/generate_openapi.go
@@ -65,7 +65,7 @@ func generateOpenAPISpec(g *generator) error {
 		}
 
 		if err != cache.ErrorNotFound {
-			if err := os.WriteFile(specPath, existingSpec, 0644); err != nil {
+			if err := os.WriteFile(specPath, existingSpec, 0o644); err != nil {
 				return err
 			}
 		} else {
@@ -141,7 +141,7 @@ func generateOpenAPISpec(g *generator) error {
 
 	// ensure out dir exists.
 	outDir := filepath.Dir(out)
-	if err := os.MkdirAll(outDir, 0766); err != nil {
+	if err := os.MkdirAll(outDir, 0o766); err != nil {
 		return err
 	}
 

--- a/ignite/pkg/cosmosgen/template.go
+++ b/ignite/pkg/cosmosgen/template.go
@@ -75,7 +75,7 @@ func (t templateWriter) Write(destDir, protoPath string, data interface{}) error
 
 		out := filepath.Join(destDir, strings.TrimSuffix(filepath.Base(path), ".tpl"))
 
-		f, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0766)
+		f, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o766)
 		if err != nil {
 			return err
 		}

--- a/ignite/pkg/cosmosutil/genesis.go
+++ b/ignite/pkg/cosmosutil/genesis.go
@@ -137,7 +137,7 @@ func UpdateGenesis(genesisPath string, options ...GenesisField) error {
 			return err
 		}
 	}
-	return os.WriteFile(genesisPath, genesisBytes, 0644)
+	return os.WriteFile(genesisPath, genesisBytes, 0o644)
 }
 
 // ParseGenesisFromPath parse ChainGenesis object from a genesis file

--- a/ignite/pkg/cosmosutil/genesis_test.go
+++ b/ignite/pkg/cosmosutil/genesis_test.go
@@ -317,7 +317,7 @@ func TestUpdateGenesis(t *testing.T) {
 					),
 				)
 			}
-			require.NoError(t, os.WriteFile(tmpGenesis, []byte(tt.args.genesis), 0644))
+			require.NoError(t, os.WriteFile(tmpGenesis, []byte(tt.args.genesis), 0o644))
 			err := cosmosutil.UpdateGenesis(tmpGenesis, tt.args.options...)
 			if tt.err != nil {
 				require.Error(t, err)

--- a/ignite/pkg/dirchange/dirchange.go
+++ b/ignite/pkg/dirchange/dirchange.go
@@ -102,7 +102,6 @@ func ChecksumFromPaths(workdir string, paths ...string) ([]byte, error) {
 
 			return nil
 		})
-
 		if err != nil {
 			return []byte{}, err
 		}

--- a/ignite/pkg/dirchange/dirchange_test.go
+++ b/ignite/pkg/dirchange/dirchange_test.go
@@ -33,15 +33,15 @@ func TestHasDirChecksumChanged(t *testing.T) {
 
 	// Create directory tree
 	dir1 := filepath.Join(tempDir, "foo1")
-	err = os.MkdirAll(dir1, 0700)
+	err = os.MkdirAll(dir1, 0o700)
 	require.NoError(t, err)
 	defer os.RemoveAll(dir1)
 	dir2 := filepath.Join(tempDir, "foo2")
-	err = os.MkdirAll(dir2, 0700)
+	err = os.MkdirAll(dir2, 0o700)
 	require.NoError(t, err)
 	defer os.RemoveAll(dir2)
 	dir3 := filepath.Join(tempDir, "foo3")
-	err = os.MkdirAll(dir3, 0700)
+	err = os.MkdirAll(dir3, 0o700)
 	require.NoError(t, err)
 	defer os.RemoveAll(dir3)
 
@@ -53,17 +53,17 @@ func TestHasDirChecksumChanged(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create files
-	err = os.WriteFile(filepath.Join(dir1, "foo"), []byte("some bytes"), 0644)
+	err = os.WriteFile(filepath.Join(dir1, "foo"), []byte("some bytes"), 0o644)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir11, "foo"), randomBytes(15), 0644)
+	err = os.WriteFile(filepath.Join(dir11, "foo"), randomBytes(15), 0o644)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir12, "foo"), randomBytes(20), 0644)
+	err = os.WriteFile(filepath.Join(dir12, "foo"), randomBytes(20), 0o644)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir21, "foo"), randomBytes(20), 0644)
+	err = os.WriteFile(filepath.Join(dir21, "foo"), randomBytes(20), 0o644)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir3, "foo1"), randomBytes(10), 0644)
+	err = os.WriteFile(filepath.Join(dir3, "foo1"), randomBytes(10), 0o644)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir3, "foo2"), randomBytes(10), 0644)
+	err = os.WriteFile(filepath.Join(dir3, "foo2"), randomBytes(10), 0o644)
 	require.NoError(t, err)
 
 	// Check checksum
@@ -76,7 +76,7 @@ func TestHasDirChecksumChanged(t *testing.T) {
 	// Checksum remains the same if a file is deleted and recreated with the same content
 	err = os.Remove(filepath.Join(dir1, "foo"))
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir1, "foo"), []byte("some bytes"), 0644)
+	err = os.WriteFile(filepath.Join(dir1, "foo"), []byte("some bytes"), 0o644)
 	require.NoError(t, err)
 	tmpChecksum, err := dirchange.ChecksumFromPaths("", paths...)
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestHasDirChecksumChanged(t *testing.T) {
 	require.NotEqual(t, checksum, tmpChecksum)
 
 	// Checksum changes if a file is modified
-	err = os.WriteFile(filepath.Join(dir3, "foo1"), randomBytes(10), 0644)
+	err = os.WriteFile(filepath.Join(dir3, "foo1"), randomBytes(10), 0o644)
 	require.NoError(t, err)
 	newChecksum, err := dirchange.ChecksumFromPaths("", paths...)
 	require.NoError(t, err)
@@ -108,11 +108,11 @@ func TestHasDirChecksumChanged(t *testing.T) {
 
 	// Error if no files in the specified dirs
 	empty1 := filepath.Join(tempDir, "empty1")
-	err = os.MkdirAll(empty1, 0700)
+	err = os.MkdirAll(empty1, 0o700)
 	require.NoError(t, err)
 	defer os.RemoveAll(empty1)
 	empty2 := filepath.Join(tempDir, "empty2")
-	err = os.MkdirAll(empty2, 0700)
+	err = os.MkdirAll(empty2, 0o700)
 	require.NoError(t, err)
 	defer os.RemoveAll(empty2)
 	_, err = dirchange.ChecksumFromPaths("", empty1, empty2)
@@ -150,7 +150,7 @@ func TestHasDirChecksumChanged(t *testing.T) {
 	require.True(t, changed)
 
 	// Return true if it has been changed
-	err = os.WriteFile(filepath.Join(dir21, "bar"), randomBytes(20), 0644)
+	err = os.WriteFile(filepath.Join(dir21, "bar"), randomBytes(20), 0o644)
 	require.NoError(t, err)
 	changed, err = dirchange.HasDirChecksumChanged(cache, ChecksumKey, "", paths...)
 	require.NoError(t, err)

--- a/ignite/pkg/goanalysis/goanalysis.go
+++ b/ignite/pkg/goanalysis/goanalysis.go
@@ -15,10 +15,8 @@ const (
 	goFileExtension = ".go"
 )
 
-var (
-	// ErrMultipleMainPackagesFound is returned when multiple main packages found while expecting only one.
-	ErrMultipleMainPackagesFound = errors.New("multiple main packages found")
-)
+// ErrMultipleMainPackagesFound is returned when multiple main packages found while expecting only one.
+var ErrMultipleMainPackagesFound = errors.New("multiple main packages found")
 
 // DiscoverMain finds main Go packages under path.
 func DiscoverMain(path string) (pkgPaths []string, err error) {

--- a/ignite/pkg/goanalysis/goanalysis_test.go
+++ b/ignite/pkg/goanalysis/goanalysis_test.go
@@ -142,11 +142,11 @@ func createMainFiles(tmpDir string, mainFiles []string) (pathsWithMain []string,
 		mainFile := filepath.Join(tmpDir, mf)
 		dir := filepath.Dir(mainFile)
 
-		if err = os.MkdirAll(dir, 0770); err != nil {
+		if err = os.MkdirAll(dir, 0o770); err != nil {
 			return nil, err
 		}
 
-		if err = os.WriteFile(mainFile, MainFile, 0644); err != nil {
+		if err = os.WriteFile(mainFile, MainFile, 0o644); err != nil {
 			return nil, err
 		}
 
@@ -160,7 +160,7 @@ func TestFindImportedPackages(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	tmpFile := filepath.Join(tmpDir, "app.go")
-	err := os.WriteFile(tmpFile, ImportFile, 0644)
+	err := os.WriteFile(tmpFile, ImportFile, 0o644)
 	require.NoError(t, err)
 
 	packages, err := goanalysis.FindImportedPackages(tmpFile)

--- a/ignite/pkg/localfs/save.go
+++ b/ignite/pkg/localfs/save.go
@@ -1,10 +1,9 @@
 package localfs
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
-
-	"io/fs"
 )
 
 // SaveTemp saves file system f to a temporary path in the local file system
@@ -64,7 +63,7 @@ func Save(f fs.FS, path string) error {
 		out := filepath.Join(path, wpath)
 
 		if d.IsDir() {
-			return os.MkdirAll(out, 0744)
+			return os.MkdirAll(out, 0o744)
 		}
 
 		content, err := fs.ReadFile(f, wpath)
@@ -72,6 +71,6 @@ func Save(f fs.FS, path string) error {
 			return err
 		}
 
-		return os.WriteFile(out, content, 0644)
+		return os.WriteFile(out, content, 0o644)
 	})
 }

--- a/ignite/pkg/localfs/search_test.go
+++ b/ignite/pkg/localfs/search_test.go
@@ -15,9 +15,9 @@ func setupGlobTests(t *testing.T, files []string) string {
 	for _, file := range files {
 		fileDir := filepath.Dir(file)
 		fileDir = filepath.Join(tmpdir, fileDir)
-		err := os.MkdirAll(fileDir, 0755)
+		err := os.MkdirAll(fileDir, 0o755)
 		require.NoError(t, err)
-		err = os.WriteFile(filepath.Join(tmpdir, file), []byte{}, 0644)
+		err = os.WriteFile(filepath.Join(tmpdir, file), []byte{}, 0o644)
 		require.NoError(t, err)
 	}
 	return tmpdir

--- a/ignite/pkg/multiformatname/multiformatname.go
+++ b/ignite/pkg/multiformatname/multiformatname.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/iancoleman/strcase"
+
 	"github.com/ignite/cli/ignite/pkg/xstrings"
 )
 

--- a/ignite/pkg/nodetime/nodetime.go
+++ b/ignite/pkg/nodetime/nodetime.go
@@ -70,7 +70,7 @@ func Binary() []byte {
 // Command setups the nodetime binary and returns the command needed to execute c.
 func Command(c CommandName) (command []string, cleanup func(), err error) {
 	cs := string(c)
-	path, cleanup, err := localfs.SaveBytesTemp(Binary(), cs, 0755)
+	path, cleanup, err := localfs.SaveBytesTemp(Binary(), cs, 0o755)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/ignite/pkg/nodetime/programs/ts-proto/tsproto.go
+++ b/ignite/pkg/nodetime/programs/ts-proto/tsproto.go
@@ -34,7 +34,7 @@ func BinaryPath() (path string, cleanup func(), err error) {
 %s "$@"
 `, strings.Join(command, " "))
 
-	err = os.WriteFile(path, []byte(script), 0755)
+	err = os.WriteFile(path, []byte(script), 0o755)
 
 	return
 }

--- a/ignite/pkg/protoc-gen-dart/protoc-gen-dart.go
+++ b/ignite/pkg/protoc-gen-dart/protoc-gen-dart.go
@@ -12,7 +12,7 @@ const Name = "protoc-gen-dart"
 
 // BinaryPath returns the binary path for the plugin.
 func BinaryPath() (path string, cleanup func(), err error) {
-	return localfs.SaveBytesTemp(data.Binary(), Name, 0755)
+	return localfs.SaveBytesTemp(data.Binary(), Name, 0o755)
 }
 
 // Flag returns the binary name-binary path format to pass to protoc --plugin.

--- a/ignite/pkg/protoc/protoc.go
+++ b/ignite/pkg/protoc/protoc.go
@@ -56,7 +56,7 @@ type Cmd struct {
 
 // Command sets the protoc binary up and returns the command needed to execute c.
 func Command() (command Cmd, cleanup func(), err error) {
-	path, cleanupProto, err := localfs.SaveBytesTemp(data.Binary(), "protoc", 0755)
+	path, cleanupProto, err := localfs.SaveBytesTemp(data.Binary(), "protoc", 0o755)
 	if err != nil {
 		return Cmd{}, nil, err
 	}
@@ -150,7 +150,8 @@ func Generate(ctx context.Context, outDir, protoPath string, includePaths, proto
 // ones may need to be discovered as well. some protoc plugins already do this discovery internally but
 // for the ones that don't, it needs to be handled here if GenerateDependencies() is enabled.
 func discoverFiles(ctx context.Context, c configs, protoPath string, includePaths []string, cache protoanalysis.Cache) (
-	discovered []string, err error) {
+	discovered []string, err error,
+) {
 	packages, err := protoanalysis.Parse(ctx, cache, protoPath)
 	if err != nil {
 		return nil, err

--- a/ignite/pkg/relayer/chain.go
+++ b/ignite/pkg/relayer/chain.go
@@ -21,9 +21,7 @@ const (
 	OrderingOrdered   = "ORDER_ORDERED"
 )
 
-var (
-	errEndpointExistsWithDifferentChainID = errors.New("rpc endpoint already exists with a different chain id")
-)
+var errEndpointExistsWithDifferentChainID = errors.New("rpc endpoint already exists with a different chain id")
 
 // Chain represents a chain in relayer.
 type Chain struct {
@@ -101,7 +99,8 @@ func WithClientID(clientID string) Option {
 
 // NewChain creates a new chain on relayer or uses the existing matching chain.
 func (r Relayer) NewChain(accountName, rpcAddress string, options ...Option) (
-	*Chain, cosmosaccount.Account, error) {
+	*Chain, cosmosaccount.Account, error,
+) {
 	c := &Chain{
 		accountName: accountName,
 		rpcAddress:  fixRPCAddress(rpcAddress),

--- a/ignite/pkg/relayer/config/config.go
+++ b/ignite/pkg/relayer/config/config.go
@@ -14,8 +14,10 @@ const SupportVersion = "2"
 
 var configPath = os.ExpandEnv("$HOME/.ignite/relayer/config.yml")
 
-var ErrChainCannotBeFound = errors.New("chain cannot be found")
-var ErrPathCannotBeFound = errors.New("path cannot be found")
+var (
+	ErrChainCannotBeFound = errors.New("chain cannot be found")
+	ErrPathCannotBeFound  = errors.New("path cannot be found")
+)
 
 type Config struct {
 	Version string  `json:"version" yaml:"version"`

--- a/ignite/pkg/relayer/relayer.go
+++ b/ignite/pkg/relayer/relayer.go
@@ -135,7 +135,8 @@ func (r Relayer) call(
 	path relayerconf.Path,
 	action string,
 ) (
-	reply relayerconf.Path, err error) {
+	reply relayerconf.Path, err error,
+) {
 	srcChain, srcKey, err := r.prepare(ctx, conf, path.Src.ChainID)
 	if err != nil {
 		return relayerconf.Path{}, err
@@ -157,7 +158,8 @@ func (r Relayer) call(
 }
 
 func (r Relayer) prepare(ctx context.Context, conf relayerconf.Config, chainID string) (
-	chain relayerconf.Chain, privKey string, err error) {
+	chain relayerconf.Chain, privKey string, err error,
+) {
 	chain, err = conf.ChainByID(chainID)
 	if err != nil {
 		return relayerconf.Chain{}, "", err

--- a/ignite/pkg/repoversion/repoversion.go
+++ b/ignite/pkg/repoversion/repoversion.go
@@ -45,7 +45,6 @@ func Determine(path string) (v Version, err error) {
 	idMap := make(map[string]int)
 
 	err = cIter.ForEach(func(c *object.Commit) error {
-
 		idMap[c.Hash.String()] = commitIndex
 		commitIndex++
 
@@ -81,7 +80,6 @@ func Determine(path string) (v Version, err error) {
 			}
 
 			commit, err := repo.CommitObject(t.Hash())
-
 			if err != nil {
 				return err
 			}

--- a/ignite/services/chain/build.go
+++ b/ignite/services/chain/build.go
@@ -113,7 +113,7 @@ func (c *Chain) BuildRelease(ctx context.Context, cacheStorage cache.Storage, ou
 		}
 	}
 
-	if err := os.MkdirAll(releasePath, 0755); err != nil {
+	if err := os.MkdirAll(releasePath, 0o755); err != nil {
 		return "", err
 	}
 

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -179,7 +179,6 @@ func New(path string, options ...Option) (*Chain, error) {
 }
 
 func (c *Chain) appVersion() (v version, err error) {
-
 	ver, err := repoversion.Determine(c.app.Path)
 	if err != nil {
 		return version{}, err

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -22,9 +22,7 @@ var (
 	ErrFaucetAccountDoesNotExist = errors.New("specified account (faucet.name) does not exist")
 )
 
-var (
-	envAPIAddress = os.Getenv("API_ADDRESS")
-)
+var envAPIAddress = os.Getenv("API_ADDRESS")
 
 // Faucet returns the faucet for the chain or an error if the faucet
 // configuration is wrong or not configured (not enabled) at all.

--- a/ignite/services/chain/generate.go
+++ b/ignite/services/chain/generate.go
@@ -120,7 +120,7 @@ func (c *Chain) Generate(
 		}
 
 		storeRootPath := filepath.Join(c.app.Path, vuexPath, "generated")
-		if err := os.MkdirAll(storeRootPath, 0766); err != nil {
+		if err := os.MkdirAll(storeRootPath, 0o766); err != nil {
 			return err
 		}
 
@@ -141,7 +141,7 @@ func (c *Chain) Generate(
 		}
 
 		rootPath := filepath.Join(c.app.Path, dartPath, "generated")
-		if err := os.MkdirAll(rootPath, 0766); err != nil {
+		if err := os.MkdirAll(rootPath, 0o766); err != nil {
 			return err
 		}
 

--- a/ignite/services/chain/plugin-stargate.go
+++ b/ignite/services/chain/plugin-stargate.go
@@ -85,7 +85,7 @@ func (p *stargatePlugin) appTOML(homePath string, conf chainconfig.Config) error
 	gas := sdktypes.NewInt64Coin(staked.Denom, 0)
 	config.Set("minimum-gas-prices", gas.String())
 
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (p *stargatePlugin) configTOML(homePath string, conf chainconfig.Config) er
 	config.Set("p2p.laddr", p2pAddr)
 	config.Set("rpc.pprof_laddr", conf.Host.Prof)
 
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func (p *stargatePlugin) clientTOML(homePath string) error {
 	}
 	config.Set("keyring-backend", "test")
 	config.Set("broadcast-mode", "block")
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -480,7 +480,7 @@ func (c *Chain) chainSavePath() (string, error) {
 	chainSavePath := filepath.Join(savePath, chainID)
 
 	// ensure the path exists
-	if err := os.MkdirAll(savePath, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(savePath, 0o700); err != nil && !os.IsExist(err) {
 		return "", err
 	}
 

--- a/ignite/services/network/launch_test.go
+++ b/ignite/services/network/launch_test.go
@@ -244,5 +244,4 @@ func TestRevertLaunch(t *testing.T) {
 		require.Equal(t, expectedError, revertError)
 		suite.AssertAllMocks(t)
 	})
-
 }

--- a/ignite/services/network/networkchain/binarycache.go
+++ b/ignite/services/network/networkchain/binarycache.go
@@ -51,7 +51,7 @@ func cacheBinaryForLaunchID(launchID uint64, binaryHash, sourceHash string) erro
 	if err != nil {
 		return err
 	}
-	var cacheList = BinaryCacheList{}
+	cacheList := BinaryCacheList{}
 	err = confile.New(confile.DefaultYAMLEncodingCreator, cachePath).Load(&cacheList)
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func checkBinaryCacheForLaunchID(launchID uint64, binaryHash, sourceHash string)
 	if err != nil {
 		return false, err
 	}
-	var cacheList = BinaryCacheList{}
+	cacheList := BinaryCacheList{}
 	err = confile.New(confile.DefaultYAMLEncodingCreator, cachePath).Load(&cacheList)
 	if err != nil {
 		return false, err

--- a/ignite/services/network/networkchain/init.go
+++ b/ignite/services/network/networkchain/init.go
@@ -78,7 +78,7 @@ func (c *Chain) initGenesis(ctx context.Context) error {
 		}
 
 		// replace the default genesis with the fetched genesis
-		if err := os.WriteFile(genesisPath, genesis, 0644); err != nil {
+		if err := os.WriteFile(genesisPath, genesis, 0o644); err != nil {
 			return err
 		}
 	} else {

--- a/ignite/services/network/networkchain/networkchain.go
+++ b/ignite/services/network/networkchain/networkchain.go
@@ -299,7 +299,6 @@ func (c *Chain) CacheBinary(launchID uint64) error {
 		return err
 	}
 	binaryChecksum, err := checksum.Binary(binaryName)
-
 	if err != nil {
 		return err
 	}
@@ -320,7 +319,7 @@ func fetchSource(
 	}
 
 	// ensure the path for chain source exists
-	if err := os.MkdirAll(path, 0755); err != nil {
+	if err := os.MkdirAll(path, 0o755); err != nil {
 		return "", "", err
 	}
 

--- a/ignite/services/network/networkchain/prepare.go
+++ b/ignite/services/network/networkchain/prepare.go
@@ -154,7 +154,6 @@ func (c Chain) buildGenesis(
 			cosmosutil.WithKeyValueInt(cosmosutil.FieldLastBlockHeight, lastBlockHeight),
 			cosmosutil.WithKeyValueInt(cosmosutil.FieldConsumerUnbondingPeriod, consumerUnbondingTime),
 		)
-
 	}
 
 	// update genesis
@@ -245,14 +244,14 @@ func (c Chain) applyGenesisValidators(ctx context.Context, genesisVals []network
 	if err := os.RemoveAll(gentxDir); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(gentxDir, 0700); err != nil {
+	if err := os.MkdirAll(gentxDir, 0o700); err != nil {
 		return err
 	}
 
 	// write gentxs
 	for i, val := range genesisVals {
 		gentxPath := filepath.Join(gentxDir, fmt.Sprintf("gentx%d.json", i))
-		if err = ioutil.WriteFile(gentxPath, val.Gentx, 0666); err != nil {
+		if err = ioutil.WriteFile(gentxPath, val.Gentx, 0o666); err != nil {
 			return err
 		}
 	}
@@ -318,7 +317,7 @@ func (c Chain) updateConfigFromGenesisValidators(genesisVals []networktypes.Gene
 		}
 
 		// save config.toml file
-		configTomlFile, err := os.OpenFile(configPath, os.O_RDWR|os.O_TRUNC, 0644)
+		configTomlFile, err := os.OpenFile(configPath, os.O_RDWR|os.O_TRUNC, 0o644)
 		if err != nil {
 			return err
 		}
@@ -342,5 +341,4 @@ func (c Chain) updateConfigFromGenesisValidators(genesisVals []networktypes.Gene
 		}
 	}
 	return nil
-
 }

--- a/ignite/services/network/networkchain/simulate.go
+++ b/ignite/services/network/networkchain/simulate.go
@@ -139,7 +139,7 @@ func (c Chain) setSimulationConfig() (string, error) {
 	config.Set("api.address", apiAddr)
 	config.Set("grpc.address", genAddr(ports[1]))
 
-	file, err := os.OpenFile(appPath, os.O_RDWR|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(appPath, os.O_RDWR|os.O_TRUNC, 0o644)
 	if err != nil {
 		return "", err
 	}
@@ -176,7 +176,7 @@ func (c Chain) setSimulationConfig() (string, error) {
 	config.Set("p2p.laddr", p2pAddr)
 	config.Set("rpc.pprof_laddr", genAddr(ports[4]))
 
-	file, err = os.OpenFile(configPath, os.O_RDWR|os.O_TRUNC, 0644)
+	file, err = os.OpenFile(configPath, os.O_RDWR|os.O_TRUNC, 0o644)
 	if err != nil {
 		return "", err
 	}

--- a/ignite/services/network/networktypes/genesisinformation.go
+++ b/ignite/services/network/networktypes/genesisinformation.go
@@ -96,6 +96,7 @@ func (gi GenesisInformation) ContainsGenesisAccount(address string) bool {
 	}
 	return false
 }
+
 func (gi GenesisInformation) ContainsVestingAccount(address string) bool {
 	for _, account := range gi.VestingAccounts {
 		if account.Address == address {
@@ -104,6 +105,7 @@ func (gi GenesisInformation) ContainsVestingAccount(address string) bool {
 	}
 	return false
 }
+
 func (gi GenesisInformation) ContainsGenesisValidator(address string) bool {
 	for _, account := range gi.GenesisValidators {
 		if account.Address == address {

--- a/ignite/services/network/networktypes/genesisinformation_test.go
+++ b/ignite/services/network/networktypes/genesisinformation_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/ignite/cli/ignite/services/network/networktypes"
 )
 
-var (
-	sampleCoins = sdk.NewCoins(sdk.NewCoin("bar", sdk.NewInt(1000)), sdk.NewCoin("foo", sdk.NewInt(2000)))
-)
+var sampleCoins = sdk.NewCoins(sdk.NewCoin("bar", sdk.NewInt(1000)), sdk.NewCoin("foo", sdk.NewInt(2000)))
 
 func TestToGenesisAccount(t *testing.T) {
 	tests := []struct {

--- a/ignite/services/network/networktypes/request.go
+++ b/ignite/services/network/networktypes/request.go
@@ -24,7 +24,6 @@ type (
 
 // ToRequest converts a request data from SPN and returns a Request object
 func ToRequest(request launchtypes.Request) Request {
-
 	return Request{
 		LaunchID:  request.LaunchID,
 		RequestID: request.RequestID,

--- a/ignite/services/network/queries.go
+++ b/ignite/services/network/queries.go
@@ -17,10 +17,8 @@ import (
 	"github.com/ignite/cli/ignite/services/network/networktypes"
 )
 
-var (
-	// ErrObjectNotFound is returned when the query returns a not found error.
-	ErrObjectNotFound = errors.New("query object not found")
-)
+// ErrObjectNotFound is returned when the query returns a not found error.
+var ErrObjectNotFound = errors.New("query object not found")
 
 // ChainLaunch fetches the chain launch from Network by launch id.
 func (n Network) ChainLaunch(ctx context.Context, id uint64) (networktypes.ChainLaunch, error) {

--- a/ignite/services/network/share_percent.go
+++ b/ignite/services/network/share_percent.go
@@ -102,7 +102,7 @@ func ParseSharePercents(percents string) (SharePercents, error) {
 }
 
 func uintPow(x, y uint64) uint64 {
-	var result = x
+	result := x
 	for i := 1; uint64(i) < y; i++ {
 		result *= x
 	}

--- a/ignite/services/network/testutil/genesis.go
+++ b/ignite/services/network/testutil/genesis.go
@@ -53,7 +53,7 @@ func (g *Genesis) SaveTo(t *testing.T, dir string) string {
 	encoded, err := json.Marshal(g)
 	assert.NoError(t, err)
 	savePath := filepath.Join(dir, "genesis.json")
-	err = os.WriteFile(savePath, encoded, 0666)
+	err = os.WriteFile(savePath, encoded, 0o666)
 	assert.NoError(t, err)
 	return savePath
 }

--- a/ignite/services/network/testutil/gentx.go
+++ b/ignite/services/network/testutil/gentx.go
@@ -55,7 +55,7 @@ func (g *Gentx) SaveTo(t *testing.T, dir string) string {
 	encoded, err := json.Marshal(g)
 	assert.NoError(t, err)
 	savePath := filepath.Join(dir, "gentx0.json")
-	err = os.WriteFile(savePath, encoded, 0666)
+	err = os.WriteFile(savePath, encoded, 0o666)
 	assert.NoError(t, err)
 	return savePath
 }

--- a/ignite/services/network/testutil/response.go
+++ b/ignite/services/network/testutil/response.go
@@ -21,7 +21,7 @@ func NewResponse(data protoiface.MessageV1) cosmosclient.Response {
 	txData := &sdk.TxMsgData{Data: []*sdk.MsgData{
 		{
 			Data: anyEncoded.Value,
-			//TODO: Find a better way
+			// TODO: Find a better way
 			MsgType: strings.TrimSuffix(anyEncoded.TypeUrl, "Response"),
 		},
 	}}

--- a/ignite/services/scaffolder/component.go
+++ b/ignite/services/scaffolder/component.go
@@ -120,7 +120,6 @@ func checkGoReservedWord(name string) error {
 
 // checkComponentCreated checks if the component has been already created with Starport in the project
 func checkComponentCreated(appPath, moduleName string, compName multiformatname.Name, noMessage bool) (err error) {
-
 	// associate the type to check with the component that scaffold this type
 	typesToCheck := map[string]string{
 		compName.UpperCamel:                           componentType,

--- a/ignite/templates/app/app.go
+++ b/ignite/templates/app/app.go
@@ -12,10 +12,8 @@ import (
 	"github.com/ignite/cli/ignite/templates/testutil"
 )
 
-var (
-	//go:embed stargate/* stargate/**/*
-	fsStargate embed.FS
-)
+//go:embed stargate/* stargate/**/*
+var fsStargate embed.FS
 
 // New returns the generator to scaffold a new Cosmos SDK app
 func New(opts *Options) (*genny.Generator, error) {

--- a/ignite/templates/field/datatype/bool.go
+++ b/ignite/templates/field/datatype/bool.go
@@ -6,36 +6,34 @@ import (
 	"github.com/ignite/cli/ignite/pkg/multiformatname"
 )
 
-var (
-	// DataBool bool data type definition
-	DataBool = DataType{
-		DataType:          func(string) string { return "bool" },
-		DefaultTestValue:  "false",
-		ValueLoop:         "false",
-		ValueIndex:        "false",
-		ValueInvalidIndex: "false",
-		ProtoType: func(_, name string, index int) string {
-			return fmt.Sprintf("bool %s = %d", name, index)
-		},
-		GenesisArgs: func(name multiformatname.Name, value int) string {
-			return fmt.Sprintf("%s: %t,\n", name.UpperCamel, value%2 == 0)
-		},
-		CLIArgs: func(name multiformatname.Name, _, prefix string, argIndex int) string {
-			return fmt.Sprintf(`%s%s, err := cast.ToBoolE(args[%d])
+// DataBool bool data type definition
+var DataBool = DataType{
+	DataType:          func(string) string { return "bool" },
+	DefaultTestValue:  "false",
+	ValueLoop:         "false",
+	ValueIndex:        "false",
+	ValueInvalidIndex: "false",
+	ProtoType: func(_, name string, index int) string {
+		return fmt.Sprintf("bool %s = %d", name, index)
+	},
+	GenesisArgs: func(name multiformatname.Name, value int) string {
+		return fmt.Sprintf("%s: %t,\n", name.UpperCamel, value%2 == 0)
+	},
+	CLIArgs: func(name multiformatname.Name, _, prefix string, argIndex int) string {
+		return fmt.Sprintf(`%s%s, err := cast.ToBoolE(args[%d])
             		if err != nil {
                 		return err
             		}`,
-				prefix, name.UpperCamel, argIndex)
-		},
-		ToBytes: func(name string) string {
-			return fmt.Sprintf(`%[1]vBytes := []byte{0}
+			prefix, name.UpperCamel, argIndex)
+	},
+	ToBytes: func(name string) string {
+		return fmt.Sprintf(`%[1]vBytes := []byte{0}
 					if %[1]v {
 						%[1]vBytes = []byte{1}
 					}`, name)
-		},
-		ToString: func(name string) string {
-			return fmt.Sprintf("strconv.FormatBool(%s)", name)
-		},
-		GoCLIImports: []GoImport{{Name: "github.com/spf13/cast"}},
-	}
-)
+	},
+	ToString: func(name string) string {
+		return fmt.Sprintf("strconv.FormatBool(%s)", name)
+	},
+	GoCLIImports: []GoImport{{Name: "github.com/spf13/cast"}},
+}

--- a/ignite/templates/field/datatype/custom.go
+++ b/ignite/templates/field/datatype/custom.go
@@ -6,25 +6,23 @@ import (
 	"github.com/ignite/cli/ignite/pkg/multiformatname"
 )
 
-var (
-	// DataCustom custom data type definition
-	DataCustom = DataType{
-		DataType:         func(datatype string) string { return fmt.Sprintf("*%s", datatype) },
-		DefaultTestValue: "null",
-		ProtoType: func(datatype, name string, index int) string {
-			return fmt.Sprintf("%s %s = %d", datatype, name, index)
-		},
-		GenesisArgs: func(name multiformatname.Name, value int) string {
-			return fmt.Sprintf("%s: new(types.%s),\n", name.UpperCamel, name.UpperCamel)
-		},
-		CLIArgs: func(name multiformatname.Name, datatype, prefix string, argIndex int) string {
-			return fmt.Sprintf(`%[1]v%[2]v := new(types.%[3]v)
+// DataCustom custom data type definition
+var DataCustom = DataType{
+	DataType:         func(datatype string) string { return fmt.Sprintf("*%s", datatype) },
+	DefaultTestValue: "null",
+	ProtoType: func(datatype, name string, index int) string {
+		return fmt.Sprintf("%s %s = %d", datatype, name, index)
+	},
+	GenesisArgs: func(name multiformatname.Name, value int) string {
+		return fmt.Sprintf("%s: new(types.%s),\n", name.UpperCamel, name.UpperCamel)
+	},
+	CLIArgs: func(name multiformatname.Name, datatype, prefix string, argIndex int) string {
+		return fmt.Sprintf(`%[1]v%[2]v := new(types.%[3]v)
 					err = json.Unmarshal([]byte(args[%[4]v]), %[1]v%[2]v)
     				if err != nil {
                 		return err
             		}`, prefix, name.UpperCamel, datatype, argIndex)
-		},
-		GoCLIImports: []GoImport{{Name: "encoding/json"}},
-		NonIndex:     true,
-	}
-)
+	},
+	GoCLIImports: []GoImport{{Name: "encoding/json"}},
+	NonIndex:     true,
+}

--- a/ignite/templates/field/parse.go
+++ b/ignite/templates/field/parse.go
@@ -18,7 +18,6 @@ func validateField(field string, isForbiddenField func(string) error) (multiform
 	name, err := multiformatname.NewName(fieldSplit[0])
 	if err != nil {
 		return name, "", err
-
 	}
 
 	// Ensure the field Name is not a Go reserved Name, it would generate an incorrect code

--- a/ignite/templates/ibc/oracle.go
+++ b/ignite/templates/ibc/oracle.go
@@ -19,10 +19,8 @@ import (
 	"github.com/ignite/cli/ignite/templates/testutil"
 )
 
-var (
-	//go:embed oracle/* oracle/**/*
-	fsOracle embed.FS
-)
+//go:embed oracle/* oracle/**/*
+var fsOracle embed.FS
 
 // OracleOptions are options to scaffold an oracle query in a IBC module
 type OracleOptions struct {

--- a/ignite/templates/query/query.go
+++ b/ignite/templates/query/query.go
@@ -11,10 +11,8 @@ import (
 	"github.com/ignite/cli/ignite/templates/field/plushhelpers"
 )
 
-var (
-	//go:embed stargate/* stargate/**/*
-	fsStargate embed.FS
-)
+//go:embed stargate/* stargate/**/*
+var fsStargate embed.FS
 
 func Box(box packd.Walker, opts *Options, g *genny.Generator) error {
 	if err := g.Box(box); err != nil {

--- a/ignite/templates/testutil/register.go
+++ b/ignite/templates/testutil/register.go
@@ -8,10 +8,8 @@ import (
 	"github.com/ignite/cli/ignite/pkg/xgenny"
 )
 
-var (
-	//go:embed stargate/* stargate/**/*
-	fsStargate embed.FS
-)
+//go:embed stargate/* stargate/**/*
+var fsStargate embed.FS
 
 // Register testutil template using existing generator.
 // Register is meant to be used by modules that depend on this module.

--- a/ignite/templates/typed/dry/stargate.go
+++ b/ignite/templates/typed/dry/stargate.go
@@ -9,10 +9,8 @@ import (
 	"github.com/ignite/cli/ignite/templates/typed"
 )
 
-var (
-	//go:embed stargate/component/* stargate/component/**/*
-	fsStargateComponent embed.FS
-)
+//go:embed stargate/component/* stargate/component/**/*
+var fsStargateComponent embed.FS
 
 // NewStargate returns the generator to scaffold a basic type in a Stargate module.
 func NewStargate(opts *typed.Options) (*genny.Generator, error) {

--- a/ignite/version/version.go
+++ b/ignite/version/version.go
@@ -46,7 +46,6 @@ func CheckNext(ctx context.Context) (isAvailable bool, version string, err error
 		NewClient(nil).
 		Repositories.
 		GetLatestRelease(ctx, "ignite", "cli")
-
 	if err != nil {
 		return false, "", err
 	}

--- a/integration/app/cmd_ibc_test.go
+++ b/integration/app/cmd_ibc_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestCreateModuleWithIBC(t *testing.T) {
-
 	var (
 		env  = envtest.New(t)
 		path = env.Scaffold("github.com/test/blogibc")
@@ -109,7 +108,6 @@ func TestCreateModuleWithIBC(t *testing.T) {
 }
 
 func TestCreateIBCOracle(t *testing.T) {
-
 	var (
 		env  = envtest.New(t)
 		path = env.Scaffold("github.com/test/ibcoracle")
@@ -188,7 +186,6 @@ func TestCreateIBCOracle(t *testing.T) {
 }
 
 func TestCreateIBCPacket(t *testing.T) {
-
 	var (
 		env  = envtest.New(t)
 		path = env.Scaffold("github.com/test/blogibc2")

--- a/integration/app/tx_test.go
+++ b/integration/app/tx_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestSignTxWithDashedAppName(t *testing.T) {
-
 	var (
 		env         = envtest.New(t)
 		appname     = "dashed-app-name"

--- a/integration/cosmosgen/cosmosgen_test.go
+++ b/integration/cosmosgen/cosmosgen_test.go
@@ -114,7 +114,7 @@ func TestCosmosGen(t *testing.T) {
 		)),
 	))
 
-	var expectedCosmosModules = []string{
+	expectedCosmosModules := []string{
 		"cosmos.auth.v1beta1",
 		"cosmos.authz.v1beta1",
 		"cosmos.bank.v1beta1",
@@ -133,7 +133,7 @@ func TestCosmosGen(t *testing.T) {
 		"cosmos.vesting.v1beta1",
 	}
 
-	var expectedCustomModules = []string{
+	expectedCustomModules := []string{
 		"test.blog.blog",
 		"test.blog.withmsg",
 		"test.blog.withoutmsg",

--- a/integration/env.go
+++ b/integration/env.go
@@ -310,7 +310,7 @@ func (e Env) RandomizeServerPorts(path string, configFile string) chainconfig.Ho
 	}
 
 	// update config.yml with the generated servers list.
-	configyml, err := os.OpenFile(filepath.Join(path, configFile), os.O_RDWR|os.O_CREATE, 0755)
+	configyml, err := os.OpenFile(filepath.Join(path, configFile), os.O_RDWR|os.O_CREATE, 0o755)
 	require.NoError(e.t, err)
 	defer configyml.Close()
 
@@ -336,7 +336,7 @@ func (e Env) ConfigureFaucet(path string, configFile string, coins, coinsMax []s
 	port, err := availableport.Find(1)
 	require.NoError(e.t, err)
 
-	configyml, err := os.OpenFile(filepath.Join(path, configFile), os.O_RDWR|os.O_CREATE, 0755)
+	configyml, err := os.OpenFile(filepath.Join(path, configFile), os.O_RDWR|os.O_CREATE, 0o755)
 	require.NoError(e.t, err)
 	defer configyml.Close()
 
@@ -364,7 +364,7 @@ func (e Env) SetRandomHomeConfig(path string, configFile string) {
 	}
 
 	// update config.yml with the generated temporary directories
-	configyml, err := os.OpenFile(filepath.Join(path, configFile), os.O_RDWR|os.O_CREATE, 0755)
+	configyml, err := os.OpenFile(filepath.Join(path, configFile), os.O_RDWR|os.O_CREATE, 0o755)
 	require.NoError(e.t, err)
 	defer configyml.Close()
 


### PR DESCRIPTION
Run the following commands on the repo:
- `make format`
- `gofumpt -l -w .`

[gofumpt](https://github.com/mvdan/gofumpt) is a stricter formatting tool that I find to be pretty helpful.  I think it will be nice to get some formatting in before this new release.  

No logic changes are made in this PR.