### PR TITLE
fix: prevent map scaffolding from failing in an edge-case

### DIFF
--- a/ignite/pkg/placeholder/tracer.go
+++ b/ignite/pkg/placeholder/tracer.go
@@ -43,6 +43,7 @@ type Replacer interface {
 	Replace(content, placeholder, replacement string) string
 	ReplaceAll(content, placeholder, replacement string) string
 	ReplaceOnce(content, placeholder, replacement string) string
+	ReplaceIfExists(content, placeholder, replacement string) string
 	AppendMiscError(miscError string)
 }
 
@@ -77,6 +78,13 @@ func (t *Tracer) Replace(content, placeholder, replacement string) string {
 func (t *Tracer) ReplaceOnce(content, placeholder, replacement string) string {
 	if !strings.Contains(content, replacement) {
 		return t.Replace(content, placeholder, replacement)
+	}
+	return content
+}
+
+func (t *Tracer) ReplaceIfExists(content, placeholder, replacement string) string {
+	if !strings.Contains(content, replacement) {
+		strings.Replace(content, placeholder, replacement, 1)
 	}
 	return content
 }

--- a/ignite/templates/typed/map/stargate.go
+++ b/ignite/templates/typed/map/stargate.go
@@ -588,10 +588,9 @@ func handlerModify(replacer placeholder.Replacer, opts *typed.Options) genny.Run
 		if err != nil {
 			return err
 		}
-
 		// Set once the MsgServer definition if it is not defined yet
 		replacementMsgServer := `msgServer := keeper.NewMsgServerImpl(k)`
-		content := replacer.ReplaceOnce(f.String(), typed.PlaceholderHandlerMsgServer, replacementMsgServer)
+		content := replacer.ReplaceIfExists(f.String(), typed.PlaceholderHandlerMsgServer, replacementMsgServer)
 
 		templateHandlers := `case *types.MsgCreate%[2]v:
 					res, err := msgServer.Create%[2]v(sdk.WrapSDKContext(ctx), msg)


### PR DESCRIPTION
* Added `ReplaceIfExists`
* Switched map scaffolding from `ReplaceOnce` to `ReplaceIfExists` to handle an edge case
 
Edge-case: https://github.com/ignite/cli/issues/2762

Not proposing this should be merged, just wanted to find the source of the issue.

Of course, we should just remove the handlers in the v0.46 version: https://github.com/ignite/cli/issues/2764