### PR TITLE
fix(`network`): Gitpod networking issue

### DIFF
--- a/ignite/cmd/network_chain_join.go
+++ b/ignite/cmd/network_chain_join.go
@@ -3,8 +3,6 @@ package ignitecmd
 import (
 	"context"
 	"fmt"
-	"os"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 	"github.com/rdegges/go-ipify"
@@ -109,20 +107,11 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	// create a temporary directory for the chain home and genesis
-	// create the chain in a temp dir
-	tmpHome, err := os.MkdirTemp("", "*-spn")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(tmpHome)
-	c.SetHome(tmpHome)
-
-	// initialize the genesis under a temporary repository
-	if err := c.Init(cmd.Context(), cacheStorage); err != nil {
-		return err
+	} else {
+		// if a custom gentx is provided, we initialize the chain home in order to check accounts
+		if err := c.Init(cmd.Context(), cacheStorage); err != nil {
+			return err
+		}
 	}
 
 	if amount != "" {

--- a/ignite/cmd/network_chain_join.go
+++ b/ignite/cmd/network_chain_join.go
@@ -3,6 +3,7 @@ package ignitecmd
 import (
 	"context"
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 	"github.com/rdegges/go-ipify"

--- a/ignite/services/network/join.go
+++ b/ignite/services/network/join.go
@@ -61,14 +61,21 @@ func (n Network) Join(
 	}
 
 	// get the peer address
-	if nodeID, err = c.NodeID(ctx); err != nil {
-		return err
-	}
+	if o.publicAddress != "" {
+		if nodeID, err = c.NodeID(ctx); err != nil {
+			return err
+		}
 
-	if xurl.IsHTTP(o.publicAddress) {
-		peer = launchtypes.NewPeerTunnel(nodeID, networkchain.HTTPTunnelChisel, o.publicAddress)
+		if xurl.IsHTTP(o.publicAddress) {
+			peer = launchtypes.NewPeerTunnel(nodeID, networkchain.HTTPTunnelChisel, o.publicAddress)
+		} else {
+			peer = launchtypes.NewPeerConn(nodeID, o.publicAddress)
+		}
 	} else {
-		peer = launchtypes.NewPeerConn(nodeID, o.publicAddress)
+		// if the peer address is not specified, we parse it from the gentx memo
+		if peer, err = ParsePeerAddress(gentxInfo.Memo); err != nil {
+			return err
+		}
 	}
 
 	// get the chain genesis path from the home folder

--- a/ignite/services/network/join.go
+++ b/ignite/services/network/join.go
@@ -61,21 +61,14 @@ func (n Network) Join(
 	}
 
 	// get the peer address
-	if o.publicAddress != "" {
-		if nodeID, err = c.NodeID(ctx); err != nil {
-			return err
-		}
+	if nodeID, err = c.NodeID(ctx); err != nil {
+		return err
+	}
 
-		if xurl.IsHTTP(o.publicAddress) {
-			peer = launchtypes.NewPeerTunnel(nodeID, networkchain.HTTPTunnelChisel, o.publicAddress)
-		} else {
-			peer = launchtypes.NewPeerConn(nodeID, o.publicAddress)
-		}
+	if xurl.IsHTTP(o.publicAddress) {
+		peer = launchtypes.NewPeerTunnel(nodeID, networkchain.HTTPTunnelChisel, o.publicAddress)
 	} else {
-		// if the peer address is not specified, we parse it from the gentx memo
-		if peer, err = ParsePeerAddress(gentxInfo.Memo); err != nil {
-			return err
-		}
+		peer = launchtypes.NewPeerConn(nodeID, o.publicAddress)
 	}
 
 	// get the chain genesis path from the home folder


### PR DESCRIPTION
We initialized the chain in a temporary directory so we could have a genesis to check the existing accounts without erasing the current gentx.
At the end, I think we don't need this if we don't provide a gentx from a custom path. If we use the default gentx, it means we use the one from the chain home, so the chain is already initialized.
We initialize the chain in the home if a custom gentx is used to check the accounts, when a custom gentx is used the node ID will be parsed in the gentx itself