### PR TITLE
chore: add CL enforcer gh action

### DIFF
--- a/.github/workflows/cl-enforcer.yml
+++ b/.github/workflows/cl-enforcer.yml
@@ -1,0 +1,18 @@
+name: Changelog Enforcer
+on:
+  pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: 'changelog.md'
+        missingUpdateErrorMessage: 'Please fill the changelog.md file or add the "Skip-Changelog" label'
+        versionPattern: ''


### PR DESCRIPTION
This forces the developper to add an entry in the changelog.md file of his PR.
It is possible to skip that rule by adding a `Skip-Changelog` label.