### PR TITLE
fix(`cosmosaccount`): return errors from sdk crypto functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 
 - Upgraded Cosmos SDK to v0.46.0 and IBC to v5 in CLI and scaffolding templates
 
+### Fixes
+- Improved error handling for crypto wrapper functions
+
 ### Features
 
 - Add `--skip-proto` flag to `build`, `init` and `serve` commands to build the chain without building proto files

--- a/docs/docs/guide/03-blog/02-connect-blockchain.md
+++ b/docs/docs/guide/03-blog/02-connect-blockchain.md
@@ -107,9 +107,14 @@ func main() {
 		log.Fatal(err)
 	}
 
+	addr, err  := account.Address(addressPrefix)
+	if err != nil {
+		log.Fatal(err)
+	}
+	
 	// Define a message to create a post
 	msg := &types.MsgCreatePost{
-		Creator: account.Address(addressPrefix),
+		Creator: addr,
 		Title:   "Hello!",
 		Body:    "This is the first post",
 	}

--- a/ignite/cmd/account.go
+++ b/ignite/cmd/account.go
@@ -46,7 +46,17 @@ Ignite CLI uses accounts to interact with the Ignite blockchain, use an IBC rela
 func printAccounts(cmd *cobra.Command, accounts ...cosmosaccount.Account) error {
 	var accEntries [][]string
 	for _, acc := range accounts {
-		accEntries = append(accEntries, []string{acc.Name, acc.Address(getAddressPrefix(cmd)), acc.PubKey()})
+		addr, err := acc.Address(getAddressPrefix(cmd))
+		if err != nil {
+			return err
+		}
+
+		pubKey, err := acc.PubKey()
+		if err != nil {
+			return err
+		}
+
+		accEntries = append(accEntries, []string{acc.Name, addr, pubKey})
 	}
 	return entrywriter.MustWrite(os.Stdout, []string{"name", "address", "public key"}, accEntries...)
 }

--- a/ignite/cmd/node.go
+++ b/ignite/cmd/node.go
@@ -1,9 +1,10 @@
 package ignitecmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ignite/cli/ignite/pkg/cosmosclient"
 	"github.com/ignite/cli/ignite/pkg/xurl"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/ignite/cmd/node_query_bank_balances.go
