### PR TITLE
chore: lint fixes

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3,5 +3,6 @@ package docs
 import "embed"
 
 // Docs are Ignite CLI docs.
+//
 //go:embed *.md */*.md
 var Docs embed.FS

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -226,9 +226,11 @@ type Response struct {
 // e.g., for the following CreateChain func the type would be: `types.MsgCreateChainResponse`.
 //
 // ```proto
-// service Msg {
-//   rpc CreateChain(MsgCreateChain) returns (MsgCreateChainResponse);
-// }
+//
+//	service Msg {
+//	  rpc CreateChain(MsgCreateChain) returns (MsgCreateChainResponse);
+//	}
+//
 // ```
 func (r Response) Decode(message proto.Message) error {
 	data, err := hex.DecodeString(r.Data)

--- a/ignite/services/network/networkchain/prepare.go
+++ b/ignite/services/network/networkchain/prepare.go
@@ -3,7 +3,6 @@ package networkchain
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -251,7 +250,7 @@ func (c Chain) applyGenesisValidators(ctx context.Context, genesisVals []network
 	// write gentxs
 	for i, val := range genesisVals {
 		gentxPath := filepath.Join(gentxDir, fmt.Sprintf("gentx%d.json", i))
-		if err = ioutil.WriteFile(gentxPath, val.Gentx, 0o666); err != nil {
+		if err = os.WriteFile(gentxPath, val.Gentx, 0o666); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Some basic lint fixes:
- remove usage of deprecated `io/ioutil` package
- formatting