### PR TITLE
feat: Support multi-validator architecture

### DIFF
--- a/ignite/chainconfig/config.go
+++ b/ignite/chainconfig/config.go
@@ -10,8 +10,8 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/imdario/mergo"
 
-	"github.com/ignite-hq/cli/ignite/pkg/xfilepath"
-	"github.com/ignite-hq/cli/ignite/pkg/xurl"
+	"github.com/ignite/cli/ignite/pkg/xfilepath"
+	"github.com/ignite/cli/ignite/pkg/xurl"
 )
 
 // internal type alias for convienence

--- a/ignite/chainconfig/config.go
+++ b/ignite/chainconfig/config.go
@@ -172,14 +172,13 @@ func makeDefaultValidator(diff ...int) Validator {
 
 		Config: configmap{
 			"rpc": configmap{
-				"laddr": fmt.Sprintf("0.0.0.0:%d", RPCPort+diffVal),
+				"laddr":       fmt.Sprintf("0.0.0.0:%d", RPCPort+diffVal),
+				"pprof_laddr": fmt.Sprintf("0.0.0.0:%d", PPROFPort+diffVal),
 			},
 
 			"p2p": configmap{
 				"laddr": fmt.Sprintf("0.0.0.0:%d", P2PPort+diffVal),
 			},
-
-			"pprof_laddr": fmt.Sprintf("0.0.0.0:%d", PPROFPort+diffVal),
 		},
 	}
 }

--- a/ignite/chainconfig/config.go
+++ b/ignite/chainconfig/config.go
@@ -99,6 +99,15 @@ func (c Config) AccountByName(name string) (acc Account, found bool) {
 	return Account{}, false
 }
 
