### PR TITLE
fix(`network`): various fixes to launch `spn` from `spn`

### DIFF
--- a/ignite/pkg/chaincmd/runner/chain.go
+++ b/ignite/pkg/chaincmd/runner/chain.go
@@ -23,7 +23,7 @@ import (
 func (r Runner) Start(ctx context.Context, args ...string) error {
 	return r.run(
 		ctx,
-		runOptions{wrappedStdErrMaxLen: 50000},
+		runOptions{wrappedStdErrMaxLen: 50000, stdout: os.Stdout, stderr: os.Stderr},
 		r.chainCmd.StartCommand(args...),
 	)
 }

--- a/ignite/pkg/chaincmd/runner/chain.go
+++ b/ignite/pkg/chaincmd/runner/chain.go
@@ -23,7 +23,7 @@ import (
 func (r Runner) Start(ctx context.Context, args ...string) error {
 	return r.run(
 		ctx,
-		runOptions{wrappedStdErrMaxLen: 50000, stdout: os.Stdout, stderr: os.Stderr},
+		runOptions{wrappedStdErrMaxLen: 50000},
 		r.chainCmd.StartCommand(args...),
 	)
 }

--- a/ignite/services/network/join_test.go
+++ b/ignite/services/network/join_test.go
@@ -35,12 +35,10 @@ func TestJoin(t *testing.T) {
 				testutil.PeerAddress,
 			)
 			gentxPath      = gentx.SaveTo(t, tmp)
-			genesisPath    = testutil.NewGenesis(testutil.ChainID).SaveTo(t, tmp)
 			suite, network = newSuite(account)
 		)
 
 		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
-		suite.ChainMock.On("GenesisPath").Return(genesisPath, nil).Once()
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
@@ -89,11 +87,9 @@ func TestJoin(t *testing.T) {
 				testutil.PeerAddress,
 			)
 			gentxPath      = gentx.SaveTo(t, tmp)
-			genesisPath    = testutil.NewGenesis(testutil.ChainID).SaveTo(t, tmp)
 			suite, network = newSuite(account)
 		)
 
-		suite.ChainMock.On("GenesisPath").Return(genesisPath, nil).Once()
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
@@ -136,13 +132,11 @@ func TestJoin(t *testing.T) {
 				testutil.PeerAddress,
 			)
 			gentxPath      = gentx.SaveTo(t, tmp)
-			genesisPath    = testutil.NewGenesis(testutil.ChainID).SaveTo(t, tmp)
 			suite, network = newSuite(account)
 			expectedError  = errors.New("failed to add validator")
 		)
 
 		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
-		suite.ChainMock.On("GenesisPath").Return(genesisPath, nil).Once()
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
@@ -192,12 +186,10 @@ func TestJoin(t *testing.T) {
 				testutil.PeerAddress,
 			)
 			gentxPath      = gentx.SaveTo(t, tmp)
-			genesisPath    = testutil.NewGenesis(testutil.ChainID).SaveTo(t, tmp)
 			suite, network = newSuite(account)
 		)
 
 		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
-		suite.ChainMock.On("GenesisPath").Return(genesisPath, nil).Once()
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
@@ -251,38 +243,6 @@ func TestJoin(t *testing.T) {
 		suite.AssertAllMocks(t)
 	})
 
