### PR TITLE
fix: remove `ignite tools completions`

### DIFF
--- a/ignite/cmd/tools.go
+++ b/ignite/cmd/tools.go
@@ -22,7 +22,6 @@ func NewTools() *cobra.Command {
 	c.AddCommand(NewToolsIBCSetup())
 	c.AddCommand(NewToolsIBCRelayer())
 	c.AddCommand(NewToolsProtoc())
-	c.AddCommand(NewToolsCompletions())
 	return c
 }
 
@@ -86,75 +85,4 @@ func toolsProxy(ctx context.Context, command []string) error {
 			step.Stderr(os.Stderr),
 		),
 	)
-}
-
-func NewToolsCompletions() *cobra.Command {
-	// completionCmd represents the completion command
-	c := &cobra.Command{
-		Use:   "completions",
-		Short: "Generate completions script",
-		Long: ` The completions command outputs a completion script you can use in your shell. The output script requires 
-				that [bash-completion](https://github.com/scop/bash-completion)	is installed and enabled in your 
-				system. Since most Unix-like operating systems come with bash-completion by default, bash-completion 
-				is probably already installed and operational.
-
-Bash:
-
-  $ source <(ignite  tools completions bash)
-
-  To load completions for every new session, run:
-
-  ** Linux **
-  $ ignite  tools completions bash > /etc/bash_completion.d/ignite
-
-  ** macOS **
-  $ ignite  tools completions bash > /usr/local/etc/bash_completion.d/ignite
-
-Zsh:
-
-  If shell completions is not already enabled in your environment, you will need to enable it.  You can execute the following once:
-
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
-
-  To load completions for each session, execute once:
-  
-  $ ignite  tools completions zsh > "${fpath[1]}/_ignite"
-
-  You will need to start a new shell for this setup to take effect.
-
-fish:
-
-  $ ignite  tools completions fish | source
-
-  To load completions for each session, execute once:
-  
-  $ ignite  tools completions fish > ~/.config/fish/completionss/ignite.fish
-
-PowerShell:
-
-  PS> ignite  tools completions powershell | Out-String | Invoke-Expression
-
-  To load completions for every new session, run:
-  
-  PS> ignite  tools completions powershell > ignite.ps1
-  
-  and source this file from your PowerShell profile.
-`,
-		DisableFlagsInUseLine: true,
-		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			switch args[0] {
-			case "bash":
-				cmd.Root().GenBashCompletion(os.Stdout)
-			case "zsh":
-				cmd.Root().GenZshCompletion(os.Stdout)
-			case "fish":
-				cmd.Root().GenFishCompletion(os.Stdout, true)
-			case "powershell":
-				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
-			}
-		},
-	}
-	return c
 }


### PR DESCRIPTION
Completions are provided by Cobra by default with `ignite completion`, so there is no need to have the command hard-coded into Ignite.

closes https://github.com/ignite/cli/issues/2402