### PR TITLE
fix(`pkg/cosmosaccount`): register cryptocodec interfaces

### DIFF
--- a/ignite/cmd/account_create.go
+++ b/ignite/cmd/account_create.go
@@ -28,12 +28,12 @@ func accountCreateHandler(cmd *cobra.Command, args []string) error {
 		cosmosaccount.WithKeyringBackend(getKeyringBackend(cmd)),
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create registry: %w", err)
 	}
 
 	_, mnemonic, err := ca.Create(name)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create account: %w", err)
 	}
 
 	fmt.Printf("Account %q created, keep your mnemonic in a secret place:\n\n%s\n", name, mnemonic)

--- a/ignite/pkg/cosmosaccount/cosmosaccount.go
+++ b/ignite/pkg/cosmosaccount/cosmosaccount.go
@@ -7,14 +7,16 @@ import (
 	"fmt"
 	"os"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
 	dkeyring "github.com/99designs/keyring"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/go-bip39"
 )
 
@@ -96,6 +98,7 @@ func New(options ...Option) (Registry, error) {
 	var err error
 	inBuf := bufio.NewReader(os.Stdin)
 	interfaceRegistry := types.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(interfaceRegistry)
 	cdc := codec.NewProtoCodec(interfaceRegistry)
 	r.Keyring, err = keyring.New(r.keyringServiceName, string(r.keyringBackend), r.homePath, inBuf, cdc)
 	if err != nil {
@@ -122,7 +125,7 @@ func NewInMemory(options ...Option) (Registry, error) {
 	)
 }
 
-// Account represents an Cosmos SDK account.
+// Account represents a Cosmos SDK account.
 type Account struct {
 	// Name of the account.
 	Name string
@@ -188,7 +191,6 @@ func (r Registry) Create(name string) (acc Account, mnemonic string, err error) 
 	if !errors.As(err, &accErr) {
 		return Account{}, "", err
 	}
-
 	entropySeed, err := bip39.NewEntropy(256)
 	if err != nil {
 		return Account{}, "", err
@@ -197,7 +199,6 @@ func (r Registry) Create(name string) (acc Account, mnemonic string, err error) 
 	if err != nil {
 		return Account{}, "", err
 	}
-
 	algo, err := r.algo()
 	if err != nil {
 		return Account{}, "", err


### PR DESCRIPTION
Resolves #2701

`cosmosaccount.New()` was missing the following line:

```go
	cryptocodec.RegisterInterfaces(interfaceRegistry)
```