### PR TITLE
fix: replace os.Rename with xos.Rename

### DIFF
--- a/ignite/cmd/network_chain_show_genesis.go
+++ b/ignite/cmd/network_chain_show_genesis.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ignite/cli/ignite/pkg/cliui"
 	"github.com/ignite/cli/ignite/pkg/cliui/icons"
+	"github.com/ignite/cli/ignite/pkg/xos"
 	"github.com/ignite/cli/ignite/services/network/networkchain"
 )
 
@@ -85,7 +86,7 @@ func networkChainShowGenesisHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := os.Rename(genesisPath, out); err != nil {
+	if err := xos.Rename(genesisPath, out); err != nil {
 		return err
 	}
 

--- a/ignite/pkg/xos/mv.go
+++ b/ignite/pkg/xos/mv.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-// Rename copy sourcePath to destPath and then delete sourcePath.
+// Rename copy oldpath to newpath and then delete oldpath.
 // Unlike os.Rename, it doesn't fail when the oldpath and newpath are in
 // different partitions (error: invalid cross-device link).
 func Rename(oldpath, newpath string) error {

--- a/ignite/pkg/xos/mv.go
+++ b/ignite/pkg/xos/mv.go
@@ -1,0 +1,33 @@
+package xos
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Rename copy sourcePath to destPath and then delete sourcePath.
+// Unlike os.Rename, it doesn't fail when the oldpath and newpath are in
+// different partitions (error: invalid cross-device link).
+func Rename(oldpath, newpath string) error {
+	inputFile, err := os.Open(oldpath)
+	if err != nil {
+		return fmt.Errorf("rename %s %s: couldn't open oldpath: %w", oldpath, newpath, err)
+	}
+	defer inputFile.Close()
+	outputFile, err := os.Create(newpath)
+	if err != nil {
+		return fmt.Errorf("rename %s %s: couldn't open dest file: %w", oldpath, newpath, err)
+	}
+	defer outputFile.Close()
+	_, err = io.Copy(outputFile, inputFile)
+	if err != nil {
+		return fmt.Errorf("rename %s %s: writing to output file failed: %w", oldpath, newpath, err)
+	}
+	// The copy was successful, so now delete the original file
+	err = os.Remove(oldpath)
+	if err != nil {
+		return fmt.Errorf("rename %s %s: failed removing original file: %w", oldpath, newpath, err)
+	}
+	return nil
+}

--- a/ignite/pkg/xos/mv_test.go
+++ b/ignite/pkg/xos/mv_test.go
@@ -1,0 +1,31 @@
+package xos_test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/ignite/cli/ignite/pkg/xos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRename(t *testing.T) {
+	var (
+		dir     = t.TempDir()
+		oldpath = path.Join(dir, "old")
+		newpath = path.Join(dir, "new")
+		require = require.New(t)
+	)
+	err := os.WriteFile(oldpath, []byte("foo"), os.ModePerm)
+	require.NoError(err)
+
+	err = xos.Rename(oldpath, newpath)
+
+	require.NoError(err)
+	bz, err := os.ReadFile(newpath)
+	require.NoError(err)
+	require.Equal([]byte("foo"), bz)
+	_, err = os.Open(oldpath)
+	require.EqualError(err, fmt.Sprintf("open %s: no such file or directory", oldpath))
+}

--- a/ignite/services/network/networkchain/account.go
+++ b/ignite/services/network/networkchain/account.go
@@ -9,6 +9,7 @@ import (
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
 	"github.com/ignite/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite/cli/ignite/pkg/randstr"
+	"github.com/ignite/cli/ignite/pkg/xos"
 	"github.com/ignite/cli/ignite/services/chain"
 )
 
@@ -48,7 +49,7 @@ func (c Chain) InitAccount(ctx context.Context, v chain.Validator, accountName s
 
 	// rename the issued gentx into gentx.json
 	gentxPath := filepath.Join(filepath.Dir(issuedGentxPath), cosmosutil.GentxFilename)
-	return gentxPath, os.Rename(issuedGentxPath, gentxPath)
+	return gentxPath, xos.Rename(issuedGentxPath, gentxPath)
 }
 
 // ImportAccount imports an account from Starport into the chain.

--- a/integration/chain/cmd_serve_test.go
+++ b/integration/chain/cmd_serve_test.go
@@ -4,13 +4,13 @@ package chain_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
+	"github.com/ignite/cli/ignite/pkg/xos"
 	envtest "github.com/ignite/cli/integration"
 )
 
@@ -96,7 +96,7 @@ func TestServeStargateWithCustomConfigFile(t *testing.T) {
 	// Move config
 	newConfig := "new_config.yml"
 	newConfigPath := filepath.Join(tmpDir, newConfig)
-	err := os.Rename(filepath.Join(apath, "config.yml"), newConfigPath)
+	err := xos.Rename(filepath.Join(apath, "config.yml"), newConfigPath)
 	require.NoError(t, err)
 
 	servers := env.RandomizeServerPorts(tmpDir, newConfig)


### PR DESCRIPTION
Fix #2660

os.Rename fails when source and destination are in different partitions.
xos.Rename works in that context.