-	t.Run("failed to send join request with account request, account exists in genesis", func(t *testing.T) {
-		var (
-			account = testutil.NewTestAccount(t, testutil.TestAccountName)
-			tmp     = t.TempDir()
-			gentx   = testutil.NewGentx(
-				account.Address(networktypes.SPN),
-				TestDenom,
-				TestAmountString,
-				"",
-				testutil.PeerAddress,
-			)
-			gentxPath      = gentx.SaveTo(t, tmp)
-			genesis        = testutil.NewGenesis(testutil.ChainID).AddAccount(account.Address(networktypes.SPN))
-			genesisPath    = genesis.SaveTo(t, tmp)
-			suite, network = newSuite(account)
-		)
-
-		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
-		suite.ChainMock.On("GenesisPath").Return(genesisPath, nil).Once()
-
-		joinErr := network.Join(
-			context.Background(),
-			suite.ChainMock,
-			testutil.LaunchID,
-			gentxPath,
-			WithAccountRequest(sdk.NewCoins(sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)))),
-			WithPublicAddress(testutil.TCPAddress),
-		)
-		require.Errorf(t, joinErr, "account %s already exist", account.Address(networktypes.SPN))
-		suite.AssertAllMocks(t)
-	})
-
 	t.Run("failed to send join request, failed to read node id", func(t *testing.T) {
 		var (
 			account = testutil.NewTestAccount(t, testutil.TestAccountName)
@@ -315,41 +275,7 @@ func TestJoin(t *testing.T) {
 		suite.AssertAllMocks(t)
 	})
 
-	t.Run("failed to send join request, failed to read genesis", func(t *testing.T) {
-		var (
-			account = testutil.NewTestAccount(t, testutil.TestAccountName)
-			tmp     = t.TempDir()
-			gentx   = testutil.NewGentx(
-				account.Address(networktypes.SPN),
-				TestDenom,
-				TestAmountString,
-				"",
-				testutil.PeerAddress,
-			)
-			gentxPath      = gentx.SaveTo(t, tmp)
-			suite, network = newSuite(account)
-			expectedError  = errors.New("failed to get genesis path")
-		)
-
-		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
-		suite.ChainMock.
-			On("GenesisPath").
-			Return("", expectedError).
-			Once()
-
-		joinErr := network.Join(
-			context.Background(),
-			suite.ChainMock,
-			testutil.LaunchID,
-			gentxPath,
-			WithPublicAddress(testutil.TCPAddress),
-		)
-		require.Error(t, joinErr)
-		require.Equal(t, expectedError, joinErr)
-		suite.AssertAllMocks(t)
-	})
-
-	t.Run("failed to send join request, failed to read custom genesis", func(t *testing.T) {
+	t.Run("failed to send join request, failed to read gentx", func(t *testing.T) {
 		var (
 			account        = testutil.NewTestAccount(t, testutil.TestAccountName)
 			gentxPath      = "invalid/path"

--- a/ignite/services/network/networkchain/simulate.go
+++ b/ignite/services/network/networkchain/simulate.go
@@ -77,7 +77,7 @@ func (c Chain) simulateChainStart(ctx context.Context) error {
 	}
 
 	// set the config with random ports to test the start command
-	addressAPI, err := c.setSimulationConfig()
+	rpcAddr, err := c.setSimulationConfig()
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (c Chain) simulateChainStart(ctx context.Context) error {
 	// routine to check the app is listening
 	go func() {
 		defer cancel()
-		exit <- isChainListening(ctx, addressAPI)
+		exit <- isChainListening(ctx, rpcAddr)
 	}()
 
 	// routine chain start
@@ -184,18 +184,18 @@ func (c Chain) setSimulationConfig() (string, error) {
 
 	_, err = config.WriteTo(file)
 
-	return genAddr(ports[0]), err
+	return genAddr(ports[2]), err
 }
 
-// isChainListening checks if the chain is listening for API queries on the specified address
-func isChainListening(ctx context.Context, addressAPI string) error {
+// isChainListening checks if the chain is listening for RPC queries on the specified address
+func isChainListening(ctx context.Context, rpcAddr string) error {
 	checkAlive := func() error {
-		addr, err := xurl.HTTP(addressAPI)
+		addr, err := xurl.HTTP(rpcAddr)
 		if err != nil {
-			return fmt.Errorf("invalid api address format %s: %w", addressAPI, err)
+			return fmt.Errorf("invalid rpc address format %s: %w", rpcAddr, err)
 		}
 
-		ok, err := httpstatuschecker.Check(ctx, fmt.Sprintf("%s/node_info", addr))
+		ok, err := httpstatuschecker.Check(ctx, fmt.Sprintf("%s/health", addr))
 		if err == nil && !ok {
 			err = errors.New("app is not online")
 		}


### PR DESCRIPTION
Add some fixes for issues occurring when launching `spn`

- Remove existing account verification in `join`
The verification process was flawed as the genesis to verify accounts was already initialized with the account.
We simulate the genesis in the  `approve` process to check request validity. We can rely on this method so that we have a single entrypoint to maintain for requests validation

- Change endpoint to check simulated chain running
Change checked endpoint from `api/node_info` to `rpc/health` for the check. `api/node_info` seems to be no longer exposed with `0.46` and `api` may not be used by all chains