### PR TITLE
docs: update tutorials 

### DIFF
--- a/docs/docs/guide/03-blog/02-connect-blockchain.md
+++ b/docs/docs/guide/03-blog/02-connect-blockchain.md
@@ -48,14 +48,14 @@ go 1.18
 
 require (
 	blog v0.0.0-00010101000000-000000000000
-	github.com/ignite/cli v0.22.2
+	github.com/ignite/cli v0.23.0
 )
 
 replace blog => ../blog
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 ```
 
-The `replace` directive uses the package from the local `blog` directory and is specified as a relative path.
+The `replace` directive uses the package from the local `blog` directory and is specified as a relative path to the `blogclient` directory.
 
 Cosmos SDK uses a custom version of the `protobuf` package, so use the `replace` directive to specify the correct dependency.
 

--- a/docs/docs/guide/04-nameservice/02-messages.md
+++ b/docs/docs/guide/04-nameservice/02-messages.md
@@ -110,11 +110,11 @@ These are the changes for each one of these files:
     ```go
     syntax = "proto3";
 
-    package username.nameservice.nameservice;
+    package nameservice.nameservice;
 
     // this line is used by starport scaffolding # proto/tx/import
 
-    option go_package = "github.com/username/nameservice/x/nameservice/types";
+    option go_package = "nameservice/x/nameservice/types";
 
     // Msg defines the Msg service.
     service Msg {

--- a/docs/docs/guide/04-nameservice/04-keeper.md
+++ b/docs/docs/guide/04-nameservice/04-keeper.md
@@ -19,10 +19,13 @@ In this section, define the keepers that are required by the nameservice module:
 
 ## Buy Name
 
-To define the keeper for the buy name transaction, add this code to the `msg_server_buy_name.go` file:
+To define the keeper for the buy name transaction, add this code to the `x/nameservice/keeper/msg_server_buy_name.go` file:
 
 ```go
 // x/nameservice/keeper/msg_server_buy_name.go
+
+package keeper
+
 import (
 	"context"
 
@@ -91,10 +94,13 @@ This dependency automatically created an `expected_keepers.go` file with a `Bank
 
 The `BuyName` transaction uses `SendCoins` and `SendCoinsFromAccountToModule` methods from the `bank` module. 
 
-Edit the `expected_keepers.go` file to add `SendCoins` and `SendCoinsFromAccountToModule` to be able to use it in the keeper methods of the `nameservice` module.
+Edit the `x/nameservice/types/expected_keepers.go` file to add `SendCoins` and `SendCoinsFromAccountToModule` to be able to use it in the keeper methods of the `nameservice` module.
 
 ```go
 // x/nameservice/types/expected_keepers.go
+
+package types
+
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -107,10 +113,13 @@ type BankKeeper interface {
 
 ## Set Name
 
-To define the keeper for the set name transaction, add this code to the `msg_server_set_name.go` file:
+To define the keeper for the set name transaction, add this code to the `x/nameservice/keeper/msg_server_set_name.go` file:
 
 ```go
 // x/nameservice/keeper/msg_server_set_name.go
+
+package keeper
+
 import (
 	"context"
 
@@ -148,10 +157,13 @@ func (k msgServer) SetName(goCtx context.Context, msg *types.MsgSetName) (*types
 
 ## Delete Name
 
-To define the keeper for the delete name transaction, add this code to the `msg_server_delete_name.go` file:
+To define the keeper for the delete name transaction, add this code to the `x/nameservice/keeper/msg_server_delete_name.go` file:
 
 ```go
 // x/nameservice/keeper/msg_server_delete_name.go
+
+package keeper
+
 import (
 	"context"
 

--- a/docs/docs/guide/05-scavenge/07-keeper.md
+++ b/docs/docs/guide/05-scavenge/07-keeper.md
@@ -17,6 +17,8 @@ Make the required changes in the `x/scavenge/keeper/msg_server_submit_scavenge.g
 ```go
 // x/scavenge/keeper/msg_server_submit_scavenge.go
 
+package keeper
+
 import (
   "context"
 
@@ -82,6 +84,9 @@ To use the `BankKeeper` interface in the keeper methods of the `scavenge` module
 
 ```go
 // x/scavenge/types/expected_keepers.go
+
+package types
+
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -100,6 +105,8 @@ Make the required changes in the `x/scavenge/keeper/msg_server_commit_solution.g
 
 ```go
 // x/scavenge/keeper/msg_server_commit_solution.go
+
+package keeper
 
 import (
 	"context"
@@ -146,6 +153,8 @@ Make the required changes in the `x/scavenge/keeper/msg_server_reveal_solution.g
 
 ```go
 // x/scavenge/keeper/msg_server_reveal_solution.go
+
+package keeper
 
 import (
 	"context"

--- a/docs/docs/guide/05-scavenge/08-cli.md
+++ b/docs/docs/guide/05-scavenge/08-cli.md
@@ -26,10 +26,11 @@ This method makes it easier to incorporate different modules for different reaso
 ```go
 // x/scavenge/client/cli/tx_commit_solution.go
 
+package cli
+
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -93,10 +94,11 @@ Note that this file makes use of the `sha256` library for hashing the plain text
 ```go
 // x/scavenge/client/cli/tx_submit_scavenge.go
 
+package cli
+
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"

--- a/docs/docs/guide/07-ibc.md
+++ b/docs/docs/guide/07-ibc.md
@@ -53,7 +53,7 @@ Use Ignite CLI to scaffold the blockchain app and the blog module.
 To scaffold a new blockchain named `planet`:
 
 ```go
-ignite scaffold chain github.com/username/planet --no-module
+ignite scaffold chain planet --no-module
 cd planet
 ```
 

--- a/docs/docs/guide/08-interchange/02-init.md
+++ b/docs/docs/guide/08-interchange/02-init.md
@@ -154,7 +154,8 @@ host:
   rpc: ":26659"
   p2p: ":26658"
   prof: ":6061"
-  grpc: ":9091"
+  grpc: ":9092"
+  grpc-web: ":9093"
   api: ":1318"
 genesis:
   chain_id: "venus"

--- a/docs/docs/guide/08-interchange/05-mint-and-burn-voucher.md
+++ b/docs/docs/guide/08-interchange/05-mint-and-burn-voucher.md
@@ -31,7 +31,7 @@ import (
   "strings"
 
   sdk "github.com/cosmos/cosmos-sdk/types"
-  ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
+  ibctransfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
 
   "interchange/x/dex/types"
 )
@@ -140,7 +140,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
 
 	"interchange/x/dex/types"
 )

--- a/docs/docs/guide/08-interchange/06-creating-sell-orders.md
+++ b/docs/docs/guide/08-interchange/06-creating-sell-orders.md
@@ -40,12 +40,14 @@ The `SendSellOrder` command:
 ```go
 // x/dex/keeper/msg_server_sell_order.go
 
+package keeper
+
 import (
 	"context"
 	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 
 	"interchange/x/dex/types"
 )

--- a/docs/docs/guide/08-interchange/07-creating-buy-orders.md
+++ b/docs/docs/guide/08-interchange/07-creating-buy-orders.md
@@ -36,6 +36,8 @@ ignite generate proto-go --yes
 ```go
 // x/dex/keeper/msg_server_buy_order.go
 
+package keeper
+
 import (
 	"context"
 	"errors"

--- a/docs/docs/guide/08-interchange/08-cancelling-orders.md
+++ b/docs/docs/guide/08-interchange/08-cancelling-orders.md
@@ -16,6 +16,8 @@ Move to the keeper directory and edit the `x/dex/keeper/msg_server_cancel_sell_o
 ```go
 // x/dex/keeper/msg_server_cancel_sell_order.go
 
+package keeper
+
 import (
 	"context"
 	"errors"
@@ -111,6 +113,8 @@ To cancel a buy order, you have to get the ID of the specific buy order. Then yo
 
 ```go
 // x/dex/keeper/msg_server_cancel_buy_order.go
+
+package keeper
 
 import (
 	"context"


### PR DESCRIPTION
- Change `ibc-go` import to use "v5"
- Add missing package definition to code examples that can be copy/pasted
- Change file references to paths for consistency with other tutorials
- Fix interchange tutorial to use ports that don't overlap
- Remove unused imports
- Fix documentation issues