### PR TITLE
docs: `ignite scaffold module` inline documentation

### DIFF
--- a/ignite/cmd/scaffold_module.go
+++ b/ignite/cmd/scaffold_module.go
@@ -31,38 +31,62 @@ func NewScaffoldModule() *cobra.Command {
 		Short: "Scaffold a Cosmos SDK module",
 		Long: `Scaffold a new Cosmos SDK module.
 
-Cosmos SDK is a modular framework and each independent piece of functionality is implemented in a separate module. By default your blockchain imports a set of standard Cosmos SDK modules. To implement custom functionality of your blockchain, scaffold a module and implement the logic of your application.
+Cosmos SDK is a modular framework and each independent piece of functionality is
+implemented in a separate module. By default your blockchain imports a set of
+standard Cosmos SDK modules. To implement custom functionality of your
+blockchain, scaffold a module and implement the logic of your application.
 
 This command does the following:
 
 * Creates a directory with module's protocol buffer files in "proto/"
 * Creates a directory with module's boilerplate Go code in "x/"
 * Imports the newly created module by modifying "app/app.go"
-* Creates a file in "testutil/keeper/" that contains logic to create a keeper for testing purposes
+* Creates a file in "testutil/keeper/" that contains logic to create a keeper
+  for testing purposes
 
-This command will proceed with module scaffolding even if "app/app.go" doesn't have the required default placeholders. If the placeholders are missing, you will need to modify "app/app.go" manually to import the module. If you want the command to fail if it can't import the module, use the "--require-registration" flag.
+This command will proceed with module scaffolding even if "app/app.go" doesn't
+have the required default placeholders. If the placeholders are missing, you
+will need to modify "app/app.go" manually to import the module. If you want the
+command to fail if it can't import the module, use the "--require-registration"
+flag.
 
-To scaffold an IBC-enabled module use the "--ibc" flag. An IBC-enabled module is like a regular module with the addition of IBC-specific logic and placeholders to scaffold IBC packets with "ignite scaffold packet".
+To scaffold an IBC-enabled module use the "--ibc" flag. An IBC-enabled module is
+like a regular module with the addition of IBC-specific logic and placeholders
+to scaffold IBC packets with "ignite scaffold packet".
 
-A module can depend on one or more other modules and import their keeper methods. To scaffold a module with a dependency use the "--dep" flag
+A module can depend on one or more other modules and import their keeper
+methods. To scaffold a module with a dependency use the "--dep" flag
 
-For example, your new custom module "foo" might have functionality that requires sending tokens between accounts. The method for sending tokens is a defined in the "bank"'s module keeper. You can scaffold a "foo" module with the dependency on "bank" with the following command:
+For example, your new custom module "foo" might have functionality that requires
+sending tokens between accounts. The method for sending tokens is a defined in
+the "bank"'s module keeper. You can scaffold a "foo" module with the dependency
+on "bank" with the following command:
 
   ignite scaffold module foo --dep bank
 
-You can then define which methods you want to import from the "bank" keeper in "expected_keepers.go".
+You can then define which methods you want to import from the "bank" keeper in
+"expected_keepers.go".
 
-You can also scaffold a module with a list of dependencies that can include both standard and custom modules (provided they exist):
+You can also scaffold a module with a list of dependencies that can include both
+standard and custom modules (provided they exist):
 
   ignite scaffold module bar --dep foo,mint,account
 
-Note: the "--dep" flag doesn't install third-party modules into your application, it just generates extra code that specifies which existing modules your new custom module depends on.
+Note: the "--dep" flag doesn't install third-party modules into your
+application, it just generates extra code that specifies which existing modules
+your new custom module depends on.
 
-A Cosmos SDK module can have parameters (or "params"). Params are values that can be set at the genesis of the blockchain and can be modified while the blockchain is running. An example of a param is "Inflation rate change" of the "mint" module. A module can be scaffolded with params using the "--params" flag that accepts a list of param names. By default params are of type "string", but you can specify a type for each param. For example:
+A Cosmos SDK module can have parameters (or "params"). Params are values that
+can be set at the genesis of the blockchain and can be modified while the
+blockchain is running. An example of a param is "Inflation rate change" of the
+"mint" module. A module can be scaffolded with params using the "--params" flag
+that accepts a list of param names. By default params are of type "string", but
+you can specify a type for each param. For example:
 
   ignite scaffold module foo --params baz:uint,bar:bool
 
-Refer to Cosmos SDK documentation to learn more about modules, dependencies and params.
+Refer to Cosmos SDK documentation to learn more about modules, dependencies and
+params.
 `,
 		Args: cobra.MinimumNArgs(1),
 		RunE: scaffoldModuleHandler,

--- a/ignite/cmd/scaffold_module.go
+++ b/ignite/cmd/scaffold_module.go
@@ -29,9 +29,43 @@ func NewScaffoldModule() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "module [name]",
 		Short: "Scaffold a Cosmos SDK module",
-		Long:  "Scaffold a new Cosmos SDK module in the `x` directory",
-		Args:  cobra.MinimumNArgs(1),
-		RunE:  scaffoldModuleHandler,
+		Long: `Scaffold a new Cosmos SDK module.
+
+Cosmos SDK is a modular framework and each independent piece of functionality is implemented in a separate module. By default your blockchain imports a set of standard Cosmos SDK modules. To implement custom functionality of your blockchain, scaffold a module and implement the logic of your application.
+
+This command does the following:
+
+* Creates a directory with module's protocol buffer files in "proto/"
+* Creates a directory with module's boilerplate Go code in "x/"
+* Imports the newly created module by modifying "app/app.go"
+* Creates a file in "testutil/keeper/" that contains logic to create a keeper for testing purposes
+
+This command will proceed with module scaffolding even if "app/app.go" doesn't have the required default placeholders. If the placeholders are missing, you will need to modify "app/app.go" manually to import the module. If you want the command to fail if it can't import the module, use the "--require-registration" flag.
+
+To scaffold an IBC-enabled module use the "--ibc" flag. An IBC-enabled module is like a regular module with the addition of IBC-specific logic and placeholders to scaffold IBC packets with "ignite scaffold packet".
+
+A module can depend on one or more other modules and import their keeper methods. To scaffold a module with a dependency use the "--dep" flag
+
+For example, your new custom module "foo" might have functionality that requires sending tokens between accounts. The method for sending tokens is a defined in the "bank"'s module keeper. You can scaffold a "foo" module with the dependency on "bank" with the following command:
+
+  ignite scaffold module foo --dep bank
+
+You can then define which methods you want to import from the "bank" keeper in "expected_keepers.go".
+
+You can also scaffold a module with a list of dependencies that can include both standard and custom modules (provided they exist):
+
+  ignite scaffold module bar --dep foo,mint,account
+
+Note: the "--dep" flag doesn't install third-party modules into your application, it just generates extra code that specifies which existing modules your new custom module depends on.
+
+A Cosmos SDK module can have parameters (or "params"). Params are values that can be set at the genesis of the blockchain and can be modified while the blockchain is running. An example of a param is "Inflation rate change" of the "mint" module. A module can be scaffolded with params using the "--params" flag that accepts a list of param names. By default params are of type "string", but you can specify a type for each param. For example:
+
+  ignite scaffold module foo --params baz:uint,bar:bool
+
+Refer to Cosmos SDK documentation to learn more about modules, dependencies and params.
+`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: scaffoldModuleHandler,
 	}
 
 	flagSetPath(c)


### PR DESCRIPTION
The idea is to have extensive inline documentation for each command. This makes it easier for devs to know how exactly the command behaves without looking it up in the documentation.