### PR TITLE
fix(cosmosclient): fix account prefix config

### DIFF
--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -208,6 +208,7 @@ func (c Client) Address(accountName string) (sdktypes.AccAddress, error) {
 	if err != nil {
 		return sdktypes.AccAddress{}, err
 	}
+
 	return account.Record.GetAddress()
 }
 
@@ -219,6 +220,7 @@ func (c Client) Context() client.Context {
 // SetConfigAddressPrefix sets the account prefix in the SDK global config
 func (c Client) SetConfigAddressPrefix() {
 	// TODO find a better way if possible.
+	// https://github.com/ignite/cli/issues/2744
 	mconf.Lock()
 	defer mconf.Unlock()
 	config := sdktypes.GetConfig()

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -192,6 +192,9 @@ func New(ctx context.Context, options ...Option) (Client, error) {
 	c.context = newContext(c.RPC, c.out, c.chainID, c.homePath).WithKeyring(c.AccountRegistry.Keyring)
 	c.Factory = newFactory(c.context)
 
+	// set address prefix in SDK global config
+	c.SetConfigAddressPrefix()
+
 	return c, nil
 }
 
@@ -208,8 +211,18 @@ func (c Client) Address(accountName string) (sdktypes.AccAddress, error) {
 	return account.Record.GetAddress()
 }
 
+// Context returns client context
 func (c Client) Context() client.Context {
 	return c.context
+}
+
+// SetConfigAddressPrefix sets the account prefix in the SDK global config
+func (c Client) SetConfigAddressPrefix() {
+	// TODO find a better way if possible.
+	mconf.Lock()
+	defer mconf.Unlock()
+	config := sdktypes.GetConfig()
+	config.SetBech32PrefixForAccount(c.addressPrefix, c.addressPrefix+"pub")
 }
 
 // Response of your broadcasted transaction.
@@ -341,11 +354,8 @@ func (c Client) BroadcastTxWithProvision(accountName string, msgs ...sdktypes.Ms
 		return 0, nil, err
 	}
 
-	// TODO find a better way if possible.
-	mconf.Lock()
-	defer mconf.Unlock()
-	config := sdktypes.GetConfig()
-	config.SetBech32PrefixForAccount(c.addressPrefix, c.addressPrefix+"pub")
+	// set address prefix in SDK global config
+	c.SetConfigAddressPrefix()
 
 	accountAddress, err := c.Address(accountName)
 	if err != nil {


### PR DESCRIPTION
account prefix config not correct when broadcasting a tx from a newly created default account


Fixes https://github.com/ignite/cli/issues/2738

There is a weird bug from `0.46`

When broadcasting a tx without mentioning an account with the `--from` flag, an account `default` is used. If default doesn't exist, the account will be created on the fly and will request tokens with the faucet.

In the case, `default` is created on the fly, the address prefix update in the SDK global config: https://github.com/ignite/cli/blob/4eaa73a187b78cdd4b6d0b19594387bfa50ca11a/ignite/pkg/cosmosclient/cosmosclient.go#L338
will not update the prefix, from `cosmos` to `spn` for example. This will make the method fails because `cosmos` prefix will be used and the error in the related issue will occur using `network` commands for example.
If the command is rerun, `default` will exist at this point and the command will then succeed with updated prefix.

This may be caused by a race condition since SDK config is global?

This fix is more a workaround rather than a long term fix. We also update the config when create `cosmosclient` in `New`, when doing this update in this method, the prefix will be effectively updated in `BroadcastTx` solving the attached issue.

We keep the call in `BroadcastTx` in case several instance of cosmosclient exists in the program.

In the long, term we should find another way to manage prefixes, which may require refactoring in the SDK as well, I will create an issue for this