### PR TITLE
chore: add Node.js version in the output of `ignite version`

### DIFF
--- a/ignite/version/version.go
+++ b/ignite/version/version.go
@@ -91,6 +91,17 @@ func Long(ctx context.Context) string {
 
 	cmdOut := &bytes.Buffer{}
 
+	nodeJSCmd := "node"
+	if xexec.IsCommandAvailable(nodeJSCmd) {
+		cmdOut.Reset()
+
+		err := exec.Exec(ctx, []string{nodeJSCmd, "-v"}, exec.StepOption(step.Stdout(cmdOut)))
+		if err == nil {
+			write("Your Node.js version", strings.TrimSpace(cmdOut.String()))
+		}
+	}
+
+	cmdOut.Reset()
 	err := exec.Exec(ctx, []string{"go", "version"}, exec.StepOption(step.Stdout(cmdOut)))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Just a tiny tweak to make it easier to debug frontend-related issues in the future.

close https://github.com/ignite/cli/issues/2251 (we no longer need the Flutter version, because mobile is on hold)