### PR TITLE
docs: change knowledge base and CLI docs to scaffold using single names

### DIFF
--- a/docs/docs/07-cli.md
+++ b/docs/docs/07-cli.md
@@ -18,7 +18,9 @@ test, build, and launch your blockchain.
 
 To get started, create a blockchain:
 
-ignite scaffold chain github.com/username/mars
+```
+ignite scaffold chain mars
+```
 
 **Options**
 
@@ -678,14 +680,16 @@ Create a new application-specific Cosmos SDK blockchain.
 
 For example, the following command will create a blockchain called "hello" in the "hello/" directory:
 
-  ignite scaffold chain hello
+```
+ignite scaffold chain hello
+```
 
 A project name can be a simple name or a URL. The name will be used as the Go module path for the project. Examples of project names:
 
-  ignite scaffold chain foo
-  ignite scaffold chain foo/bar
-  ignite scaffold chain example.org/foo
-  ignite scaffold chain github.com/username/foo
+  - ignite scaffold chain foo
+  - ignite scaffold chain foo/bar
+  - ignite scaffold chain example.org/foo
+  - ignite scaffold chain github.com/username/foo
 		
 A new directory with source code files will be created in the current directory. To use a different path use the "--path" flag.
 

--- a/docs/docs/guide/04-nameservice/02-messages.md
+++ b/docs/docs/guide/04-nameservice/02-messages.md
@@ -110,11 +110,11 @@ These are the changes for each one of these files:
     ```go
     syntax = "proto3";
 
-    package username.nameservice.nameservice;
+    package nameservice.nameservice;
 
     // this line is used by starport scaffolding # proto/tx/import
 
-    option go_package = "github.com/username/nameservice/x/nameservice/types";
+    option go_package = "nameservice/x/nameservice/types";
 
     // Msg defines the Msg service.
     service Msg {

--- a/docs/docs/guide/07-ibc.md
+++ b/docs/docs/guide/07-ibc.md
@@ -53,7 +53,7 @@ Use Ignite CLI to scaffold the blockchain app and the blog module.
 To scaffold a new blockchain named `planet`:
 
 ```go
-ignite scaffold chain github.com/username/planet --no-module
+ignite scaffold chain planet --no-module
 cd planet
 ```
 

--- a/docs/docs/guide/08-interchange/09-tests.md
+++ b/docs/docs/guide/08-interchange/09-tests.md
@@ -726,5 +726,5 @@ func TestFillBuyOrder(t *testing.T) {
 When the tests are successful, your output is:
 
 ```go
-ok      github.com/username/interchange/x/dex/types       0.550s
+ok      interchange/x/dex/types       0.550s
 ```

--- a/docs/docs/kb/01-scaffold-chain.md
+++ b/docs/docs/kb/01-scaffold-chain.md
@@ -12,12 +12,12 @@ The `ignite scaffold chain` command scaffolds a new Cosmos SDK blockchain projec
 To build the planet application:
 
 ```bash
-ignite scaffold chain github.com/username/planet
+ignite scaffold chain planet
 ```
 
 ## Directory structure
 
-The `ignite scaffold chain github.com/username/planet` command creates a directory called `planet` that contains all the files for your project and initializes a local git repository. The `github.com` URL in the argument is a string that is used for the Go module path. The repository name (`planet`, in this case) is used as the project's name.
+The `ignite scaffold chain planet` command creates a directory called `planet` that contains all the files for your project and initializes a local git repository. The `planet` argument is a string that is used for the Go module path. The repository name (`planet`, in this case) is used as the project's name.
 
 The project directory structure:
 
@@ -54,7 +54,7 @@ Account addresses on Cosmos SDK-based blockchains have string prefixes. For exam
 When you create a new blockchain, pass a prefix as a value to the `--address-prefix` flag:
 
 ```bash
-ignite scaffold chain github.com/username/planet --address-prefix moonlight
+ignite scaffold chain planet --address-prefix moonlight
 ```
 
 Using the `moonlight` prefix, account addresses on your blockchain look like this: `moonlight12fjzdtqfrrve7zyg9sv8j25azw2ua6tvu07ypf`.

--- a/docs/docs/kb/10-band.md
+++ b/docs/docs/kb/10-band.md
@@ -50,7 +50,7 @@ When you scaffold a BandChain oracle module, the following files and directories
 First, scaffold a chain but don't scaffold a default module:
 
 ```bash
-ignite scaffold chain github.com/username/oracle --no-module 
+ignite scaffold chain oracle --no-module 
 ```
 
 Next, change to the new `oracle` directory and scaffold an IBC-enabled module named `consuming`:
@@ -78,7 +78,7 @@ Now it's time to change the data.
 
 The output of the `ignite scaffold band coinRates --module consuming` command prompts you to update the `keys.go` file.
 
-In the `x/oracle/types/keys.go` file, update the `Version` variable in the `const` block to the required version that the IBC module supports:
+In the `x/consuming/types/keys.go` file, update the `Version` variable in the `const` block to the required version that the IBC module supports:
 
 ```go
 const (
@@ -211,9 +211,9 @@ In the `proto/consuming/gold_price.proto` file:
 
 ```protobuf
 syntax = "proto3";
-package username.oracle.consuming;
+package oracle.consuming;
 
-option go_package = "github.com/username/oracle/x/consuming/types";
+option go_package = "oracle/x/consuming/types";
 
 message GoldPriceCallData {
   uint64 multiplier = 2;
@@ -232,13 +232,13 @@ package cli
 import (
 	"strconv"
 
-	"github.com/spf13/cobra"
-
-	"github.com/username/oracle/x/consuming/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
+	"oracle/x/consuming/types"
 )
 
 // CmdRequestGoldPriceData creates and broadcast a GoldPrice request transaction

--- a/docs/docs/kb/11-simapp.md
+++ b/docs/docs/kb/11-simapp.md
@@ -27,7 +27,7 @@ For better randomizations, you can define a random seed. The simulation with the
 To create a new chain:
 
 ```shell
-ignite scaffold chain github.com/username/mars
+ignite scaffold chain mars
 ```
 
 Review the empty `x/mars/simulation` folder and the `x/mars/module_simulation.go` file to see that a simulation is not registered. 


### PR DESCRIPTION
Resolves #2750 

The changeset fixes minor issues in the documentation format and changes scaffold command to use single chain app names that were left unmodified during #2632.