### PR TITLE
fix(`cosmosclient`): use protobuf Any for TxMsgData 

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3,5 +3,6 @@ package docs
 import "embed"
 
 // Docs are Ignite CLI docs.
+//
 //go:embed *.md */*.md
 var Docs embed.FS

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -248,6 +248,7 @@ func (r Response) Decode(message proto.Message) error {
 		resData := txMsgData.Data[0]
 		return prototypes.UnmarshalAny(&prototypes.Any{
 			// TODO get type url dynamically(basically remove `+ "Response"`) after the following issue has solved.
+			// https://github.com/ignite/cli/issues/2098
 			// https://github.com/cosmos/cosmos-sdk/issues/10496
 			TypeUrl: resData.MsgType + "Response",
 			Value:   resData.Data,

--- a/ignite/services/network/testutil/response.go
+++ b/ignite/services/network/testutil/response.go
@@ -2,12 +2,10 @@ package testutil
 
 import (
 	"encoding/hex"
-	"strings"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	prototypes "github.com/gogo/protobuf/types"
 	"google.golang.org/protobuf/runtime/protoiface"
 
 	"github.com/ignite/cli/ignite/pkg/cosmosclient"
@@ -17,14 +15,10 @@ import (
 // for using as a return result for a cosmosclient mock
 func NewResponse(data protoiface.MessageV1) cosmosclient.Response {
 	marshaler := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
-	anyEncoded, _ := prototypes.MarshalAny(data)
-	txData := &sdk.TxMsgData{Data: []*sdk.MsgData{
-		{
-			Data: anyEncoded.Value,
-			// TODO: Find a better way
-			MsgType: strings.TrimSuffix(anyEncoded.TypeUrl, "Response"),
-		},
-	}}
+	anyEncoded, _ := codectypes.NewAnyWithValue(data)
+
+	txData := &sdk.TxMsgData{MsgResponses: []*codectypes.Any{anyEncoded}}
+
 	encodedTxData, _ := marshaler.Marshal(txData)
 	resp := cosmosclient.Response{
 		Codec: marshaler,


### PR DESCRIPTION
Moves to using the `MsgResponses` field `TxMsgData` instead of the deprecated `MsgData` field.

This PR retains the decoding of deprecated messages in the `Decode` method of `cosmosclient`.