+++ b/ignite/cmd/node_query_bank_balances.go
@@ -2,8 +2,10 @@ package ignitecmd
 
 import (
 	"fmt"
-	"github.com/ignite/cli/ignite/pkg/cliui"
+
 	"github.com/spf13/cobra"
+
+	"github.com/ignite/cli/ignite/pkg/cliui"
 )
 
 func NewNodeQueryBankBalances() *cobra.Command {

--- a/ignite/cmd/node_query_bank_balances.go
+++ b/ignite/cmd/node_query_bank_balances.go
@@ -1,8 +1,6 @@
 package ignitecmd
 
 import (
-	"fmt"
-
 	"github.com/ignite/cli/ignite/pkg/cliui"
 	"github.com/spf13/cobra"
 )
@@ -53,7 +51,7 @@ func nodeQueryBankBalancesHandler(cmd *cobra.Command, args []string) error {
 
 	var rows [][]string
 	for _, b := range balances {
-		rows = append(rows, []string{fmt.Sprintf("%s", b.Amount), b.Denom})
+		rows = append(rows, []string{b.String()})
 	}
 
 	session.StopSpinner()

--- a/ignite/cmd/node_query_bank_balances.go
+++ b/ignite/cmd/node_query_bank_balances.go
@@ -1,6 +1,7 @@
 package ignitecmd
 
 import (
+	"fmt"
 	"github.com/ignite/cli/ignite/pkg/cliui"
 	"github.com/spf13/cobra"
 )
@@ -51,7 +52,7 @@ func nodeQueryBankBalancesHandler(cmd *cobra.Command, args []string) error {
 
 	var rows [][]string
 	for _, b := range balances {
-		rows = append(rows, []string{b.String()})
+		rows = append(rows, []string{fmt.Sprintf("%s", b.Amount), b.Denom})
 	}
 
 	session.StopSpinner()

--- a/ignite/cmd/node_tx_bank_send.go
+++ b/ignite/cmd/node_tx_bank_send.go
@@ -3,8 +3,9 @@ package ignitecmd
 import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ignite/cli/ignite/pkg/cliui"
 	"github.com/spf13/cobra"
+
+	"github.com/ignite/cli/ignite/pkg/cliui"
 )
 
 func NewNodeTxBankSend() *cobra.Command {

--- a/ignite/cmd/relayer_configure.go
+++ b/ignite/cmd/relayer_configure.go
@@ -486,7 +486,10 @@ func initChain(
 		return nil, errors.Wrapf(err, "cannot resolve %s", name)
 	}
 
-	accountAddr := account.Address(addressPrefix)
+	accountAddr, err := account.Address(addressPrefix)
+	if err != nil {
+		return nil, err
+	}
 
 	session.StopSpinner()
 	session.Printf("🔐  Account on %q is %s(%s)\n \n", name, accountName, accountAddr)

--- a/ignite/pkg/chaincmd/chaincmd.go
+++ b/ignite/pkg/chaincmd/chaincmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
 	"github.com/ignite/cli/ignite/pkg/cosmosver"
 )

--- a/ignite/pkg/cosmosaccount/cosmosaccount.go
+++ b/ignite/pkg/cosmosaccount/cosmosaccount.go
@@ -135,37 +135,35 @@ type Account struct {
 }
 
 // Address returns the address of the account from given prefix.
-func (a Account) Address(accPrefix string) string {
+func (a Account) Address(accPrefix string) (string, error) {
 	if accPrefix == "" {
 		accPrefix = AccountPrefixCosmos
 	}
 
-	// TODO: handle error
 	pk, err := a.Record.GetPubKey()
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
-	return toBench32(accPrefix, pk.Address())
+	return toBech32(accPrefix, pk.Address())
 }
 
 // PubKey returns a public key for account.
-func (a Account) PubKey() string {
-	// TODO: handle error
+func (a Account) PubKey() (string, error) {
 	pk, err := a.Record.GetPubKey()
 	if err != nil {
-		panic(err)
+		return "", nil
 	}
 
-	return pk.String()
+	return pk.String(), nil
 }
 
-func toBench32(prefix string, addr []byte) string {
+func toBech32(prefix string, addr []byte) (string, error) {
 	bech32Addr, err := bech32.ConvertAndEncode(prefix, addr)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return bech32Addr
+	return bech32Addr, nil
 }
 
 // EnsureDefaultAccount ensures that default account exists.

--- a/ignite/pkg/cosmosaccount/cosmosaccount_test.go
+++ b/ignite/pkg/cosmosaccount/cosmosaccount_test.go
@@ -33,7 +33,8 @@ func TestRegistry(t *testing.T) {
 	require.Equal(t, getAccount.Name, account.Name)
 	require.Equal(t, getAccount.Name, account.Record.Name)
 
-	addr = account.Address("cosmos")
+	addr, err = account.Address("cosmos")
+	require.NoError(t, err)
 	getAccount, err = registry.GetByAddress(addr)
 	require.NoError(t, err)
 	require.Equal(t, getAccount.Record.PubKey, account.Record.PubKey)

--- a/ignite/pkg/cosmosclient/bank.go
+++ b/ignite/pkg/cosmosclient/bank.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
 	"github.com/ignite/cli/ignite/pkg/cosmosaccount"
 )
 

--- a/ignite/pkg/cosmosclient/bank.go
+++ b/ignite/pkg/cosmosclient/bank.go
@@ -25,8 +25,13 @@ func (c Client) BankBalances(ctx context.Context, address string, pagination *qu
 }
 
 func (c Client) BankSendTx(fromAccount cosmosaccount.Account, toAddress string, amount sdk.Coins) (TxService, error) {
+	addr, err := fromAccount.Address(c.addressPrefix)
+	if err != nil {
+		return TxService{}, err
+	}
+
 	msg := &banktypes.MsgSend{
-		FromAddress: fromAccount.Address(c.addressPrefix),
+		FromAddress: addr,
 		ToAddress:   toAddress,
 		Amount:      amount,
 	}

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -432,7 +432,11 @@ func (c *Client) prepareBroadcast(ctx context.Context, accountName string, _ []s
 
 	// make sure that account has enough balances before broadcasting.
 	if c.useFaucet {
-		if err := c.makeSureAccountHasTokens(ctx, account.Address(c.addressPrefix)); err != nil {
+		addr, err := account.Address(c.addressPrefix)
+		if err != nil {
+			return err
+		}
+		if err := c.makeSureAccountHasTokens(ctx, addr); err != nil {
 			return err
 		}
 	}

--- a/ignite/pkg/relayer/chain.go
+++ b/ignite/pkg/relayer/chain.go
@@ -127,7 +127,10 @@ func (c *Chain) TryRetrieve(ctx context.Context) (sdk.Coins, error) {
 		return nil, err
 	}
 
-	addr := acc.Address(c.addressPrefix)
+	addr, err := acc.Address(c.addressPrefix)
+	if err != nil {
+		return nil, err
+	}
 
 	if err = cosmosfaucet.TryRetrieve(ctx, c.ID, c.rpcAddress, c.faucetAddress, addr); err != nil {
 		return nil, err

--- a/ignite/pkg/relayer/relayer.go
+++ b/ignite/pkg/relayer/relayer.go
@@ -183,8 +183,13 @@ func (r Relayer) prepare(ctx context.Context, conf relayerconf.Config, chainID s
 		return relayerconf.Chain{}, "", err
 	}
 
+	addr, err := account.Address(chain.AddressPrefix)
+	if err != nil {
+		return relayerconf.Chain{}, "", err
+	}
+
 	errMissingBalance := fmt.Errorf(`account "%s(%s)" on %q chain does not have enough balances`,
-		account.Address(chain.AddressPrefix),
+		addr,
 		chain.Account,
 		chain.ID,
 	)
@@ -235,7 +240,10 @@ func (r Relayer) balance(ctx context.Context, rpcAddress, account, addressPrefix
 		return nil, err
 	}
 
-	addr := acc.Address(addressPrefix)
+	addr, err := acc.Address(addressPrefix)
+	if err != nil {
+		return nil, err
+	}
 
 	queryClient := banktypes.NewQueryClient(client.Context())
 	res, err := queryClient.AllBalances(ctx, &banktypes.QueryAllBalancesRequest{Address: addr})

--- a/ignite/pkg/xos/mv_test.go
+++ b/ignite/pkg/xos/mv_test.go
@@ -6,8 +6,9 @@ import (
 	"path"
 	"testing"
 
-	"github.com/ignite/cli/ignite/pkg/xos"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ignite/cli/ignite/pkg/xos"
 )
 
 func TestRename(t *testing.T) {

--- a/ignite/services/network/campaign.go
+++ b/ignite/services/network/campaign.go
@@ -81,9 +81,12 @@ func (n Network) Campaigns(ctx context.Context) ([]networktypes.Campaign, error)
 // CreateCampaign creates a campaign in Network
 func (n Network) CreateCampaign(name, metadata string, totalSupply sdk.Coins) (uint64, error) {
 	n.ev.Send(events.New(events.StatusOngoing, fmt.Sprintf("Creating campaign %s", name)))
-
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return 0, err
+	}
 	msgCreateCampaign := campaigntypes.NewMsgCreateCampaign(
-		n.account.Address(networktypes.SPN),
+		addr,
 		name,
 		totalSupply,
 		[]byte(metadata),
@@ -109,8 +112,13 @@ func (n Network) InitializeMainnet(
 	mainnetChainID string,
 ) (uint64, error) {
 	n.ev.Send(events.New(events.StatusOngoing, "Initializing the mainnet campaign"))
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return 0, err
+	}
+
 	msg := campaigntypes.NewMsgInitializeMainnet(
-		n.account.Address(networktypes.SPN),
+		addr,
 		campaignID,
 		sourceURL,
 		sourceHash,
@@ -144,7 +152,10 @@ func (n Network) UpdateCampaign(
 	}
 
 	n.ev.Send(events.New(events.StatusOngoing, fmt.Sprintf("Updating the campaign %d", id)))
-	account := n.account.Address(networktypes.SPN)
+	account, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
 	msgs := make([]sdk.Msg, 0)
 	if p.name != "" || len(p.metadata) > 0 {
 		msgs = append(msgs, campaigntypes.NewMsgEditCampaign(

--- a/ignite/services/network/client.go
+++ b/ignite/services/network/client.go
@@ -16,8 +16,13 @@ func (n Network) CreateClient(
 	unbondingTime int64,
 	rewardsInfo networktypes.Reward,
 ) (string, error) {
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return "", err
+	}
+
 	msgCreateClient := monitoringctypes.NewMsgCreateClient(
-		n.account.Address(networktypes.SPN),
+		addr,
 		launchID,
 		rewardsInfo.ConsensusState,
 		rewardsInfo.ValidatorSet,

--- a/ignite/services/network/join.go
+++ b/ignite/services/network/join.go
@@ -101,8 +101,13 @@ func (n Network) sendValidatorRequest(
 	gentx []byte,
 	gentxInfo cosmosutil.GentxInfo,
 ) error {
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
 	msg := launchtypes.NewMsgRequestAddValidator(
-		n.account.Address(networktypes.SPN),
+		addr,
 		launchID,
 		valAddress,
 		gentx,

--- a/ignite/services/network/join_test.go
+++ b/ignite/services/network/join_test.go
@@ -24,19 +24,19 @@ const (
 
 func TestJoin(t *testing.T) {
 	t.Run("successfully send join request", func(t *testing.T) {
-		var (
-			account = testutil.NewTestAccount(t, testutil.TestAccountName)
-			tmp     = t.TempDir()
-			gentx   = testutil.NewGentx(
-				account.Address(networktypes.SPN),
-				TestDenom,
-				TestAmountString,
-				"",
-				testutil.PeerAddress,
-			)
-			gentxPath      = gentx.SaveTo(t, tmp)
-			suite, network = newSuite(account)
+		account := testutil.NewTestAccount(t, testutil.TestAccountName)
+		tmp := t.TempDir()
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+		gentx := testutil.NewGentx(
+			addr,
+			TestDenom,
+			TestAmountString,
+			"",
+			testutil.PeerAddress,
 		)
+		gentxPath := gentx.SaveTo(t, tmp)
+		suite, network := newSuite(account)
 
 		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
 		suite.CosmosClientMock.
@@ -44,9 +44,9 @@ func TestJoin(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgRequestAddValidator{
-					Creator:        account.Address(networktypes.SPN),
+					Creator:        addr,
 					LaunchID:       testutil.LaunchID,
-					ValAddress:     account.Address(networktypes.SPN),
+					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
 					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
@@ -76,28 +76,28 @@ func TestJoin(t *testing.T) {
 	})
 
 	t.Run("successfully send join request with custom gentx", func(t *testing.T) {
-		var (
-			account = testutil.NewTestAccount(t, testutil.TestAccountName)
-			tmp     = t.TempDir()
-			gentx   = testutil.NewGentx(
-				account.Address(networktypes.SPN),
-				TestDenom,
-				TestAmountString,
-				"",
-				testutil.PeerAddress,
-			)
-			gentxPath      = gentx.SaveTo(t, tmp)
-			suite, network = newSuite(account)
+		account := testutil.NewTestAccount(t, testutil.TestAccountName)
+		tmp := t.TempDir()
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+		gentx := testutil.NewGentx(
+			addr,
+			TestDenom,
+			TestAmountString,
+			"",
+			testutil.PeerAddress,
 		)
+		gentxPath := gentx.SaveTo(t, tmp)
+		suite, network := newSuite(account)
 
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgRequestAddValidator{
-					Creator:        account.Address(networktypes.SPN),
+					Creator:        addr,
 					LaunchID:       testutil.LaunchID,
-					ValAddress:     account.Address(networktypes.SPN),
+					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
 					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
@@ -121,20 +121,20 @@ func TestJoin(t *testing.T) {
 	})
 
 	t.Run("failed to send join request, failed to broadcast join tx", func(t *testing.T) {
-		var (
-			account = testutil.NewTestAccount(t, testutil.TestAccountName)
-			tmp     = t.TempDir()
-			gentx   = testutil.NewGentx(
-				account.Address(networktypes.SPN),
-				TestDenom,
-				TestAmountString,
-				"",
-				testutil.PeerAddress,
-			)
-			gentxPath      = gentx.SaveTo(t, tmp)
-			suite, network = newSuite(account)
-			expectedError  = errors.New("failed to add validator")
+		account := testutil.NewTestAccount(t, testutil.TestAccountName)
+		tmp := t.TempDir()
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+		gentx := testutil.NewGentx(
+			addr,
+			TestDenom,
+			TestAmountString,
+			"",
+			testutil.PeerAddress,
 		)
+		gentxPath := gentx.SaveTo(t, tmp)
+		suite, network := newSuite(account)
+		expectedError := errors.New("failed to add validator")
 
 		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
 		suite.CosmosClientMock.
@@ -142,9 +142,9 @@ func TestJoin(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgRequestAddValidator{
-					Creator:        account.Address(networktypes.SPN),
+					Creator:        addr,
 					LaunchID:       testutil.LaunchID,
-					ValAddress:     account.Address(networktypes.SPN),
+					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
 					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
@@ -175,19 +175,19 @@ func TestJoin(t *testing.T) {
 	})
 
 	t.Run("successfully send join request with account request", func(t *testing.T) {
-		var (
-			account = testutil.NewTestAccount(t, testutil.TestAccountName)
-			tmp     = t.TempDir()
-			gentx   = testutil.NewGentx(
-				account.Address(networktypes.SPN),
-				TestDenom,
-				TestAmountString,
-				"",
-				testutil.PeerAddress,
-			)
-			gentxPath      = gentx.SaveTo(t, tmp)
-			suite, network = newSuite(account)
+		account := testutil.NewTestAccount(t, testutil.TestAccountName)
+		tmp := t.TempDir()
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+		gentx := testutil.NewGentx(
+			addr,
+			TestDenom,
+			TestAmountString,
+			"",
+			testutil.PeerAddress,
 		)
+		gentxPath := gentx.SaveTo(t, tmp)
+		suite, network := newSuite(account)
 
 		suite.ChainMock.On("NodeID", context.Background()).Return(testutil.NodeID, nil).Once()
 		suite.CosmosClientMock.
@@ -195,9 +195,9 @@ func TestJoin(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgRequestAddValidator{
-					Creator:        account.Address(networktypes.SPN),
+					Creator:        addr,
 					LaunchID:       testutil.LaunchID,
-					ValAddress:     account.Address(networktypes.SPN),
+					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
 					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
@@ -219,9 +219,9 @@ func TestJoin(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgRequestAddAccount{
-					Creator:  account.Address(networktypes.SPN),
+					Creator:  addr,
 					LaunchID: testutil.LaunchID,
-					Address:  account.Address(networktypes.SPN),
+					Address:  addr,
 					Coins:    sdk.NewCoins(sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt))),
 				},
 			).
@@ -244,20 +244,21 @@ func TestJoin(t *testing.T) {
 	})
 
 	t.Run("failed to send join request, failed to read node id", func(t *testing.T) {
-		var (
-			account = testutil.NewTestAccount(t, testutil.TestAccountName)
-			tmp     = t.TempDir()
-			gentx   = testutil.NewGentx(
-				account.Address(networktypes.SPN),
-				TestDenom,
-				TestAmountString,
-				"",
-				testutil.PeerAddress,
-			)
-			gentxPath      = gentx.SaveTo(t, tmp)
-			suite, network = newSuite(account)
-			expectedError  = errors.New("failed to get node id")
+		account := testutil.NewTestAccount(t, testutil.TestAccountName)
+		tmp := t.TempDir()
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+		gentx := testutil.NewGentx(
+			addr,
+			TestDenom,
+			TestAmountString,
+			"",
+			testutil.PeerAddress,
 		)
+		gentxPath := gentx.SaveTo(t, tmp)
+		suite, network := newSuite(account)
+		expectedError := errors.New("failed to get node id")
+
 		suite.ChainMock.
 			On("NodeID", mock.Anything).
 			Return("", expectedError).

--- a/ignite/services/network/launch.go
+++ b/ignite/services/network/launch.go
@@ -80,7 +80,7 @@ func (n Network) RevertLaunch(launchID uint64, chain Chain) error {
 	}
 
 	msg := launchtypes.NewMsgRevertLaunch(address, launchID)
-	_, err = n.cosmos.BroadcastTx(n.account.Name, msg)
+	_, err = n.cosmos.BroadcastTx(n.account, msg)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/launch.go
+++ b/ignite/services/network/launch.go
@@ -32,8 +32,12 @@ func (n Network) TriggerLaunch(ctx context.Context, launchID uint64, remainingTi
 	var (
 		minLaunch = xtime.Seconds(params.LaunchTimeRange.MinLaunchTime)
 		maxLaunch = xtime.Seconds(params.LaunchTimeRange.MaxLaunchTime)
-		address   = n.account.Address(networktypes.SPN)
 	)
+	address, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
 	switch {
 	case remainingTime == 0:
 		// if the user does not specify the remaining time, use the minimal one
@@ -70,9 +74,13 @@ func (n Network) TriggerLaunch(ctx context.Context, launchID uint64, remainingTi
 func (n Network) RevertLaunch(launchID uint64, chain Chain) error {
 	n.ev.Send(events.New(events.StatusOngoing, fmt.Sprintf("Reverting launched chain %d", launchID)))
 
-	address := n.account.Address(networktypes.SPN)
+	address, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
 	msg := launchtypes.NewMsgRevertLaunch(address, launchID)
-	_, err := n.cosmos.BroadcastTx(n.account.Name, msg)
+	_, err = n.cosmos.BroadcastTx(n.account.Name, msg)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/launch_test.go
+++ b/ignite/services/network/launch_test.go
@@ -38,11 +38,13 @@ func TestTriggerLaunch(t *testing.T) {
 			}, nil).
 			Once()
 		suite.CosmosClientMock.
-			On("BroadcastTx", account.Name, &launchtypes.MsgTriggerLaunch{
-				Coordinator:   addr,
-				LaunchID:      testutil.LaunchID,
-				RemainingTime: TestMaxRemainingTime,
-			}).
+			On("BroadcastTx",
+				account,
+				&launchtypes.MsgTriggerLaunch{
+					Coordinator:   addr,
+					LaunchID:      testutil.LaunchID,
+					RemainingTime: TestMaxRemainingTime,
+				}).
 			Return(testutil.NewResponse(&launchtypes.MsgTriggerLaunchResponse{}), nil).
 			Once()
 
@@ -118,11 +120,13 @@ func TestTriggerLaunch(t *testing.T) {
 			}, nil).
 			Once()
 		suite.CosmosClientMock.
-			On("BroadcastTx", account.Name, &launchtypes.MsgTriggerLaunch{
-				Coordinator:   addr,
-				LaunchID:      testutil.LaunchID,
-				RemainingTime: TestMaxRemainingTime,
-			}).
+			On("BroadcastTx",
+				account,
+				&launchtypes.MsgTriggerLaunch{
+					Coordinator:   addr,
+					LaunchID:      testutil.LaunchID,
+					RemainingTime: TestMaxRemainingTime,
+				}).
 			Return(testutil.NewResponse(&launchtypes.MsgTriggerLaunch{}), expectedError).
 			Once()
 
@@ -149,11 +153,13 @@ func TestTriggerLaunch(t *testing.T) {
 			}, nil).
 			Once()
 		suite.CosmosClientMock.
-			On("BroadcastTx", account.Name, &launchtypes.MsgTriggerLaunch{
-				Coordinator:   addr,
-				LaunchID:      testutil.LaunchID,
-				RemainingTime: TestMaxRemainingTime,
-			}).
+			On("BroadcastTx",
+				account,
+				&launchtypes.MsgTriggerLaunch{
+					Coordinator:   addr,
+					LaunchID:      testutil.LaunchID,
+					RemainingTime: TestMaxRemainingTime,
+				}).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{}), expectedError).
 			Once()
 
@@ -196,10 +202,12 @@ func TestRevertLaunch(t *testing.T) {
 
 		suite.ChainMock.On("ResetGenesisTime").Return(nil).Once()
 		suite.CosmosClientMock.
-			On("BroadcastTx", account.Name, &launchtypes.MsgRevertLaunch{
-				Coordinator: addr,
-				LaunchID:    testutil.LaunchID,
-			}).
+			On("BroadcastTx",
+				account,
+				&launchtypes.MsgRevertLaunch{
+					Coordinator: addr,
+					LaunchID:    testutil.LaunchID,
+				}).
 			Return(testutil.NewResponse(&launchtypes.MsgRevertLaunchResponse{}), nil).
 			Once()
 
@@ -219,10 +227,12 @@ func TestRevertLaunch(t *testing.T) {
 		require.NoError(t, err)
 
 		suite.CosmosClientMock.
-			On("BroadcastTx", account.Name, &launchtypes.MsgRevertLaunch{
-				Coordinator: addr,
-				LaunchID:    testutil.LaunchID,
-			}).
+			On("BroadcastTx",
+				account,
+				&launchtypes.MsgRevertLaunch{
+					Coordinator: addr,
+					LaunchID:    testutil.LaunchID,
+				}).
 			Return(
 				testutil.NewResponse(&launchtypes.MsgRevertLaunchResponse{}),
 				expectedError,
@@ -250,10 +260,12 @@ func TestRevertLaunch(t *testing.T) {
 			Return(expectedError).
 			Once()
 		suite.CosmosClientMock.
-			On("BroadcastTx", account.Name, &launchtypes.MsgRevertLaunch{
-				Coordinator: addr,
-				LaunchID:    testutil.LaunchID,
-			}).
+			On("BroadcastTx",
+				account,
+				&launchtypes.MsgRevertLaunch{
+					Coordinator: addr,
+					LaunchID:    testutil.LaunchID,
+				}).
 			Return(testutil.NewResponse(&launchtypes.MsgRevertLaunchResponse{}), nil).
 			Once()
 

--- a/ignite/services/network/launch_test.go
+++ b/ignite/services/network/launch_test.go
@@ -28,6 +28,9 @@ func TestTriggerLaunch(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.LaunchQueryMock.
 			On("Params", context.Background(), &launchtypes.QueryParamsRequest{}).
 			Return(&launchtypes.QueryParamsResponse{
@@ -36,7 +39,7 @@ func TestTriggerLaunch(t *testing.T) {
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx", account.Name, &launchtypes.MsgTriggerLaunch{
-				Coordinator:   account.Address(networktypes.SPN),
+				Coordinator:   addr,
 				LaunchID:      testutil.LaunchID,
 				RemainingTime: TestMaxRemainingTime,
 			}).
@@ -105,6 +108,9 @@ func TestTriggerLaunch(t *testing.T) {
 			expectedError  = errors.New("Failed to fetch")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.LaunchQueryMock.
 			On("Params", context.Background(), &launchtypes.QueryParamsRequest{}).
 			Return(&launchtypes.QueryParamsResponse{
@@ -113,7 +119,7 @@ func TestTriggerLaunch(t *testing.T) {
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx", account.Name, &launchtypes.MsgTriggerLaunch{
-				Coordinator:   account.Address(networktypes.SPN),
+				Coordinator:   addr,
 				LaunchID:      testutil.LaunchID,
 				RemainingTime: TestMaxRemainingTime,
 			}).
@@ -133,6 +139,9 @@ func TestTriggerLaunch(t *testing.T) {
 			expectedError  = errors.New("failed to fetch")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.LaunchQueryMock.
 			On("Params", context.Background(), &launchtypes.QueryParamsRequest{}).
 			Return(&launchtypes.QueryParamsResponse{
@@ -141,7 +150,7 @@ func TestTriggerLaunch(t *testing.T) {
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx", account.Name, &launchtypes.MsgTriggerLaunch{
-				Coordinator:   account.Address(networktypes.SPN),
+				Coordinator:   addr,
 				LaunchID:      testutil.LaunchID,
 				RemainingTime: TestMaxRemainingTime,
 			}).
@@ -182,10 +191,13 @@ func TestRevertLaunch(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ChainMock.On("ResetGenesisTime").Return(nil).Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx", account.Name, &launchtypes.MsgRevertLaunch{
-				Coordinator: account.Address(networktypes.SPN),
+				Coordinator: addr,
 				LaunchID:    testutil.LaunchID,
 			}).
 			Return(testutil.NewResponse(&launchtypes.MsgRevertLaunchResponse{}), nil).
@@ -203,9 +215,12 @@ func TestRevertLaunch(t *testing.T) {
 			expectedError  = errors.New("failed to revert launch")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.CosmosClientMock.
 			On("BroadcastTx", account.Name, &launchtypes.MsgRevertLaunch{
-				Coordinator: account.Address(networktypes.SPN),
+				Coordinator: addr,
 				LaunchID:    testutil.LaunchID,
 			}).
 			Return(
@@ -227,13 +242,16 @@ func TestRevertLaunch(t *testing.T) {
 			expectedError  = errors.New("failed to reset genesis time")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ChainMock.
 			On("ResetGenesisTime").
 			Return(expectedError).
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx", account.Name, &launchtypes.MsgRevertLaunch{
-				Coordinator: account.Address(networktypes.SPN),
+				Coordinator: addr,
 				LaunchID:    testutil.LaunchID,
 			}).
 			Return(testutil.NewResponse(&launchtypes.MsgRevertLaunchResponse{}), nil).

--- a/ignite/services/network/profile.go
+++ b/ignite/services/network/profile.go
@@ -88,7 +88,10 @@ func (n Network) Balances(ctx context.Context, address string) (sdk.Coins, error
 
 // Profile returns the address profile info
 func (n Network) Profile(ctx context.Context, campaignID uint64) (networktypes.Profile, error) {
-	address := n.account.Address(networktypes.SPN)
+	address, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return networktypes.Profile{}, err
+	}
 
 	// fetch vouchers held by the account
 	coins, err := n.Balances(ctx, address)

--- a/ignite/services/network/publish.go
+++ b/ignite/services/network/publish.go
@@ -123,7 +123,10 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 		}
 	}
 
-	coordinatorAddress := n.account.Address(networktypes.SPN)
+	coordinatorAddress, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return 0, 0, err
+	}
 	campaignID = o.campaignID
 
 	n.ev.Send(events.New(events.StatusOngoing, "Publishing the network"))
@@ -180,8 +183,14 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 		// TODO consider moving to UpdateCampaign, but not sure, may not be relevant.
 		// It is better to send multiple message in a single tx too.
 		// consider ways to refactor to accomplish a better API and efficiency.
+
+		addr, err := n.account.Address(networktypes.SPN)
+		if err != nil {
+			return 0, 0, err
+		}
+
 		msgMintVouchers := campaigntypes.NewMsgMintVouchers(
-			n.account.Address(networktypes.SPN),
+			addr,
 			campaignID,
 			campaigntypes.NewSharesFromCoins(sdk.NewCoins(coins...)),
 		)
@@ -198,8 +207,13 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 			return 0, 0, err
 		}
 	} else {
+		addr, err := n.account.Address(networktypes.SPN)
+		if err != nil {
+			return 0, 0, err
+		}
+
 		msgCreateChain := launchtypes.NewMsgCreateChain(
-			n.account.Address(networktypes.SPN),
+			addr,
 			chainID,
 			c.SourceURL(),
 			c.SourceHash(),
@@ -227,7 +241,12 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 }
 
 func (n Network) SendAccountRequestForCoordinator(launchID uint64, amount sdk.Coins) error {
-	return n.sendAccountRequest(launchID, n.account.Address(networktypes.SPN), amount)
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
+	return n.sendAccountRequest(launchID, addr, amount)
 }
 
 // SendAccountRequest creates an add AddAccount request message.
@@ -236,8 +255,13 @@ func (n Network) sendAccountRequest(
 	address string,
 	amount sdk.Coins,
 ) error {
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
 	msg := launchtypes.NewMsgRequestAddAccount(
-		n.account.Address(networktypes.SPN),
+		addr,
 		launchID,
 		address,
 		amount,

--- a/ignite/services/network/publish_test.go
+++ b/ignite/services/network/publish_test.go
@@ -41,17 +41,20 @@ func TestPublish(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -61,7 +64,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: testutil.ChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -93,17 +96,20 @@ func TestPublish(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -123,7 +129,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: testutil.ChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -155,17 +161,20 @@ func TestPublish(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -195,7 +204,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				campaigntypes.NewMsgMintVouchers(
-					account.Address(networktypes.SPN),
+					addr,
 					testutil.CampaignID,
 					campaigntypes.NewSharesFromCoins(sdk.NewCoins(sdk.NewInt64Coin("foo", 2000), sdk.NewInt64Coin("staking", 50000))),
 				),
@@ -207,7 +216,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: testutil.ChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -248,17 +257,20 @@ func TestPublish(t *testing.T) {
 		)
 		defer gts.Close()
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -268,7 +280,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: customGenesisChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -299,17 +311,20 @@ func TestPublish(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -319,7 +334,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: testutil.ChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -353,17 +368,20 @@ func TestPublish(t *testing.T) {
 		)
 		defer gts.Close()
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -373,7 +391,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&campaigntypes.MsgCreateCampaign{
-					Coordinator:  account.Address(networktypes.SPN),
+					Coordinator:  addr,
 					CampaignName: testutil.ChainName,
 					Metadata:     []byte{},
 				},
@@ -387,7 +405,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&campaigntypes.MsgInitializeMainnet{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					CampaignID:     testutil.CampaignID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -418,17 +436,20 @@ func TestPublish(t *testing.T) {
 			expectedError  = errors.New("failed to initialize mainnet")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -438,7 +459,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&campaigntypes.MsgCreateCampaign{
-					Coordinator:  account.Address(networktypes.SPN),
+					Coordinator:  addr,
 					CampaignName: testutil.ChainName,
 					Metadata:     []byte{},
 				},
@@ -452,7 +473,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&campaigntypes.MsgInitializeMainnet{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					CampaignID:     testutil.CampaignID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -495,9 +516,12 @@ func TestPublish(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On("CoordinatorByAddress", mock.Anything, &profiletypes.QueryGetCoordinatorByAddressRequest{
-				Address: account.Address(networktypes.SPN),
+				Address: addr,
 			}).
 			Return(nil, cosmoserror.ErrNotFound).
 			Once()
@@ -506,7 +530,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: testutil.ChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -525,7 +549,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&profiletypes.MsgCreateCoordinator{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(testutil.NewResponse(&profiletypes.MsgCreateCoordinatorResponse{}), nil).
@@ -549,9 +573,12 @@ func TestPublish(t *testing.T) {
 			expectedError  = errors.New("failed to fetch coordinator")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On("CoordinatorByAddress", mock.Anything, &profiletypes.QueryGetCoordinatorByAddressRequest{
-				Address: account.Address(networktypes.SPN),
+				Address: addr,
 			}).
 			Return(nil, expectedError).
 			Once()
@@ -587,17 +614,20 @@ func TestPublish(t *testing.T) {
 			suite, network = newSuite(account)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -623,17 +653,20 @@ func TestPublish(t *testing.T) {
 			expectedError  = errors.New("failed to create chain")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -643,7 +676,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: testutil.ChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,
@@ -674,17 +707,20 @@ func TestPublish(t *testing.T) {
 			expectedError  = errors.New("failed to cache binary")
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.ProfileQueryMock.
 			On(
 				"CoordinatorByAddress",
 				context.Background(),
 				&profiletypes.QueryGetCoordinatorByAddressRequest{
-					Address: account.Address(networktypes.SPN),
+					Address: addr,
 				},
 			).
 			Return(&profiletypes.QueryGetCoordinatorByAddressResponse{
 				CoordinatorByAddress: profiletypes.CoordinatorByAddress{
-					Address:       account.Address(networktypes.SPN),
+					Address:       addr,
 					CoordinatorID: 1,
 				},
 			}, nil).
@@ -694,7 +730,7 @@ func TestPublish(t *testing.T) {
 				"BroadcastTx",
 				account.Name,
 				&launchtypes.MsgCreateChain{
-					Coordinator:    account.Address(networktypes.SPN),
+					Coordinator:    addr,
 					GenesisChainID: testutil.ChainID,
 					SourceURL:      testutil.ChainSourceURL,
 					SourceHash:     testutil.ChainSourceHash,

--- a/ignite/services/network/request.go
+++ b/ignite/services/network/request.go
@@ -76,10 +76,15 @@ func (n Network) RequestFromIDs(ctx context.Context, launchID uint64, requestIDs
 func (n Network) SubmitRequest(launchID uint64, reviewal ...Reviewal) error {
 	n.ev.Send(events.New(events.StatusOngoing, "Submitting requests..."))
 
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
 	messages := make([]sdk.Msg, len(reviewal))
 	for i, reviewal := range reviewal {
 		messages[i] = launchtypes.NewMsgSettleRequest(
-			n.account.Address(networktypes.SPN),
+			addr,
 			launchID,
 			reviewal.RequestID,
 			reviewal.IsApproved,

--- a/ignite/services/network/reward.go
+++ b/ignite/services/network/reward.go
@@ -24,8 +24,13 @@ func (n Network) SetReward(launchID uint64, lastRewardHeight int64, coins sdk.Co
 		),
 	))
 
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
 	msg := rewardtypes.NewMsgSetRewards(
-		n.account.Address(networktypes.SPN),
+		addr,
 		launchID,
 		lastRewardHeight,
 		coins,

--- a/ignite/services/network/reward_test.go
+++ b/ignite/services/network/reward_test.go
@@ -22,12 +22,15 @@ func TestSetReward(t *testing.T) {
 			lastRewarHeight = int64(10)
 		)
 
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
 				account.Name,
 				&rewardtypes.MsgSetRewards{
-					Provider:         account.Address(networktypes.SPN),
+					Provider:         addr,
 					LaunchID:         testutil.LaunchID,
 					Coins:            coins,
 					LastRewardHeight: lastRewarHeight,
@@ -53,12 +56,16 @@ func TestSetReward(t *testing.T) {
 			lastRewarHeight = int64(10)
 			expectedErr     = errors.New("failed to set reward")
 		)
+
+		addr, err := account.Address(networktypes.SPN)
+		require.NoError(t, err)
+
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
 				account.Name,
 				&rewardtypes.MsgSetRewards{
-					Provider:         account.Address(networktypes.SPN),
+					Provider:         addr,
 					LaunchID:         testutil.LaunchID,
 					Coins:            coins,
 					LastRewardHeight: lastRewarHeight,

--- a/integration/account/cmd_account_test.go
+++ b/integration/account/cmd_account_test.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
 	"github.com/ignite/cli/ignite/pkg/randstr"
 	envtest "github.com/ignite/cli/integration"
-	"github.com/stretchr/testify/require"
 )
 
 const testAccountMnemonic = "develop mansion drum glow husband trophy labor jelly fault run pause inside jazz foil page injury foam oppose fruit chunk segment morning series nation"

--- a/integration/app.go
+++ b/integration/app.go
@@ -8,13 +8,14 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
 	"github.com/ignite/cli/ignite/chainconfig"
 	"github.com/ignite/cli/ignite/pkg/availableport"
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
 	"github.com/ignite/cli/ignite/pkg/gocmd"
 	"github.com/ignite/cli/ignite/pkg/xurl"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 const ServeTimeout = time.Minute * 15

--- a/integration/exec.go
+++ b/integration/exec.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ignite/cli/ignite/pkg/cmdrunner"
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
-	"github.com/stretchr/testify/assert"
 )
 
 type execOptions struct {

--- a/integration/node/cmd_query_bank_test.go
+++ b/integration/node/cmd_query_bank_test.go
@@ -136,6 +136,10 @@ func TestNodeQueryBankBalances(t *testing.T) {
 		assertBankBalanceOutput(t, b.String(), "5600atoken,1200btoken")
 
 		b.Reset()
+
+		aliceAddr, err := aliceAccount.Address(testPrefix)
+		require.NoError(t, err)
+
 		env.Exec("query bank balances by address",
 			step.NewSteps(step.New(
 				step.Exec(
@@ -144,7 +148,7 @@ func TestNodeQueryBankBalances(t *testing.T) {
 					"query",
 					"bank",
 					"balances",
-					aliceAccount.Address(testPrefix),
+					aliceAddr,
 					"--node", node,
 					"--keyring-dir", accKeyringDir,
 					"--address-prefix", testPrefix,

--- a/integration/node/cmd_tx_bank_send_test.go
+++ b/integration/node/cmd_tx_bank_send_test.go
@@ -132,6 +132,11 @@ func TestNodeTxBankSend(t *testing.T) {
 			return
 		}
 
+		bobAddr, err := bobAccount.Address(testPrefix)
+		require.NoError(t, err)
+		aliceAddr, err := aliceAccount.Address(testPrefix)
+		require.NoError(t, err)
+
 		env.Exec("send 2stake from bob to alice using addresses",
 			step.NewSteps(step.New(
 				step.Exec(
@@ -140,8 +145,8 @@ func TestNodeTxBankSend(t *testing.T) {
 					"tx",
 					"bank",
 					"send",
-					bobAccount.Address(testPrefix),
-					aliceAccount.Address(testPrefix),
+					bobAddr,
+					aliceAddr,
 					"2stake",
 					"--node", node,
 					"--keyring-dir", accKeyringDir,
@@ -163,7 +168,7 @@ func TestNodeTxBankSend(t *testing.T) {
 					"bank",
 					"send",
 					"alice",
-					bobAccount.Address(testPrefix),
+					bobAddr,
 					"5token",
 					"--node", node,
 					"--keyring-dir", accKeyringDir,
@@ -244,7 +249,7 @@ func TestNodeTxBankSend(t *testing.T) {
 
 		require.Contains(t, b.String(),
 			fmt.Sprintf(`"body":{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","from_address":"%s","to_address":"%s","amount":[{"denom":"token","amount":"5"}]}]`,
-				aliceAccount.Address(testPrefix), bobAccount.Address(testPrefix)),
+				aliceAddr, bobAddr),
 		)
 		require.Contains(t, b.String(), `"signatures":[]`)
 


### PR DESCRIPTION
Upgrading cosmos SDK to `v0.46.0` changed the signatures of functions in `keyring` used by `cosmosaccount` like `Address()` and `GetPubKey()` to return errors.

This PR modifies our wrapper functions to also return errors and makes the corresponding changes in the codebase.

Closes #2679