### PR TITLE
fix: go formatting require go 1.18

### DIFF
--- a/.github/workflows/go-formatting.yml
+++ b/.github/workflows/go-formatting.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Install Go
         uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
 
       - name: Run make format
         run: make format


### PR DESCRIPTION
Surprisingly, actions/setup-go doesn't fetch the latest go version. We
need to specify 1.18 because we use some generics.