### PR TITLE
refactor: use `cosmossdk.io/math` package

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Upgraded Cosmos SDK to v0.46.0 and IBC to v5 in CLI and scaffolding templates
 - Removed `handler.go` from scaffolded module template
+- Migrated to `cosmossdk.io` packages for `errors` and `math`
 
 ### Fixes
 - Improved error handling for crypto wrapper functions

--- a/docs/docs/guide/08-interchange/05-mint-and-burn-voucher.md
+++ b/docs/docs/guide/08-interchange/05-mint-and-burn-voucher.md
@@ -27,11 +27,12 @@ Create a new `x/dex/keeper/mint.go` file:
 package keeper
 
 import (
-  "fmt"
-  "strings"
+   "fmt"
+   "strings"
 
-  sdk "github.com/cosmos/cosmos-sdk/types"
-  ibctransfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
+   sdkmath "cosmossdk.io/math"
+   sdk "github.com/cosmos/cosmos-sdk/types"
+   ibctransfertypes "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types"
 
   "interchange/x/dex/types"
 )
@@ -45,12 +46,12 @@ func isIBCToken(denom string) bool {
 func (k Keeper) SafeBurn(ctx sdk.Context, port string, channel string, sender sdk.AccAddress, denom string, amount int32) error {
   if isIBCToken(denom) {
     // Burn the tokens
-    if err := k.BurnTokens(ctx, sender, sdk.NewCoin(denom, sdk.NewInt(int64(amount)))); err != nil {
+    if err := k.BurnTokens(ctx, sender, sdk.NewCoin(denom, sdkmath.NewInt(int64(amount)))); err != nil {
       return err
     }
   } else {
     // Lock the tokens
-    if err := k.LockTokens(ctx, port, channel, sender, sdk.NewCoin(denom, sdk.NewInt(int64(amount)))); err != nil {
+    if err := k.LockTokens(ctx, port, channel, sender, sdk.NewCoin(denom, sdkmath.NewInt(int64(amount)))); err != nil {
       return err
     }
   }
@@ -215,7 +216,7 @@ Go back to the `x/dex/keeper/mint.go` file and add the following code:
 func (k Keeper) SafeMint(ctx sdk.Context, port string, channel string, receiver sdk.AccAddress, denom string, amount int32) error {
 	if isIBCToken(denom) {
 		// Mint IBC tokens
-		if err := k.MintTokens(ctx, receiver, sdk.NewCoin(denom, sdk.NewInt(int64(amount)))); err != nil {
+		if err := k.MintTokens(ctx, receiver, sdk.NewCoin(denom, sdkmath.NewInt(int64(amount)))); err != nil {
 			return err
 		}
 	} else {
@@ -225,7 +226,7 @@ func (k Keeper) SafeMint(ctx sdk.Context, port string, channel string, receiver 
 			port,
 			channel,
 			receiver,
-			sdk.NewCoin(denom, sdk.NewInt(int64(amount))),
+			sdk.NewCoin(denom, sdkmath.NewInt(int64(amount))),
 		); err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ignite/cli
 go 1.18
 
 require (
+	cosmossdk.io/math v1.0.0-beta.3
 	github.com/99designs/keyring v1.2.1
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/blang/semver v3.5.1+incompatible
@@ -65,7 +66,6 @@ require (
 
 require (
 	cosmossdk.io/errors v1.0.0-beta.7 // indirect
-	cosmossdk.io/math v1.0.0-beta.3 // indirect
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
@@ -81,7 +82,7 @@ func Account(name, mnemonic string, coinType string) Option {
 // denom is denomination of the coin to be distributed by the faucet.
 func Coin(amount, maxAmount uint64, denom string) Option {
 	return func(f *Faucet) {
-		f.coins = append(f.coins, sdk.NewCoin(denom, sdk.NewIntFromUint64(amount)))
+		f.coins = append(f.coins, sdk.NewCoin(denom, sdkmath.NewIntFromUint64(amount)))
 		f.coinsMax[denom] = maxAmount
 	}
 }

--- a/ignite/pkg/cosmosutil/gentx.go
+++ b/ignite/pkg/cosmosutil/gentx.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/tendermint/tendermint/crypto/ed25519"
-
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
 var GentxFilename = "gentx.json"
@@ -82,7 +82,7 @@ func ParseGentx(gentx []byte) (info GentxInfo, file []byte, err error) {
 		return info, gentx, fmt.Errorf("invalid validator public key %s", err.Error())
 	}
 
-	amount, ok := sdk.NewIntFromString(stargateGentx.Body.Messages[0].Value.Amount)
+	amount, ok := sdkmath.NewIntFromString(stargateGentx.Body.Messages[0].Value.Amount)
 	if !ok {
 		return info, gentx, errors.New("the self-delegation inside the gentx is invalid")
 	}

--- a/ignite/pkg/cosmosutil/gentx_test.go
+++ b/ignite/pkg/cosmosutil/gentx_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -31,7 +32,7 @@ func TestParseGentx(t *testing.T) {
 				PubKey:           ed25519.PubKey(pk1),
 				SelfDelegation: sdk.Coin{
 					Denom:  "stake",
-					Amount: sdk.NewInt(95000000),
+					Amount: sdkmath.NewInt(95000000),
 				},
 				Memo: "9b1f4adbfb0c0b513040d914bfb717303c0eaa71@192.168.0.148:26656",
 			},
@@ -43,7 +44,7 @@ func TestParseGentx(t *testing.T) {
 				PubKey:           ed25519.PubKey(pk2),
 				SelfDelegation: sdk.Coin{
 					Denom:  "stake",
-					Amount: sdk.NewInt(95000000),
+					Amount: sdkmath.NewInt(95000000),
 				},
 				Memo: "a412c917cb29f73cc3ad0592bbd0152fe0e690bd@192.168.0.148:26656",
 			},

--- a/ignite/services/network/join_test.go
+++ b/ignite/services/network/join_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestJoin(t *testing.T) {
 					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
-					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
+					SelfDelegation: sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt)),
 					Peer: launchtypes.Peer{
 						Id: testutil.NodeID,
 						Connection: &launchtypes.Peer_TcpAddress{
@@ -100,7 +101,7 @@ func TestJoin(t *testing.T) {
 					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
-					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
+					SelfDelegation: sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt)),
 					Peer: launchtypes.Peer{
 						Id: testutil.NodeID,
 						Connection: &launchtypes.Peer_TcpAddress{
@@ -147,7 +148,7 @@ func TestJoin(t *testing.T) {
 					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
-					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
+					SelfDelegation: sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt)),
 					Peer: launchtypes.Peer{
 						Id: testutil.NodeID,
 						Connection: &launchtypes.Peer_TcpAddress{
@@ -200,7 +201,7 @@ func TestJoin(t *testing.T) {
 					ValAddress:     addr,
 					GenTx:          gentx.JSON(t),
 					ConsPubKey:     []byte{},
-					SelfDelegation: sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)),
+					SelfDelegation: sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt)),
 					Peer: launchtypes.Peer{
 						Id: testutil.NodeID,
 						Connection: &launchtypes.Peer_TcpAddress{
@@ -222,7 +223,7 @@ func TestJoin(t *testing.T) {
 					Creator:  addr,
 					LaunchID: testutil.LaunchID,
 					Address:  addr,
-					Coins:    sdk.NewCoins(sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt))),
+					Coins:    sdk.NewCoins(sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt))),
 				},
 			).
 			Return(testutil.NewResponse(&launchtypes.MsgRequestAddAccountResponse{
@@ -236,7 +237,7 @@ func TestJoin(t *testing.T) {
 			suite.ChainMock,
 			testutil.LaunchID,
 			gentxPath,
-			WithAccountRequest(sdk.NewCoins(sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)))),
+			WithAccountRequest(sdk.NewCoins(sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt)))),
 			WithPublicAddress(testutil.TCPAddress),
 		)
 		require.NoError(t, joinErr)

--- a/ignite/services/network/networktypes/genesisinformation_test.go
+++ b/ignite/services/network/networktypes/genesisinformation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
@@ -11,7 +12,7 @@ import (
 	"github.com/ignite/cli/ignite/services/network/networktypes"
 )
 
-var sampleCoins = sdk.NewCoins(sdk.NewCoin("bar", sdk.NewInt(1000)), sdk.NewCoin("foo", sdk.NewInt(2000)))
+var sampleCoins = sdk.NewCoins(sdk.NewCoin("bar", sdkmath.NewInt(1000)), sdk.NewCoin("foo", sdkmath.NewInt(2000)))
 
 func TestToGenesisAccount(t *testing.T) {
 	tests := []struct {
@@ -124,14 +125,14 @@ func TestGenesisInformation_ApplyRequest(t *testing.T) {
 		[]networktypes.GenesisAccount{
 			{
 				Address: "spn1g50xher44l9hjuatjdfxgv254jh2wgzfs55yu3",
-				Coins:   sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(1000))),
+				Coins:   sdk.NewCoins(sdk.NewCoin("foo", sdkmath.NewInt(1000))),
 			},
 		},
 		[]networktypes.VestingAccount{
 			{
 				Address:      "spn1gkzf4e0x6wr4djfd8h82v6cy507gy5v4spaus3",
-				TotalBalance: sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(1000))),
-				Vesting:      sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(500))),
+				TotalBalance: sdk.NewCoins(sdk.NewCoin("foo", sdkmath.NewInt(1000))),
+				Vesting:      sdk.NewCoins(sdk.NewCoin("foo", sdkmath.NewInt(500))),
 				EndTime:      time.Now().Unix(),
 			},
 		},

--- a/ignite/services/network/networktypes/request_test.go
+++ b/ignite/services/network/networktypes/request_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
@@ -47,7 +48,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
 					ConsPubKey:     ed25519.PubKey(pk),
-					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
+					SelfDelegation: sdk.NewCoin("stake", sdkmath.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
 			},
@@ -59,7 +60,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
 					ConsPubKey:     ed25519.PubKey(pk),
-					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
+					SelfDelegation: sdk.NewCoin("stake", sdkmath.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "122.114.800.11"),
 				},
 			},
@@ -72,7 +73,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          []byte(`{}`),
 					ConsPubKey:     ed25519.PubKey(pk),
-					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
+					SelfDelegation: sdk.NewCoin("stake", sdkmath.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
 			},
@@ -85,7 +86,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
 					ConsPubKey:     ed25519.PubKey(pk),
-					SelfDelegation: sdk.NewCoin("foo", sdk.NewInt(95000000)),
+					SelfDelegation: sdk.NewCoin("foo", sdkmath.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
 			},
@@ -98,7 +99,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
 					ConsPubKey:     ed25519.PubKey(pk),
-					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(3)),
+					SelfDelegation: sdk.NewCoin("stake", sdkmath.NewInt(3)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
 			},
@@ -111,7 +112,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 					Address:        "spn1dd246yq6z5vzjz9gh8cff46pll75yyl8c5tt7g",
 					GenTx:          gentx,
 					ConsPubKey:     ed25519.PubKey("cosmos1gkheudhhjsvq0s8fxt7p6pwe0k3k30kepcnz9p="),
-					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
+					SelfDelegation: sdk.NewCoin("stake", sdkmath.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
 			},
@@ -124,7 +125,7 @@ func TestVerifyAddValidatorRequest(t *testing.T) {
 					Address:        "spn1gkheudhhjsvq0s8fxt7p6pwe0k3k30keaytytm",
 					GenTx:          gentx,
 					ConsPubKey:     ed25519.PubKey(pk),
-					SelfDelegation: sdk.NewCoin("stake", sdk.NewInt(95000000)),
+					SelfDelegation: sdk.NewCoin("stake", sdkmath.NewInt(95000000)),
 					Peer:           launchtypes.NewPeerConn("nodeid", "127.163.0.1:2446"),
 				},
 			},

