### PR TITLE
docs: change the prefix in `app/app.go`

### DIFF
--- a/docs/docs/kb/01-scaffold-chain.md
+++ b/docs/docs/kb/01-scaffold-chain.md
@@ -61,10 +61,7 @@ Using the `moonlight` prefix, account addresses on your blockchain look like thi
 
 ### Change prefix on existing blockchains
 
-To change the prefix after the blockchain has been scaffolded, modify the `AccountAddressPrefix` in the `app/prefix.go` file.
-
-1. Change the `AccountAddressPrefix` variable in the `/app/prefix.go` file. Be sure to preserve other variables in the file.
-2. To recognize the new prefix, change the `VITE_ADDRESS_PREFIX` variable in `/vue/.env`.
+To change the prefix after the blockchain has been scaffolded, modify the `AccountAddressPrefix` in the `app/app.go` file.
 
 ## Cosmos SDK version
 


### PR DESCRIPTION
Because we no longer have `prefix.go`. This might change once we no longer depend on `cosmoscmd`, but for now it's the case.

close https://github.com/ignite/cli/issues/1990