### PR TITLE
fix(template): remove QuerierRoute

### DIFF
--- a/ignite/templates/module/create/stargate/x/{{moduleName}}/module.go.plush
+++ b/ignite/templates/module/create/stargate/x/{{moduleName}}/module.go.plush
@@ -117,7 +117,7 @@ func (am AppModule) Route() sdk.Route {
 }
 
 // Deprecated: use RegisterServices
-func (AppModule) QuerierRoute() string { return types.QuerierRoute }
+func (AppModule) QuerierRoute() string { return types.RouterKey }
 
 // Deprecated: use RegisterServices
 func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sdk.Querier {

--- a/ignite/templates/module/create/stargate/x/{{moduleName}}/types/keys.go.plush
+++ b/ignite/templates/module/create/stargate/x/{{moduleName}}/types/keys.go.plush
@@ -7,11 +7,8 @@ const (
 	// StoreKey defines the primary module store key
 	StoreKey = ModuleName
 
-	// RouterKey is the message route for slashing
+	// RouterKey defines the module's message routing key
 	RouterKey = ModuleName
-
-    // QuerierRoute defines the module's query routing key
-    QuerierRoute = ModuleName
 
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_<%= moduleName %>"


### PR DESCRIPTION
`QuerierRoute` key is used only in the deprecated `QuerierRoute` function. Might as well simplify the template right now. Also, fixed a comment.