--- a/ignite/services/network/reward_test.go
+++ b/ignite/services/network/reward_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 	rewardtypes "github.com/tendermint/spn/x/reward/types"
 
 	"github.com/ignite/cli/ignite/services/network/networktypes"
@@ -18,7 +18,7 @@ func TestSetReward(t *testing.T) {
 		var (
 			account         = testutil.NewTestAccount(t, testutil.TestAccountName)
 			suite, network  = newSuite(account)
-			coins           = sdk.NewCoins(sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)))
+			coins           = sdk.NewCoins(sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt)))
 			lastRewarHeight = int64(10)
 		)
 
@@ -52,7 +52,7 @@ func TestSetReward(t *testing.T) {
 		var (
 			account         = testutil.NewTestAccount(t, testutil.TestAccountName)
 			suite, network  = newSuite(account)
-			coins           = sdk.NewCoins(sdk.NewCoin(TestDenom, sdk.NewInt(TestAmountInt)))
+			coins           = sdk.NewCoins(sdk.NewCoin(TestDenom, sdkmath.NewInt(TestAmountInt)))
 			lastRewarHeight = int64(10)
 			expectedErr     = errors.New("failed to set reward")
 		)

--- a/ignite/services/network/share_percent_test.go
+++ b/ignite/services/network/share_percent_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ignite/cli/ignite/services/network"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ignite/cli/ignite/services/network"
 )
 
 func TestParseSharePercentages(t *testing.T) {

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -32,7 +33,7 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	} {
@@ -64,7 +65,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{}
 	args = append(args, fields...)
@@ -119,7 +120,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{}
 	args = append(args, fields...)

--- a/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -5,6 +5,7 @@ import (
     "strconv"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -40,7 +41,7 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	} {
@@ -74,7 +75,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{
         <%= for (i, index) in Indexes { %>"0",
@@ -138,7 +139,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{
         <%= for (i, index) in Indexes { %>"0",

--- a/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -31,7 +32,7 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	} {
@@ -62,7 +63,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     var args []string
 	args = append(args, fields...)
@@ -109,7 +110,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     var args []string
 	args = append(args, fields...)


### PR DESCRIPTION
Use the `cosmossdk.io/math` package instead of the math types found in `github.com/cosmos/cosmos-sdk/types`.  

As of `v0.46.x` the old type aliases are deprecated.