### PR TITLE
refactor(network): change host for local flag

### DIFF
--- a/ignite/cmd/network.go
+++ b/ignite/cmd/network.go
@@ -32,8 +32,8 @@ const (
 	spnNodeAddressNightly   = "http://178.128.251.28:26657"
 	spnFaucetAddressNightly = "http://178.128.251.28:4500"
 
-	spnNodeAddressLocal   = "http://0.0.0.0:26657"
-	spnFaucetAddressLocal = "http://0.0.0.0:4500"
+	spnNodeAddressLocal   = "http://0.0.0.0:26661"
+	spnFaucetAddressLocal = "http://0.0.0.0:4502"
 )
 
 // NewNetwork creates a new network command that holds some other sub commands


### PR DESCRIPTION
Change host used when using `--local` flag of `network` commands

We created `config_2.yml` on `spn`to serves the chain with different ports so that the chain can be launched locally with default config

We change to those ports with the `--local` flag