+func (c Config) ValidatorByName(name string) (Validator, bool) {
+	for _, val := range c.Validators {
+		if val.Name == name {
+			return val, true
+		}
+	}
+	return Validator{}, false
+}
+
 // Account holds the options related to setting up Cosmos wallets.
 type Account struct {
 	Name     string   `yaml:"name"`
@@ -202,6 +211,13 @@ func (v Validator) Pprof() string {
 	return v.getConfigItem(v.Config, "pprof_laddr")
 }
 
+func (v Validator) Moniker() string {
+	if v.GenTx.Moniker != "" {
+		return v.GenTx.Moniker
+	}
+	return v.Name
+}
+
 // we can generalize these getter into a single recursive map field getter
 // func that accepts an abritrary depth, but we only ever seem to either
 // do 1 or two deep, so that might be overkill.
@@ -241,7 +257,7 @@ type GenTx struct {
 	CommisionRate           string `yaml:"rate"`
 	CommissionMaxRate       string `yaml:"max-rate"`
 	CommissionMaxChangeRate string `yaml:"max-change-rate"`
-	MinDelegation           string `yaml:"min-delegation"`
+	MinSelfDelegation       string `yaml:"min-delegation"`
 	GasPrices               string `yaml:"gas-prices"`
 	Details                 string `yaml:"details"`
 	Identity                string `yaml:"identity"`
@@ -399,6 +415,7 @@ func validate(conf Config) error {
 	if len(conf.Validators) == 0 || conf.Validators[0].Name == "" {
 		return &ValidationError{"at least one validator is required"}
 	}
+	// todo: Verify validators have unique names/ports
 	return nil
 }
 

--- a/ignite/chainconfig/config_test.go
+++ b/ignite/chainconfig/config_test.go
@@ -14,9 +14,9 @@ accounts:
     coins: ["1000token", "100000000stake"]
   - name: you
     coins: ["5000token"]
-validator:
-  name: user1
-  staked: "100000000stake"
+validators:
+  - name: user1
+    bonded: "100000000stake"
 `
 
 	conf, err := Parse(strings.NewReader(confyml))
@@ -34,8 +34,8 @@ validator:
 	}, conf.Accounts)
 	require.Equal(t, Validator{
 		Name:   "user1",
-		Staked: "100000000stake",
-	}, conf.Validator)
+		Bonded: "100000000stake",
+	}, conf.Validators[0])
 }
 
 func TestCoinTypeParse(t *testing.T) {
@@ -48,9 +48,9 @@ accounts:
   - name: you
     coins: ["5000token"]
     cointype: 123456
-validator:
-  name: user1
-  staked: "100000000stake"
+validators:
+  - name: user1
+    bonded: "100000000stake"
 `
 
 	conf, err := Parse(strings.NewReader(confyml))
@@ -71,8 +71,8 @@ validator:
 	}, conf.Accounts)
 	require.Equal(t, Validator{
 		Name:   "user1",
-		Staked: "100000000stake",
-	}, conf.Validator)
+		Bonded: "100000000stake",
+	}, conf.Validators[0])
 }
 
 func TestParseInvalid(t *testing.T) {
@@ -85,7 +85,7 @@ accounts:
 `
 
 	_, err := Parse(strings.NewReader(confyml))
-	require.Equal(t, &ValidationError{"validator is required"}, err)
+	require.Equal(t, &ValidationError{"at least one validator is required"}, err)
 }
 
 func TestFaucetHost(t *testing.T) {
@@ -95,9 +95,9 @@ accounts:
     coins: ["1000token", "100000000stake"]
   - name: you
     coins: ["5000token"]
-validator:
-  name: user1
-  staked: "100000000stake"
+validators:
+  - name: user1
+    bonded: "100000000stake"
 faucet:
   host: "0.0.0.0:4600"
 `
@@ -111,9 +111,9 @@ accounts:
     coins: ["1000token", "100000000stake"]
   - name: you
     coins: ["5000token"]
-validator:
-  name: user1
-  staked: "100000000stake"
+validators:
+  - name: user1
+    bonded: "100000000stake"
 faucet:
   port: 4700
 `
@@ -128,9 +128,9 @@ accounts:
     coins: ["1000token", "100000000stake"]
   - name: you
     coins: ["5000token"]
-validator:
-  name: user1
-  staked: "100000000stake"
+validators:
+  - name: user1
+    bonded: "100000000stake"
 faucet:
   host: "0.0.0.0:4600"
   port: 4700

--- a/ignite/chainconfig/config_test.go
+++ b/ignite/chainconfig/config_test.go
@@ -32,10 +32,56 @@ validators:
 			Coins: []string{"5000token"},
 		},
 	}, conf.Accounts)
-	require.Equal(t, Validator{
-		Name:   "user1",
-		Bonded: "100000000stake",
-	}, conf.Validators[0])
+	require.Equal(t, "user1", conf.Validators[0].Name)
+	require.Equal(t, "100000000stake", conf.Validators[0].Bonded)
+}
+
+func TestValidatorParse(t *testing.T) {
+	confyml := `
+accounts:
+  - name: me
+    coins: ["1000token", "100000000stake"]
+  - name: you
+    coins: ["5000token"]
+validators:
+  - name: user1
+    bonded: "100000000stake"
+`
+
+	conf, err := Parse(strings.NewReader(confyml))
+
+	require.NoError(t, err)
+	require.Equal(t, []Validator{
+		{
+			Name:   "user1",
+			Bonded: "100000000stake",
+			App: configmap{
+				"grpc": configmap{
+					"address": "0.0.0.0:9090",
+				},
+
+				"grpc-web": configmap{
+					"address": "0.0.0.0:9091",
+				},
+
+				"api": configmap{
+					"address": "0.0.0.0:1317",
+				},
+			},
+
+			Config: configmap{
+				"rpc": configmap{
+					"laddr": "0.0.0.0:26657",
+				},
+
+				"p2p": configmap{
+					"laddr": "0.0.0.0:26656",
+				},
+
+				"pprof_laddr": "0.0.0.0:6060",
+			},
+		},
+	}, conf.Validators)
 }
 
 func TestCoinTypeParse(t *testing.T) {
@@ -69,10 +115,6 @@ validators:
 			CoinType: "123456",
 		},
 	}, conf.Accounts)
-	require.Equal(t, Validator{
-		Name:   "user1",
-		Bonded: "100000000stake",
-	}, conf.Validators[0])
 }
 
 func TestParseInvalid(t *testing.T) {

--- a/ignite/cmd/chain_init.go
+++ b/ignite/cmd/chain_init.go
@@ -55,10 +55,7 @@ func chainInitHandler(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	home, err := c.Home()
-	if err != nil {
-		return err
-	}
+	home := c.AppHome()
 
 	fmt.Printf("🗃  Initialized. Checkout your chain's home (data) directory: %s\n", colors.Info(home))
 

--- a/ignite/cmd/chain_serve.go
+++ b/ignite/cmd/chain_serve.go
@@ -28,6 +28,7 @@ func NewChainServe() *cobra.Command {
 	c.Flags().AddFlagSet(flagSetProto3rdParty(""))
 	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	c.Flags().AddFlagSet(flagSetSkipProto())
+	c.Flags().AddFlagSet(flagSetValidator())
 	c.Flags().BoolP("verbose", "v", false, "Verbose output")
 	c.Flags().BoolP(flagForceReset, "f", false, "Force reset of the app state on start and every source change")
 	c.Flags().BoolP(flagResetOnce, "r", false, "Reset of the app state on first start")

--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -33,6 +33,7 @@ const (
 	flagYes           = "yes"
 	flagClearCache    = "clear-cache"
 	flagSkipProto     = "skip-proto"
+	flagValidator     = "validator"
 
 	checkVersionTimeout = time.Millisecond * 600
 	cacheFileName       = "ignite_cache.db"
@@ -161,7 +162,23 @@ func flagGetClearCache(cmd *cobra.Command) bool {
 	return clearCache
 }
 
+func flagSetValidator() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.String(flagValidator, "", "Validator to serve the chain from")
+	return fs
+}
+
+func getValidator(cmd *cobra.Command) (validator string) {
+	validator, _ = cmd.Flags().GetString(flagValidator)
+	return
+}
+
 func newChainWithHomeFlags(cmd *cobra.Command, chainOption ...chain.Option) (*chain.Chain, error) {
+	// Check if validator is provided
+	if validator := getValidator(cmd); validator != "" {
+		chainOption = append(chainOption, chain.SetValidator(validator))
+	}
+
 	// Check if custom home is provided
 	if home := getHome(cmd); home != "" {
 		chainOption = append(chainOption, chain.HomePath(home))

--- a/ignite/cmd/network_chain_init.go
+++ b/ignite/cmd/network_chain_init.go
@@ -137,7 +137,7 @@ func networkChainInitHandler(cmd *cobra.Command, args []string) error {
 	}
 	session.StartSpinner("Generating your Gentx")
 
-	gentxPath, err := c.InitAccount(cmd.Context(), v, validatorAccount)
+	gentxPath, err := c.InitAccount(cmd.Context(), v.ToConfig(), validatorAccount)
 	if err != nil {
 		return err
 	}

--- a/ignite/pkg/chaincmd/chaincmd.go
+++ b/ignite/pkg/chaincmd/chaincmd.go
@@ -2,6 +2,8 @@ package chaincmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
 	"github.com/ignite/cli/ignite/pkg/cosmosver"
@@ -78,6 +80,8 @@ type ChainCmd struct {
 	isAutoChainIDDetectionEnabled bool
 
 	sdkVersion cosmosver.Version
+
+	stdout, stderr io.Writer
 }
 
 // New creates a new ChainCmd to launch command with the chain app
@@ -85,6 +89,8 @@ func New(appCmd string, options ...Option) ChainCmd {
 	chainCmd := ChainCmd{
 		appCmd:     appCmd,
 		sdkVersion: cosmosver.Latest,
+		stdout:     os.Stdout,
+		stderr:     os.Stderr,
 	}
 
 	applyOptions(&chainCmd, options)
@@ -180,6 +186,20 @@ func WithLaunchpadCLIHome(cliHome string) Option {
 func WithLegacySendCommand() Option {
 	return func(c *ChainCmd) {
 		c.legacySend = true
+	}
+}
+
+// WithStdout will make the command use the given io.Writer as the stdout
+func WithStdout(out io.Writer) Option {
+	return func(c *ChainCmd) {
+		c.stdout = out
+	}
+}
+
+// WithStdout will make the command use the given io.Writer as the stdout
+func WithStderr(err io.Writer) Option {
+	return func(c *ChainCmd) {
+		c.stderr = err
 	}
 }
 
@@ -297,6 +317,16 @@ func (c ChainCmd) AddVestingAccountCommand(address, originalCoins, vestingCoins 
 	}
 
 	return c.daemonCommand(command)
+}
+
+// Stdout returns the configured stdout io.Writer
+func (c ChainCmd) Stdout() io.Writer {
+	return c.stdout
+}
+
+// Stderr returns the configured stderr io.Writer
+func (c ChainCmd) Stderr() io.Writer {
+	return c.stderr
 }
 
 // GentxOption for the GentxCommand

--- a/ignite/pkg/protoc/protoc.go
+++ b/ignite/pkg/protoc/protoc.go
@@ -131,6 +131,9 @@ func Generate(ctx context.Context, outDir, protoPath string, includePaths, proto
 	}
 	var existentIncludePaths []string
 
+	gopath := os.Getenv("GOPATH") + "/src"
+	includePaths = append(includePaths, gopath)
+
 	// skip if a third party proto source actually doesn't exist on the filesystem.
 	for _, path := range includePaths {
 		if _, err := os.Stat(path); os.IsNotExist(err) {

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -105,7 +105,7 @@ func IsHTTP(address string) bool {
 
 func parseURL(s string) (*url.URL, error) {
 	if s == "" {
-		return nil, errors.New("url is empty")
+		panic(errors.New("url is empty"))
 	}
 
 	// Handle the case where the URI is an IP:PORT or HOST:PORT

--- a/ignite/pkg/xurl/xurl.go
+++ b/ignite/pkg/xurl/xurl.go
@@ -103,9 +103,13 @@ func IsHTTP(address string) bool {
 	return strings.HasPrefix(address, "http")
 }
 
+func Parse(s string) (*url.URL, error) {
+	return parseURL(s)
+}
+
 func parseURL(s string) (*url.URL, error) {
 	if s == "" {
-		panic(errors.New("url is empty"))
+		return nil, errors.New("url is empty")
 	}
 
 	// Handle the case where the URI is an IP:PORT or HOST:PORT

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -456,6 +456,12 @@ func (c *Chain) keyringBackendForValidator(v chainconfig.Validator) (chaincmd.Ke
 	return chaincmd.KeyringBackendTest, nil
 }
 
+// DefaultCommands returns the runner execute commands on the chains binary
+// using the default validator
+func (c *Chain) DefaultCommands(ctx context.Context, chainCmdOpts ...chaincmd.Option) (chaincmdrunner.Runner, error) {
+	return c.Commands(ctx, c.validator, chainCmdOpts...)
+}
+
 // Commands returns the runner execute commands on the chain's binary
 func (c *Chain) Commands(ctx context.Context, v chainconfig.Validator, chainCmdOpts ...chaincmd.Option) (chaincmdrunner.Runner, error) {
 	id, err := c.ID()
@@ -494,8 +500,8 @@ func (c *Chain) Commands(ctx context.Context, v chainconfig.Validator, chainCmdO
 	ccrOptions := make([]chaincmdrunner.Option, 0)
 	if c.logLevel == LogVerbose {
 		ccrOptions = append(ccrOptions,
-			chaincmdrunner.Stdout(os.Stdout),
-			chaincmdrunner.Stderr(os.Stderr),
+			chaincmdrunner.Stdout(cc.Stdout()),
+			chaincmdrunner.Stderr(cc.Stderr()),
 			chaincmdrunner.DaemonLogPrefix(c.genPrefix(logAppd)),
 		)
 	}

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -212,7 +212,7 @@ func (c *Chain) RPCPublicAddress() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		rpcAddress = conf.Host.RPC
+		rpcAddress = conf.Validators[0].RPC()
 	}
 	return rpcAddress, nil
 }
@@ -316,8 +316,9 @@ func (c *Chain) DefaultHome() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if config.Init.Home != "" {
-		return config.Init.Home, nil
+	val := config.Validators[0]
+	if val.Home != "" {
+		return val.Home, nil
 	}
 
 	return c.plugin.Home(), nil
@@ -389,14 +390,16 @@ func (c *Chain) KeyringBackend() (chaincmd.KeyringBackend, error) {
 		return "", err
 	}
 
+	val := config.Validators[0]
+
 	// 2nd.
-	if config.Init.KeyringBackend != "" {
-		return chaincmd.KeyringBackendFromString(config.Init.KeyringBackend)
+	if val.KeyringBackend != "" {
+		return chaincmd.KeyringBackendFromString(val.KeyringBackend)
 	}
 
 	// 3rd.
-	if config.Init.Client != nil {
-		if backend, ok := config.Init.Client["keyring-backend"]; ok {
+	if val.Client != nil {
+		if backend, ok := val.Client["keyring-backend"]; ok {
 			if backendStr, ok := backend.(string); ok {
 				return chaincmd.KeyringBackendFromString(backendStr)
 			}
@@ -450,7 +453,8 @@ func (c *Chain) Commands(ctx context.Context) (chaincmdrunner.Runner, error) {
 		return chaincmdrunner.Runner{}, err
 	}
 
-	nodeAddr, err := xurl.TCP(config.Host.RPC)
+	val := config.Validators[0]
+	nodeAddr, err := xurl.TCP(val.RPC())
 	if err != nil {
 		return chaincmdrunner.Runner{}, err
 	}

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -55,7 +55,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 	}
 
 	// construct faucet options.
-	apiAddress := conf.Host.API
+	apiAddress := conf.Validators[0].API()
 	if envAPIAddress != "" {
 		apiAddress = envAPIAddress
 	}

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -37,7 +37,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 		return cosmosfaucet.Faucet{}, err
 	}
 
-	commands, err := c.Commands(ctx)
+	commands, err := c.Commands(ctx, c.validator)
 	if err != nil {
 		return cosmosfaucet.Faucet{}, err
 	}

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -55,7 +55,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 	}
 
 	// construct faucet options.
-	apiAddress := conf.Validators[0].API()
+	apiAddress := c.validator.API()
 	if envAPIAddress != "" {
 		apiAddress = envAPIAddress
 	}

--- a/ignite/services/chain/init.go
+++ b/ignite/services/chain/init.go
@@ -66,13 +66,6 @@ func (c *Chain) InitChain(ctx context.Context) error {
 		return err
 	}
 
-	// overwrite configuration changes from Ignite CLI's config.yml to
-	// over app's sdk configs.
-
-	if err := c.plugin.Configure(home, conf); err != nil {
-		return err
-	}
-
 	// make sure that chain id given during chain.New() has the most priority.
 	if conf.Genesis != nil {
 		conf.Genesis["chain_id"] = chainID
@@ -122,6 +115,13 @@ func (c *Chain) InitChain(ctx context.Context) error {
 		if err := cf.Save(conf); err != nil {
 			return err
 		}
+	}
+
+	// overwrite configuration changes from Ignite CLI's config.yml to
+	// over app's sdk configs.
+
+	if err := c.plugin.Configure(home, conf); err != nil {
+		return err
 	}
 
 	return nil

--- a/ignite/services/chain/init.go
+++ b/ignite/services/chain/init.go
@@ -96,16 +96,18 @@ func (c *Chain) InitChain(ctx context.Context) error {
 		return err
 	}
 
-	// for each validator
+	// todo: update for each validator
+	// now: hard code first validator
+	validator := conf.Validators[0]
 	appconfigs := []struct {
 		ec      confile.EncodingCreator
 		path    string
 		changes map[string]interface{}
 	}{
 		{confile.DefaultJSONEncodingCreator, genesisPath, conf.Genesis},
-		{confile.DefaultTOMLEncodingCreator, appTOMLPath, conf.Init.App},
-		{confile.DefaultTOMLEncodingCreator, clientTOMLPath, conf.Init.Client},
-		{confile.DefaultTOMLEncodingCreator, configTOMLPath, conf.Init.Config},
+		{confile.DefaultTOMLEncodingCreator, appTOMLPath, validator.App},
+		{confile.DefaultTOMLEncodingCreator, clientTOMLPath, validator.Client},
+		{confile.DefaultTOMLEncodingCreator, configTOMLPath, validator.Config},
 	}
 
 	for _, ac := range appconfigs {
@@ -169,9 +171,12 @@ func (c *Chain) InitAccounts(ctx context.Context, conf chainconfig.Config) error
 		}
 	}
 
+	// todo: for each validator
+	// now: hardcode validator
+	validator := conf.Validators[0]
 	_, err = c.IssueGentx(ctx, Validator{
-		Name:          conf.Validator.Name,
-		StakingAmount: conf.Validator.Staked,
+		Name:          validator.Name,
+		StakingAmount: validator.Bonded,
 	})
 	return err
 }

--- a/ignite/services/chain/init.go
+++ b/ignite/services/chain/init.go
@@ -96,6 +96,7 @@ func (c *Chain) InitChain(ctx context.Context) error {
 		return err
 	}
 
+	// for each validator
 	appconfigs := []struct {
 		ec      confile.EncodingCreator
 		path    string

--- a/ignite/services/chain/init.go
+++ b/ignite/services/chain/init.go
@@ -91,7 +91,7 @@ func (c *Chain) InitChain(ctx context.Context) error {
 
 	// todo: update for each validator
 	// now: hard code first validator
-	validator := conf.Validators[0]
+	validator := c.validator
 	appconfigs := []struct {
 		ec      confile.EncodingCreator
 		path    string
@@ -173,7 +173,7 @@ func (c *Chain) InitAccounts(ctx context.Context, conf chainconfig.Config) error
 
 	// todo: for each validator
 	// now: hardcode validator
-	validator := conf.Validators[0]
+	validator := c.validator
 	_, err = c.IssueGentx(ctx, Validator{
 		Name:          validator.Name,
 		StakingAmount: validator.Bonded,

--- a/ignite/services/chain/plugin-stargate.go
+++ b/ignite/services/chain/plugin-stargate.go
@@ -103,23 +103,23 @@ func (p *stargatePlugin) configTOML(homePath string, conf chainconfig.Config) er
 		return err
 	}
 
-	rpcAddr, err := xurl.TCP(conf.Host.RPC)
-	if err != nil {
-		return fmt.Errorf("invalid rpc address format %s: %w", conf.Host.RPC, err)
-	}
+	// rpcAddr, err := xurl.TCP(conf.Host.RPC)
+	// if err != nil {
+	// 	return fmt.Errorf("invalid rpc address format %s: %w", conf.Host.RPC, err)
+	// }
 
-	p2pAddr, err := xurl.TCP(conf.Host.P2P)
-	if err != nil {
-		return fmt.Errorf("invalid p2p address format %s: %w", conf.Host.P2P, err)
-	}
+	// p2pAddr, err := xurl.TCP(conf.Host.P2P)
+	// if err != nil {
+	// 	return fmt.Errorf("invalid p2p address format %s: %w", conf.Host.P2P, err)
+	// }
 
 	config.Set("mode", "validator")
 	config.Set("rpc.cors_allowed_origins", []string{"*"})
 	config.Set("consensus.timeout_commit", "1s")
 	config.Set("consensus.timeout_propose", "1s")
-	config.Set("rpc.laddr", rpcAddr)
-	config.Set("p2p.laddr", p2pAddr)
-	config.Set("rpc.pprof_laddr", conf.Host.Prof)
+	// config.Set("rpc.laddr", rpcAddr)
+	// config.Set("p2p.laddr", p2pAddr)
+	// config.Set("rpc.pprof_laddr", conf.Host.Prof)
 
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0o644)
 	if err != nil {

--- a/ignite/services/chain/plugin.go
+++ b/ignite/services/chain/plugin.go
@@ -17,10 +17,10 @@ type Plugin interface {
 	Gentx(context.Context, chaincmdrunner.Runner, Validator) (path string, err error)
 
 	// Configure configures config defaults.
-	Configure(string, chainconfig.Config) error
+	Configure(string, chainconfig.Validator) error
 
 	// Start returns step.Exec configuration to start servers.
-	Start(context.Context, chaincmdrunner.Runner, chainconfig.Config) error
+	Start(context.Context, chaincmdrunner.Runner, chainconfig.Validator) error
 
 	// Home returns the blockchain node's home dir.
 	Home() string

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -388,7 +388,6 @@ func (c *Chain) serve(ctx context.Context, cacheStorage cache.Storage, forceRese
 	}
 
 	// start the blockchain
-	fmt.Println("starting...")
 	return c.start(ctx, conf)
 }
 
@@ -415,9 +414,7 @@ func (c *Chain) start(ctx context.Context, config chainconfig.Config) error {
 		// variables
 		func(commands chaincmdrunner.Runner, validator chainconfig.Validator) {
 			g.Go(func() error {
-				fmt.Printf("----- RUNNING VALIDATOR %s -----\n", validator.Name)
 				if err := c.plugin.Start(ctx, commands, validator); err != nil {
-					fmt.Printf("FAILED START %s %s\n", validator.Name, err)
 					return err
 				}
 				return nil

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -422,8 +422,9 @@ func (c *Chain) start(ctx context.Context, config chainconfig.Config) error {
 
 	// note: address format errors are handled by the
 	// error group, so they can be safely ignored here
-	rpcAddr, _ := xurl.HTTP(config.Host.RPC)
-	apiAddr, _ := xurl.HTTP(config.Host.API)
+	val := config.Validators[0]
+	rpcAddr, _ := xurl.HTTP(val.RPC())
+	apiAddr, _ := xurl.HTTP(val.API())
 
 	// print the server addresses.
 	fmt.Fprintf(c.stdLog().out, "🌍 Tendermint node: %s\n", rpcAddr)

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -131,7 +131,7 @@ func (c *Chain) Serve(ctx context.Context, cacheStorage cache.Storage, options .
 				return ctx.Err()
 
 			case <-c.serveRefresher:
-				commands, err := c.Commands(ctx)
+				commands, err := c.Commands(ctx, c.validator)
 				if err != nil {
 					return err
 				}
@@ -264,7 +264,7 @@ func (c *Chain) serve(ctx context.Context, cacheStorage cache.Storage, forceRese
 
 	// note(jsimnz): Might initialize target validator here
 	fmt.Fprintf(c.stdLog().out, "💿 Running app as validator %v...\n", c.validator.Name)
-	commands, err := c.Commands(ctx)
+	commands, err := c.Commands(ctx, c.validator)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func (c *Chain) serve(ctx context.Context, cacheStorage cache.Storage, forceRese
 }
 
 func (c *Chain) start(ctx context.Context, config chainconfig.Config) error {
-	commands, err := c.Commands(ctx)
+	commands, err := c.Commands(ctx, c.validator)
 	if err != nil {
 		return err
 	}
@@ -398,7 +398,7 @@ func (c *Chain) start(ctx context.Context, config chainconfig.Config) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	// start the blockchain.
-	g.Go(func() error { return c.plugin.Start(ctx, commands, config) })
+	g.Go(func() error { return c.plugin.Start(ctx, commands, c.validator) })
 
 	// start the faucet if enabled.
 	faucet, err := c.Faucet(ctx)

--- a/ignite/services/chain/simulate.go
+++ b/ignite/services/chain/simulate.go
@@ -65,7 +65,7 @@ func (c *Chain) Simulate(ctx context.Context, options ...SimappOption) error {
 		apply(&simappOptions)
 	}
 
-	commands, err := c.Commands(ctx)
+	commands, err := c.Commands(ctx, c.validator)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/networkchain/account.go
+++ b/ignite/services/network/networkchain/account.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ignite/cli/ignite/chainconfig"
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
 	"github.com/ignite/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite/cli/ignite/pkg/randstr"
 	"github.com/ignite/cli/ignite/pkg/xos"
-	"github.com/ignite/cli/ignite/services/chain"
 )
 
 const (
@@ -19,12 +19,12 @@ const (
 )
 
 // InitAccount initializes an account for the blockchain and issue a gentx in config/gentx/gentx.json
-func (c Chain) InitAccount(ctx context.Context, v chain.Validator, accountName string) (string, error) {
+func (c Chain) InitAccount(ctx context.Context, v chainconfig.Validator, accountName string) (string, error) {
 	if !c.isInitialized {
 		return "", errors.New("the blockchain must be initialized to initialize an account")
 	}
 
-	chainCmd, err := c.chain.Commands(ctx)
+	chainCmd, err := c.chain.Commands(ctx, v)
 	if err != nil {
 		return "", err
 	}
@@ -36,7 +36,7 @@ func (c Chain) InitAccount(ctx context.Context, v chain.Validator, accountName s
 	}
 
 	// add account into the genesis
-	err = chainCmd.AddGenesisAccount(ctx, address, v.StakingAmount)
+	err = chainCmd.AddGenesisAccount(ctx, address, v.Bonded)
 	if err != nil {
 		return "", err
 	}
@@ -76,7 +76,7 @@ func (c *Chain) ImportAccount(ctx context.Context, name string) (string, error) 
 	}
 
 	// import the key file into the chain.
-	chainCmd, err := c.chain.Commands(ctx)
+	chainCmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return "", err
 	}
@@ -88,7 +88,7 @@ func (c *Chain) ImportAccount(ctx context.Context, name string) (string, error) 
 // detectPrefix detects the account address prefix for the chain
 // the method create a sample account and parse the address prefix from it
 func (c Chain) detectPrefix(ctx context.Context) (string, error) {
-	chainCmd, err := c.chain.Commands(ctx)
+	chainCmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return "", err
 	}

--- a/ignite/services/network/networkchain/init.go
+++ b/ignite/services/network/networkchain/init.go
@@ -83,7 +83,7 @@ func (c *Chain) initGenesis(ctx context.Context) error {
 		}
 	} else {
 		// default genesis is used, init CLI command is used to generate it
-		cmd, err := c.chain.Commands(ctx)
+		cmd, err := c.chain.Commands(ctx, c.chain.Validator())
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ func (c *Chain) initGenesis(ctx context.Context) error {
 // checkGenesis checks the stored genesis is valid
 func (c *Chain) checkInitialGenesis(ctx context.Context) error {
 	// perform static analysis of the chain with the validate-genesis command.
-	chainCmd, err := c.chain.Commands(ctx)
+	chainCmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/networkchain/networkchain.go
+++ b/ignite/services/network/networkchain/networkchain.go
@@ -255,7 +255,7 @@ func (c Chain) IsHomeDirExist() (ok bool, err error) {
 
 // NodeID returns the chain node id
 func (c Chain) NodeID(ctx context.Context) (string, error) {
-	chainCmd, err := c.chain.Commands(ctx)
+	chainCmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return "", err
 	}

--- a/ignite/services/network/networkchain/prepare.go
+++ b/ignite/services/network/networkchain/prepare.go
@@ -83,7 +83,7 @@ func (c Chain) Prepare(
 		return err
 	}
 
-	cmd, err := c.chain.Commands(ctx)
+	cmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (c Chain) applyGenesisAccounts(
 ) error {
 	var err error
 
-	cmd, err := c.chain.Commands(ctx)
+	cmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func (c Chain) applyVestingAccounts(
 	vestingAccs []networktypes.VestingAccount,
 	addressPrefix string,
 ) error {
-	cmd, err := c.chain.Commands(ctx)
+	cmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func (c Chain) applyGenesisValidators(ctx context.Context, genesisVals []network
 	}
 
 	// gather gentxs
-	cmd, err := c.chain.Commands(ctx)
+	cmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/networkchain/simulate.go
+++ b/ignite/services/network/networkchain/simulate.go
@@ -71,7 +71,7 @@ func (c Chain) SimulateRequests(
 // SimulateChainStart simulates and verify the chain start by starting it with a simulation config
 // and checking if the gentxs execution is successful
 func (c Chain) simulateChainStart(ctx context.Context) error {
-	cmd, err := c.chain.Commands(ctx)
+	cmd, err := c.chain.Commands(ctx, c.chain.Validator())
 	if err != nil {
 		return err
 	}

--- a/ignite/templates/app/stargate/config.yml
+++ b/ignite/templates/app/stargate/config.yml
@@ -3,9 +3,9 @@ accounts:
     coins: ["20000token", "200000000stake"]
   - name: bob
     coins: ["10000token", "100000000stake"]
-validator:
-  name: alice
-  staked: "100000000stake"
+validators:
+  - name: alice
+    bonded: "100000000stake"
 client:
   openapi:
     path: "docs/static/openapi.yml"

--- a/integration/chain/config_test.go
+++ b/integration/chain/config_test.go
@@ -32,8 +32,8 @@ func TestOverwriteSDKConfigsAndChainID(t *testing.T) {
 	require.NoError(t, cf.Load(&c))
 
 	c.Genesis = map[string]interface{}{"chain_id": "cosmos"}
-	c.Init.App = map[string]interface{}{"hello": "cosmos"}
-	c.Init.Config = map[string]interface{}{"fast_sync": false}
+	c.Validators[0].App = map[string]interface{}{"hello": "cosmos"}
+	c.Validators[0].Config = map[string]interface{}{"fast_sync": false}
 
 	require.NoError(t, cf.Save(c))
 

--- a/integration/env.go
+++ b/integration/env.go
@@ -309,6 +309,34 @@ func (e Env) RandomizeServerPorts(path string, configFile string) chainconfig.Ho
 		API:     genAddr(ports[5]),
 	}
 
+	val := chainconfig.Validator{
+		App: map[string]interface{}{
+			"grpc": map[string]interface{}{
+				"address": servers.GRPC,
+			},
+
+			"grpc-web": map[string]interface{}{
+				"address": servers.GRPCWeb,
+			},
+
+			"api": map[string]interface{}{
+				"address": servers.API,
+			},
+		},
+
+		Config: map[string]interface{}{
+			"rpc": map[string]interface{}{
+				"laddr": servers.RPC,
+			},
+
+			"p2p": map[string]interface{}{
+				"laddr": servers.P2P,
+			},
+
+			"pprof_laddr": servers.Prof,
+		},
+	}
+
 	// update config.yml with the generated servers list.
 	configyml, err := os.OpenFile(filepath.Join(path, configFile), os.O_RDWR|os.O_CREATE, 0o755)
 	require.NoError(e.t, err)
@@ -317,7 +345,8 @@ func (e Env) RandomizeServerPorts(path string, configFile string) chainconfig.Ho
 	var conf chainconfig.Config
 	require.NoError(e.t, yaml.NewDecoder(configyml).Decode(&conf))
 
-	conf.Host = servers
+	conf.Validators[0].App = val.App
+	conf.Validators[0].Config = val.App
 	require.NoError(e.t, configyml.Truncate(0))
 	_, err = configyml.Seek(0, 0)
 	require.NoError(e.t, err)
@@ -371,7 +400,7 @@ func (e Env) SetRandomHomeConfig(path string, configFile string) {
 	var conf chainconfig.Config
 	require.NoError(e.t, yaml.NewDecoder(configyml).Decode(&conf))
 
-	conf.Init.Home = e.TmpDir()
+	conf.Validators[0].Home = e.TmpDir()
 	require.NoError(e.t, configyml.Truncate(0))
 	_, err = configyml.Seek(0, 0)
 	require.NoError(e.t, err)


### PR DESCRIPTION
Resolves #2473

This is an initial draft PR to get feedback. Still, some rough edges that will be worked on, but this PR is already late enough relative to when the issue/bounty was issued, and I know there's interest from others, so hopefully this moves the ball forward.

This is a fairly significant (breaking) change to the chain service, configuration, and folder structure of the chain home directory.

You can see the comment thread on #2473 for some of the ideas / changes that are implemented.

### TLDR
- Support multiple validators on the configuration
- Deprecate old config fields that are superceded by the validator specific config. 
- Uses the same Go command runner to start multiple validators. 
- Several changes to the chain home directory. 
  - Each validator has its own home-folder which contains the respective config/data folders
  - Shared keyring folder used by all validators
  - Single genesis.json that is symlinked into each validator config folder
  - The "root" validator (ie the first validator in the config array) is symlinked into the root config folder (see diagram below).

![Ignite Symlink Folder Structure@2x](https://user-images.githubusercontent.com/4015414/186024089-037f2505-d879-4fb7-bd31-bac2d9a7675c.png)

The various symlinks are used to keep a nice developer/user experience. For example, symlink the config files from the main validator into the root config folder means we can still use the same CLI operations `marsd start` which will start a single validator, or `ignite chain serve` which will start all the validators.