### PR TITLE
refactor: use `cosmossdk.io/errors` package

### DIFF
--- a/docs/docs/guide/03-blog/01-comment-blog.md
+++ b/docs/docs/guide/03-blog/01-comment-blog.md
@@ -156,7 +156,7 @@ You need to do the following things:
 import (
     // ...
 
-    sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+    sdkerrors "cosmossdk.io/errors"
 
     // ...
 )
@@ -167,7 +167,7 @@ func (k msgServer) CreateComment(goCtx context.Context, msg *types.MsgCreateComm
 	// Check if the Post Exists for which a comment is being created
 	post, found := k.GetPost(ctx, msg.PostID)
 	if !found {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
 	}
 
 	// Create variable of type comment
@@ -362,7 +362,7 @@ package keeper
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"blog/x/blog/types"
  )

--- a/docs/docs/guide/04-nameservice/04-keeper.md
+++ b/docs/docs/guide/04-nameservice/04-keeper.md
@@ -30,7 +30,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"nameservice/x/nameservice/types"
 )
@@ -57,7 +57,7 @@ func (k msgServer) BuyName(goCtx context.Context, msg *types.MsgBuyName) (*types
 		// If the current price is higher than the bid
 		if price.IsAllGT(bid) {
 			// Throw an error
-			return nil, sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, "Bid is not high enough")
+			return nil, sdkerrors.Wrap(sdkerrortypes.ErrInsufficientFunds, "Bid is not high enough")
 		}
 
 		// Otherwise (when the bid is higher), send tokens from the buyer to the owner
@@ -66,7 +66,7 @@ func (k msgServer) BuyName(goCtx context.Context, msg *types.MsgBuyName) (*types
 		// If the minimum price is higher than the bid
 		if minPrice.IsAllGT(bid) {
 			// Throw an error
-			return nil, sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, "Bid is less than min amount")
+			return nil, sdkerrors.Wrap(sdkerrortypes.ErrInsufficientFunds, "Bid is less than min amount")
 		}
 
 		// Otherwise (when the bid is higher), send tokens from the buyer's account to the module's account (as a payment for the name)
@@ -124,7 +124,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"nameservice/x/nameservice/types"
 )
@@ -137,7 +137,7 @@ func (k msgServer) SetName(goCtx context.Context, msg *types.MsgSetName) (*types
 
 	// If the message sender address doesn't match the name owner, throw an error
 	if !(msg.Creator == whois.Owner) {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "Incorrect Owner")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "Incorrect Owner")
 	}
 
 	// Otherwise, create an updated whois record
@@ -168,7 +168,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"nameservice/x/nameservice/types"
 )
@@ -181,12 +181,12 @@ func (k msgServer) DeleteName(goCtx context.Context, msg *types.MsgDeleteName) (
 
 	// If a name is not found, throw an error
 	if !isFound {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Name doesn't exist")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "Name doesn't exist")
 	}
 
 	// If the message sender address doesn't match the name owner, throw an error
 	if !(whois.Owner == msg.Creator) {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "Incorrect Owner")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "Incorrect Owner")
 	}
 
 	// Otherwise, remove the name information from the store

--- a/docs/docs/guide/05-scavenge/07-keeper.md
+++ b/docs/docs/guide/05-scavenge/07-keeper.md
@@ -23,7 +23,7 @@ import (
   "context"
 
   sdk "github.com/cosmos/cosmos-sdk/types"
-  sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+  sdkerrors "cosmossdk.io/errors"
   "github.com/tendermint/tendermint/crypto"
 
   "scavenge/x/scavenge/types"
@@ -46,7 +46,7 @@ func (k msgServer) SubmitScavenge(goCtx context.Context, msg *types.MsgSubmitSca
 
 	// return an error if a scavenge already exists in the store
 	if isFound {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Scavenge with that solution hash already exists")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "Scavenge with that solution hash already exists")
 	}
 
 	// get address of the Scavenge module account
@@ -112,7 +112,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"scavenge/x/scavenge/types"
 )
@@ -132,7 +132,7 @@ func (k msgServer) CommitSolution(goCtx context.Context, msg *types.MsgCommitSol
 
 	// return an error if a commit already exists in the store
 	if isFound {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Commit with that hash already exists")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "Commit with that hash already exists")
 	}
 
 	// write commit to the store
@@ -162,7 +162,7 @@ import (
 	"encoding/hex"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 	"github.com/tendermint/tendermint/crypto"
 
 	"scavenge/x/scavenge/types"
@@ -185,7 +185,7 @@ func (k msgServer) RevealSolution(goCtx context.Context, msg *types.MsgRevealSol
 
 	// return an error if a commit doesn't exist
 	if !isFound {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Commit with that hash doesn't exists")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "Commit with that hash doesn't exists")
 	}
 
 	// find a hash of the solution
@@ -200,7 +200,7 @@ func (k msgServer) RevealSolution(goCtx context.Context, msg *types.MsgRevealSol
 
 	// return an error if the solution doesn't exist
 	if !isFound {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Scavenge with that solution hash doesn't exists")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "Scavenge with that solution hash doesn't exists")
 	}
 
 	// check that the scavenger property contains a valid address
@@ -208,7 +208,7 @@ func (k msgServer) RevealSolution(goCtx context.Context, msg *types.MsgRevealSol
 
 	// return an error if a scavenge has already been solved
 	if err == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Scavenge has already been solved")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "Scavenge has already been solved")
 	}
 
 	// save the scavebger address to the scavenge

--- a/docs/docs/guide/06-loan.md
+++ b/docs/docs/guide/06-loan.md
@@ -244,28 +244,28 @@ Add the following code to the `ValidateBasic()` function in the `x/loan/types/me
 ```go
 func (msg *MsgRequestLoan) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(msg.Creator); err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
 
 	amount, _ := sdk.ParseCoinsNormalized(msg.Amount)
 	if !amount.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "amount is not a valid Coins object")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "amount is not a valid Coins object")
 	}
 	if amount.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "amount is empty")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "amount is empty")
 	}
 
 	fee, _ := sdk.ParseCoinsNormalized(msg.Fee)
 	if !fee.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "fee is not a valid Coins object")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "fee is not a valid Coins object")
 	}
 
 	collateral, _ := sdk.ParseCoinsNormalized(msg.Collateral)
 	if !collateral.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "collateral is not a valid Coins object")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "collateral is not a valid Coins object")
 	}
 	if collateral.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "collateral is empty")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "collateral is empty")
 	}
 
 	return nil
@@ -346,7 +346,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"loan/x/loan/types"
 )
@@ -356,7 +356,7 @@ func (k msgServer) ApproveLoan(goCtx context.Context, msg *types.MsgApproveLoan)
 
 	loan, found := k.GetLoan(ctx, msg.Id)
 	if !found {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrKeyNotFound, "key %d doesn't exist", msg.Id)
+		return nil, sdkerrors.Wrapf(sdkerrortypes.ErrKeyNotFound, "key %d doesn't exist", msg.Id)
 	}
 
 	// TODO: for some reason the error doesn't get printed to the terminal
@@ -406,7 +406,7 @@ package types
 // DONTCOVER
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 )
 
 // x/loan module sentinel errors
@@ -501,7 +501,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"loan/x/loan/types"
 )
@@ -511,7 +511,7 @@ func (k msgServer) RepayLoan(goCtx context.Context, msg *types.MsgRepayLoan) (*t
 
 	loan, found := k.GetLoan(ctx, msg.Id)
 	if !found {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
 	}
 
 	if loan.State != "approved" {
@@ -522,7 +522,7 @@ func (k msgServer) RepayLoan(goCtx context.Context, msg *types.MsgRepayLoan) (*t
 	borrower, _ := sdk.AccAddressFromBech32(loan.Borrower)
 
 	if msg.Creator != loan.Borrower {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "Cannot repay: not the borrower")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "Cannot repay: not the borrower")
 	}
 
 	amount, _ := sdk.ParseCoinsNormalized(loan.Amount)
@@ -661,7 +661,7 @@ import (
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"loan/x/loan/types"
 )
@@ -671,11 +671,11 @@ func (k msgServer) LiquidateLoan(goCtx context.Context, msg *types.MsgLiquidateL
 
 	loan, found := k.GetLoan(ctx, msg.Id)
 	if !found {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
 	}
 
 	if loan.Lender != msg.Creator {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "Cannot liquidate: not the lender")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "Cannot liquidate: not the lender")
 	}
 
 	if loan.State != "approved" {
@@ -712,7 +712,7 @@ package types
 // DONTCOVER
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 )
 
 // x/loan module sentinel errors
@@ -821,7 +821,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 
 	"loan/x/loan/types"
 )
@@ -831,11 +831,11 @@ func (k msgServer) CancelLoan(goCtx context.Context, msg *types.MsgCancelLoan) (
 
 	loan, found := k.GetLoan(ctx, msg.Id)
 	if !found {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
 	}
 
 	if loan.Borrower != msg.Creator {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "Cannot cancel: not the borrower")
+		return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "Cannot cancel: not the borrower")
 	}
 
 	if loan.State != "requested" {

--- a/ignite/pkg/cosmosaccount/cosmosaccount.go
+++ b/ignite/pkg/cosmosaccount/cosmosaccount.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	dkeyring "github.com/99designs/keyring"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -17,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/go-bip39"
 )
 
@@ -272,7 +271,7 @@ func unsafeExportPrivKeyHex(kr keyring.Keyring, uid, passphrase string) (privkey
 // GetByName returns an account by its name.
 func (r Registry) GetByName(name string) (Account, error) {
 	record, err := r.Keyring.Key(name)
-	if errors.Is(err, dkeyring.ErrKeyNotFound) || errors.Is(err, sdkerrors.ErrKeyNotFound) {
+	if errors.Is(err, dkeyring.ErrKeyNotFound) || errors.Is(err, sdkerrortypes.ErrKeyNotFound) {
 		return Account{}, &AccountDoesNotExistError{name}
 	}
 	if err != nil {
@@ -294,7 +293,7 @@ func (r Registry) GetByAddress(address string) (Account, error) {
 		return Account{}, err
 	}
 	record, err := r.Keyring.KeyByAddress(sdkAddr)
-	if errors.Is(err, dkeyring.ErrKeyNotFound) || errors.Is(err, sdkerrors.ErrKeyNotFound) {
+	if errors.Is(err, dkeyring.ErrKeyNotFound) || errors.Is(err, sdkerrortypes.ErrKeyNotFound) {
 		return Account{}, &AccountDoesNotExistError{address}
 	}
 	if err != nil {

--- a/ignite/pkg/cosmosclient/txservice.go
+++ b/ignite/pkg/cosmosclient/txservice.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 type TxService struct {
@@ -43,7 +43,7 @@ func (s TxService) Broadcast() (Response, error) {
 	}
 
 	resp, err := s.clientContext.BroadcastTx(txBytes)
-	if err == sdkerrors.ErrInsufficientFunds {
+	if err == sdkerrortypes.ErrInsufficientFunds {
 		err = s.client.makeSureAccountHasTokens(context.Background(), accountAddress.String())
 		if err != nil {
 			return Response{}, err

--- a/ignite/pkg/cosmosibckeeper/keeper.go
+++ b/ignite/pkg/cosmosibckeeper/keeper.go
@@ -1,9 +1,9 @@
 package cosmosibckeeper
 
 import (
+	sdkerrors "cosmossdk.io/errors"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v5/modules/core/24-host"

--- a/ignite/templates/ibc/oracle.go
+++ b/ignite/templates/ibc/oracle.go
@@ -85,7 +85,7 @@ func moduleOracleModify(replacer placeholder.Replacer, opts *OracleOptions) genn
 		// Recv packet dispatch
 		templateRecv := `oracleAck, err := im.handleOraclePacket(ctx, modulePacket)
 	if err != nil {
-		return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: "+err.Error()))
+		return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrap(sdkerrortypes.ErrUnknownRequest, "cannot unmarshal packet data: "+err.Error()))
 	} else if ack != oracleAck {
 		return oracleAck
 	}
@@ -305,7 +305,7 @@ func packetHandlerOracleModify(replacer placeholder.Replacer, opts *OracleOption
 		var %[2]vResult types.%[3]vResult
 		if err := obi.Decode(modulePacketData.Result, &%[2]vResult); err != nil {
 			ack = channeltypes.NewErrorAcknowledgement(err)
-			return ack, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest,
+			return ack, sdkerrors.Wrap(sdkerrortypes.ErrUnknownRequest,
 				"cannot decode the %[2]v received packet")
 		}
 		im.keeper.Set%[3]vResult(ctx, types.OracleRequestID(modulePacketData.RequestID), %[2]vResult)

--- a/ignite/templates/ibc/oracle/x/{{moduleName}}/keeper/msg_{{queryName}}.go.plush
+++ b/ignite/templates/ibc/oracle/x/{{moduleName}}/keeper/msg_{{queryName}}.go.plush
@@ -4,10 +4,11 @@ import (
 	"context"
 	"time"
 
+    sdkerrors "cosmossdk.io/errors"
     "github.com/bandprotocol/bandchain-packet/obi"
 	"github.com/bandprotocol/bandchain-packet/packet"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
     channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
     host "github.com/cosmos/ibc-go/v5/modules/core/24-host"
@@ -23,7 +24,7 @@ func (k msgServer) <%= queryName.UpperCamel %>Data(goCtx context.Context, msg *t
 	sourceChannelEnd, found := k.ChannelKeeper.GetChannel(ctx, sourcePort, msg.SourceChannel)
 	if !found {
 		return nil, sdkerrors.Wrapf(
-			sdkerrors.ErrUnknownRequest,
+			sdkerrortypes.ErrUnknownRequest,
 			"unknown channel %s port %s",
 			msg.SourceChannel,
 			sourcePort,

--- a/ignite/templates/ibc/oracle/x/{{moduleName}}/keeper/{{queryName}}.go.plush
+++ b/ignite/templates/ibc/oracle/x/{{moduleName}}/keeper/{{queryName}}.go.plush
@@ -3,7 +3,6 @@ package keeper
 import (
     sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	gogotypes "github.com/gogo/protobuf/types"
 	"<%= ModulePath %>/x/<%= moduleName %>/types"
 )

--- a/ignite/templates/ibc/oracle/x/{{moduleName}}/keeper/{{queryName}}.go.plush
+++ b/ignite/templates/ibc/oracle/x/{{moduleName}}/keeper/{{queryName}}.go.plush
@@ -1,8 +1,9 @@
 package keeper
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	gogotypes "github.com/gogo/protobuf/types"
 	"<%= ModulePath %>/x/<%= moduleName %>/types"
 )

--- a/ignite/templates/ibc/oracle/x/{{moduleName}}/oracle.go.plush
+++ b/ignite/templates/ibc/oracle/x/{{moduleName}}/oracle.go.plush
@@ -1,10 +1,11 @@
 package <%= moduleName %>
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	"github.com/bandprotocol/bandchain-packet/obi"
 	"github.com/bandprotocol/bandchain-packet/packet"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	"<%= ModulePath %>/x/<%= moduleName %>/types"
 )
@@ -25,7 +26,7 @@ func (im IBCModule) handleOraclePacket(
 	// this line is used by starport scaffolding # oracle/module/recv
 
 	default:
-		err := sdkerrors.Wrapf(sdkerrors.ErrJSONUnmarshal,
+		err := sdkerrors.Wrapf(sdkerrortypes.ErrJSONUnmarshal,
 			"oracle received packet not found: %s", modulePacketData.GetClientID())
 		ack = channeltypes.NewErrorAcknowledgement(err)
 		return ack, err
@@ -64,7 +65,7 @@ func (im IBCModule) handleOracleAcknowledgment(
 		// this line is used by starport scaffolding # oracle/module/ack
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrJSONUnmarshal,
+			return nil, sdkerrors.Wrapf(sdkerrortypes.ErrJSONUnmarshal,
 				"oracle acknowledgment packet not found: %s", data.GetClientID())
 		}
 	}

--- a/ignite/templates/ibc/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
+++ b/ignite/templates/ibc/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
@@ -2,7 +2,7 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const TypeMsg<%= queryName.UpperCamel %>Data = "<%= queryName.Snake %>_data"
@@ -75,10 +75,10 @@ func (m *Msg<%= queryName.UpperCamel %>Data) GetSignBytes() []byte {
 func (m *Msg<%= queryName.UpperCamel %>Data) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.<%= MsgSigner.UpperCamel %>)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+		return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
 	}
 	if m.SourceChannel == "" {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid source channel")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "invalid source channel")
 	}
 	return nil
 }

--- a/ignite/templates/ibc/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
+++ b/ignite/templates/ibc/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
@@ -1,6 +1,7 @@
 package types
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )

--- a/ignite/templates/ibc/oracle/x/{{moduleName}}/types/{{queryName}}_test.go.plush
+++ b/ignite/templates/ibc/oracle/x/{{moduleName}}/types/{{queryName}}_test.go.plush
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"<%= ModulePath %>/testutil/sample"
 )
@@ -20,14 +20,14 @@ func TestMsg<%= queryName.UpperCamel %>Data_ValidateBasic(t *testing.T) {
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 				SourceChannel: "channel-0",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "invalid source channel",
 			msg: Msg<%= queryName.UpperCamel %>Data{
 				<%= MsgSigner.UpperCamel %>: sample.AccAddress(),
 				SourceChannel: "",
 			},
-			err: sdkerrors.ErrInvalidRequest,
+			err: sdkerrortypes.ErrInvalidRequest,
 		}, {
 			name: "valid message",
 			msg: Msg<%= queryName.UpperCamel %>Data{

--- a/ignite/templates/ibc/packet.go
+++ b/ignite/templates/ibc/packet.go
@@ -115,7 +115,7 @@ func moduleModify(replacer placeholder.Replacer, opts *PacketOptions) genny.RunF
 		// Encode packet acknowledgment
 		packetAckBytes, err := types.ModuleCdc.MarshalJSON(&packetAck)
 		if err != nil {
-			return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error()))
+			return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrap(sdkerrortypes.ErrJSONMarshal, err.Error()))
 		}
 		ack = channeltypes.NewResultAcknowledgement(sdk.MustSortJSON(packetAckBytes))
 	}

--- a/ignite/templates/ibc/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
+++ b/ignite/templates/ibc/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
@@ -3,8 +3,9 @@ package keeper
 import (
     "errors"
 
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"<%= ModulePath %>/x/<%= moduleName %>/types"
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
@@ -45,7 +46,7 @@ func (k Keeper) Transmit<%= packetName.UpperCamel %>Packet(
 
     packetBytes, err := packetData.GetBytes()
     if err != nil {
-        return sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, "cannot marshal the packet: " + err.Error())
+        return sdkerrors.Wrap(sdkerrortypes.ErrJSONMarshal, "cannot marshal the packet: " + err.Error())
     }
 
     packet := channeltypes.NewPacket(

--- a/ignite/templates/ibc/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}.go.plush
+++ b/ignite/templates/ibc/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}.go.plush
@@ -1,8 +1,9 @@
 package types
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const TypeMsgSend<%= packetName.UpperCamel %> = "send_<%= packetName.Snake %>"
@@ -49,16 +50,16 @@ func (msg *MsgSend<%= packetName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgSend<%= packetName.UpperCamel %>) ValidateBasic() error {
     _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
     if err != nil {
-        return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+        return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
     }
 	if msg.Port == "" {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid packet port")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "invalid packet port")
 	}
 	if msg.ChannelID == "" {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid packet channel")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "invalid packet channel")
 	}
 	if msg.TimeoutTimestamp == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid packet timeout")
+		return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "invalid packet timeout")
 	}
     return nil
 }

--- a/ignite/templates/ibc/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}_test.go.plush
+++ b/ignite/templates/ibc/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}_test.go.plush
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"<%= ModulePath %>/testutil/sample"
 )
@@ -22,7 +22,7 @@ func TestMsgSend<%= packetName.UpperCamel %>_ValidateBasic(t *testing.T) {
 				ChannelID:        "channel-0",
 				TimeoutTimestamp: 100,
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "invalid port",
 			msg: MsgSend<%= packetName.UpperCamel %>{
@@ -31,7 +31,7 @@ func TestMsgSend<%= packetName.UpperCamel %>_ValidateBasic(t *testing.T) {
 				ChannelID:        "channel-0",
 				TimeoutTimestamp: 100,
 			},
-			err: sdkerrors.ErrInvalidRequest,
+			err: sdkerrortypes.ErrInvalidRequest,
 		}, {
 			name: "invalid channel",
 			msg: MsgSend<%= packetName.UpperCamel %>{
@@ -40,7 +40,7 @@ func TestMsgSend<%= packetName.UpperCamel %>_ValidateBasic(t *testing.T) {
 				ChannelID:        "",
 				TimeoutTimestamp: 100,
 			},
-			err: sdkerrors.ErrInvalidRequest,
+			err: sdkerrortypes.ErrInvalidRequest,
 		}, {
 			name: "invalid timeout",
 			msg: MsgSend<%= packetName.UpperCamel %>{
@@ -49,7 +49,7 @@ func TestMsgSend<%= packetName.UpperCamel %>_ValidateBasic(t *testing.T) {
 				ChannelID:        "channel-0",
 				TimeoutTimestamp: 0,
 			},
-			err: sdkerrors.ErrInvalidRequest,
+			err: sdkerrortypes.ErrInvalidRequest,
 		}, {
 			name: "valid message",
 			msg: MsgSend<%= packetName.UpperCamel %>{

--- a/ignite/templates/message/stargate/message/x/{{moduleName}}/types/message_{{msgName}}.go.plush
+++ b/ignite/templates/message/stargate/message/x/{{moduleName}}/types/message_{{msgName}}.go.plush
@@ -1,8 +1,9 @@
 package types
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const TypeMsg<%= MsgName.UpperCamel %> = "<%= MsgName.Snake %>"
@@ -40,7 +41,7 @@ func (msg *Msg<%= MsgName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *Msg<%= MsgName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
-  		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+  		return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   	}
   return nil
 }

--- a/ignite/templates/message/stargate/message/x/{{moduleName}}/types/message_{{msgName}}_test.go.plush
+++ b/ignite/templates/message/stargate/message/x/{{moduleName}}/types/message_{{msgName}}_test.go.plush
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"<%= ModulePath %>/testutil/sample"
 )
@@ -19,7 +19,7 @@ func TestMsg<%= MsgName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: Msg<%= MsgName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: Msg<%= MsgName.UpperCamel %>{

--- a/ignite/templates/module/create/ibc/x/{{moduleName}}/module_ibc.go.plush
+++ b/ignite/templates/module/create/ibc/x/{{moduleName}}/module_ibc.go.plush
@@ -3,8 +3,9 @@ package <%= moduleName %>
 import (
 	"fmt"
 
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	channeltypes "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v5/modules/core/05-port/types"
@@ -126,7 +127,7 @@ func (im IBCModule) OnChanCloseInit(
 	channelID string,
 ) error {
 	// Disallow user-initiated channel closing for channels
-	return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "user cannot close channel")
+	return sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "user cannot close channel")
 }
 
 // OnChanCloseConfirm implements the IBCModule interface
@@ -150,7 +151,7 @@ func (im IBCModule) OnRecvPacket(
 
 	var modulePacketData types.<%= title(moduleName) %>PacketData
 	if err := modulePacketData.Unmarshal(modulePacket.GetData()); err != nil {
-		return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error()))
+		return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrapf(sdkerrortypes.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error()))
 	}
 
 	// Dispatch packet
@@ -174,14 +175,14 @@ func (im IBCModule) OnAcknowledgementPacket(
 ) error {
 	var ack channeltypes.Acknowledgement
 	if err := types.ModuleCdc.UnmarshalJSON(acknowledgement, &ack); err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet acknowledgement: %v", err)
+		return sdkerrors.Wrapf(sdkerrortypes.ErrUnknownRequest, "cannot unmarshal packet acknowledgement: %v", err)
 	}
 
 	// this line is used by starport scaffolding # oracle/packet/module/ack
 
 	var modulePacketData types.<%= title(moduleName) %>PacketData
 	if err := modulePacketData.Unmarshal(modulePacket.GetData()); err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error())
+		return sdkerrors.Wrapf(sdkerrortypes.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error())
 	}
 
 	var eventType string
@@ -191,7 +192,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 	// this line is used by starport scaffolding # ibc/packet/module/ack
 	default:
 		errMsg := fmt.Sprintf("unrecognized %s packet type: %T", types.ModuleName, packet)
-		return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+		return sdkerrors.Wrap(sdkerrortypes.ErrUnknownRequest, errMsg)
 	}
 
     ctx.EventManager().EmitEvent(
@@ -230,7 +231,7 @@ func (im IBCModule) OnTimeoutPacket(
 ) error {
 	var modulePacketData types.<%= title(moduleName) %>PacketData
 	if err := modulePacketData.Unmarshal(modulePacket.GetData()); err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error())
+		return sdkerrors.Wrapf(sdkerrortypes.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error())
 	}
 
 	// Dispatch packet
@@ -238,7 +239,7 @@ func (im IBCModule) OnTimeoutPacket(
         // this line is used by starport scaffolding # ibc/packet/module/timeout
         default:
             errMsg := fmt.Sprintf("unrecognized %s packet type: %T", types.ModuleName, packet)
-            return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
+            return sdkerrors.Wrap(sdkerrortypes.ErrUnknownRequest, errMsg)
     }
 
     return nil

--- a/ignite/templates/module/create/stargate/x/{{moduleName}}/types/errors.go.plush
+++ b/ignite/templates/module/create/stargate/x/{{moduleName}}/types/errors.go.plush
@@ -3,7 +3,7 @@ package types
 // DONTCOVER
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "cosmossdk.io/errors"
 )
 
 // x/<%= moduleName %> module sentinel errors

--- a/ignite/templates/typed/list/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}.go.plush
+++ b/ignite/templates/typed/list/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}.go.plush
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"<%= ModulePath %>/x/<%= ModuleName %>/types"
 	"google.golang.org/grpc/codes"
@@ -48,7 +48,7 @@ func (k Keeper) <%= TypeName.UpperCamel %>(c context.Context, req *types.QueryGe
 	ctx := sdk.UnwrapSDKContext(c)
 	<%= TypeName.LowerCamel %>, found := k.Get<%= TypeName.UpperCamel %>(ctx, req.Id)
 	if !found {
-		return nil, sdkerrors.ErrKeyNotFound
+		return nil, sdkerrortypes.ErrKeyNotFound
 	}
 
 	return &types.QueryGet<%= TypeName.UpperCamel %>Response{<%= TypeName.UpperCamel %>: <%= TypeName.LowerCamel %>}, nil

--- a/ignite/templates/typed/list/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -38,7 +38,7 @@ func Test<%= TypeName.UpperCamel %>QuerySingle(t *testing.T) {
 		{
 			desc:    "KeyNotFound",
 			request: &types.QueryGet<%= TypeName.UpperCamel %>Request{Id: uint64(len(msgs))},
-			err:     sdkerrors.ErrKeyNotFound,
+			err:     sdkerrortypes.ErrKeyNotFound,
 		},
 		{
 			desc: "InvalidRequest",

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
 	"<%= ModulePath %>/testutil/network"
@@ -88,7 +88,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 			desc: "key not found",
 			id:   "1",
 			args: common,
-			code: sdkerrors.ErrKeyNotFound.ABCICode(),
+			code: sdkerrortypes.ErrKeyNotFound.ABCICode(),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -143,7 +143,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 			desc: "key not found",
 			id:   "1",
 			args: common,
-			code: sdkerrors.ErrKeyNotFound.ABCICode(),
+			code: sdkerrortypes.ErrKeyNotFound.ABCICode(),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}.go.plush
@@ -4,9 +4,11 @@ import (
     "fmt"
 	"context"
 
-    "<%= ModulePath %>/x/<%= ModuleName %>/types"
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"<%= ModulePath %>/x/<%= ModuleName %>/types"
 )
 
 
@@ -40,12 +42,12 @@ func (k msgServer) Update<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
     // Checks that the element exists
     val, found := k.Get<%= TypeName.UpperCamel %>(ctx, msg.Id)
     if !found {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
     }
 
     // Checks if the msg <%= MsgSigner.LowerCamel %> is the same as the current owner
     if msg.<%= MsgSigner.UpperCamel %> != val.Creator {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "incorrect owner")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "incorrect owner")
     }
 
 	k.Set<%= TypeName.UpperCamel %>(ctx, <%= TypeName.LowerCamel %>)
@@ -59,12 +61,12 @@ func (k msgServer) Delete<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
     // Checks that the element exists
     val, found := k.Get<%= TypeName.UpperCamel %>(ctx, msg.Id)
     if !found {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
     }
 
     // Checks if the msg <%= MsgSigner.LowerCamel %> is the same as the current owner
     if msg.<%= MsgSigner.UpperCamel %> != val.Creator {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "incorrect owner")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "incorrect owner")
     }
 
 	k.Remove<%= TypeName.UpperCamel %>(ctx, msg.Id)

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
@@ -3,7 +3,7 @@ package keeper_test
 import (
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
@@ -34,12 +34,12 @@ func Test<%= TypeName.UpperCamel %>MsgServerUpdate(t *testing.T) {
 		{
 			desc:    "Unauthorized",
 			request: &types.MsgUpdate<%= TypeName.UpperCamel %>{<%= MsgSigner.UpperCamel %>: "B"},
-			err:     sdkerrors.ErrUnauthorized,
+			err:     sdkerrortypes.ErrUnauthorized,
 		},
 		{
 			desc:    "Unauthorized",
 			request: &types.MsgUpdate<%= TypeName.UpperCamel %>{<%= MsgSigner.UpperCamel %>: <%= MsgSigner.LowerCamel %>, Id: 10},
-			err:     sdkerrors.ErrKeyNotFound,
+			err:     sdkerrortypes.ErrKeyNotFound,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -72,12 +72,12 @@ func Test<%= TypeName.UpperCamel %>MsgServerDelete(t *testing.T) {
 		{
 			desc:    "Unauthorized",
 			request: &types.MsgDelete<%= TypeName.UpperCamel %>{<%= MsgSigner.UpperCamel %>: "B"},
-			err:     sdkerrors.ErrUnauthorized,
+			err:     sdkerrortypes.ErrUnauthorized,
 		},
 		{
 			desc:    "KeyNotFound",
 			request: &types.MsgDelete<%= TypeName.UpperCamel %>{<%= MsgSigner.UpperCamel %>: <%= MsgSigner.LowerCamel %>, Id: 10},
-			err:     sdkerrors.ErrKeyNotFound,
+			err:     sdkerrortypes.ErrKeyNotFound,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -1,8 +1,9 @@
 package types
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const (
@@ -44,7 +45,7 @@ func (msg *MsgCreate<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgCreate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
-  		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+  		return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   	}
   return nil
 }
@@ -83,7 +84,7 @@ func (msg *MsgUpdate<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgUpdate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
-    return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+    return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   }
    return nil
 }
@@ -120,7 +121,7 @@ func (msg *MsgDelete<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgDelete<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
-    return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+    return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   }
   return nil
 }

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}_test.go.plush
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"<%= ModulePath %>/testutil/sample"
 )
@@ -19,7 +19,7 @@ func TestMsgCreate<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgCreate<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgCreate<%= TypeName.UpperCamel %>{
@@ -50,7 +50,7 @@ func TestMsgUpdate<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgUpdate<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgUpdate<%= TypeName.UpperCamel %>{
@@ -81,7 +81,7 @@ func TestMsgDelete<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgDelete<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgDelete<%= TypeName.UpperCamel %>{

--- a/ignite/templates/typed/map/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}.go.plush
+++ b/ignite/templates/typed/map/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}.go.plush
@@ -5,7 +5,7 @@ import (
 
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 
@@ -18,7 +18,7 @@ func (k msgServer) Create<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
         <%= for (i, index) in Indexes { %>msg.<%= index.Name.UpperCamel %>,
         <% } %>)
     if isFound {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "index already set")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "index already set")
     }
 
     var <%= TypeName.LowerCamel %> = types.<%= TypeName.UpperCamel %>{
@@ -44,12 +44,12 @@ func (k msgServer) Update<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
         <%= for (i, index) in Indexes { %>msg.<%= index.Name.UpperCamel %>,
     <% } %>)
     if !isFound {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, "index not set")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, "index not set")
     }
 
     // Checks if the the msg <%= MsgSigner.LowerCamel %> is the same as the current owner
     if msg.<%= MsgSigner.UpperCamel %> != valFound.<%= MsgSigner.UpperCamel %> {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "incorrect owner")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "incorrect owner")
     }
 
     var <%= TypeName.LowerCamel %> = types.<%= TypeName.UpperCamel %>{
@@ -73,12 +73,12 @@ func (k msgServer) Delete<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
         <%= for (i, index) in Indexes { %>msg.<%= index.Name.UpperCamel %>,
     <% } %>)
     if !isFound {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, "index not set")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, "index not set")
     }
 
     // Checks if the the msg <%= MsgSigner.LowerCamel %> is the same as the current owner
     if msg.<%= MsgSigner.UpperCamel %> != valFound.<%= MsgSigner.UpperCamel %> {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "incorrect owner")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "incorrect owner")
     }
 
 	k.Remove<%= TypeName.UpperCamel %>(

--- a/ignite/templates/typed/map/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/map/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -1,8 +1,9 @@
 package types
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const (
@@ -51,7 +52,7 @@ func (msg *MsgCreate<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgCreate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
-  		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+  		return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   	}
   return nil
 }
@@ -96,7 +97,7 @@ func (msg *MsgUpdate<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgUpdate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
-    return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+    return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   }
    return nil
 }
@@ -138,7 +139,7 @@ func (msg *MsgDelete<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgDelete<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
-    return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+    return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   }
   return nil
 }

--- a/ignite/templates/typed/map/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}_test.go.plush
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"<%= ModulePath %>/testutil/sample"
 )
@@ -19,7 +19,7 @@ func TestMsgCreate<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgCreate<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgCreate<%= TypeName.UpperCamel %>{
@@ -50,7 +50,7 @@ func TestMsgUpdate<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgUpdate<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgUpdate<%= TypeName.UpperCamel %>{
@@ -81,7 +81,7 @@ func TestMsgDelete<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgDelete<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgDelete<%= TypeName.UpperCamel %>{

--- a/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
 	"<%= ModulePath %>/testutil/network"
@@ -104,7 +104,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 			<%= for (i, index) in Indexes { %>id<%= index.Name.UpperCamel %>: <%= index.ValueInvalidIndex() %>,
             <% } %>
 			args: common,
-			code: sdkerrors.ErrKeyNotFound.ABCICode(),
+			code: sdkerrortypes.ErrKeyNotFound.ABCICode(),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 			<%= for (i, index) in Indexes { %>id<%= index.Name.UpperCamel %>: <%= index.ValueInvalidIndex() %>,
             <% } %>
 			args: common,
-			code: sdkerrors.ErrKeyNotFound.ABCICode(),
+			code: sdkerrortypes.ErrKeyNotFound.ABCICode(),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
     keepertest "<%= ModulePath %>/testutil/keeper"
@@ -58,7 +58,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerUpdate(t *testing.T) {
 			    <%= for (i, index) in Indexes { %><%= index.Name.UpperCamel %>: <%= index.ValueIndex() %>,
                 <% } %>
 			},
-			err:     sdkerrors.ErrUnauthorized,
+			err:     sdkerrortypes.ErrUnauthorized,
 		},
 		{
 			desc:    "KeyNotFound",
@@ -66,7 +66,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerUpdate(t *testing.T) {
 			    <%= for (i, index) in Indexes { %><%= index.Name.UpperCamel %>: <%= index.ValueInvalidIndex() %>,
                 <% } %>
 			},
-			err:     sdkerrors.ErrKeyNotFound,
+			err:     sdkerrortypes.ErrKeyNotFound,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -117,7 +117,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerDelete(t *testing.T) {
 			    <%= for (i, index) in Indexes { %><%= index.Name.UpperCamel %>: <%= index.ValueIndex() %>,
                 <% } %>
 			},
-			err:     sdkerrors.ErrUnauthorized,
+			err:     sdkerrortypes.ErrUnauthorized,
 		},
 		{
 			desc:    "KeyNotFound",
@@ -125,7 +125,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerDelete(t *testing.T) {
 			    <%= for (i, index) in Indexes { %><%= index.Name.UpperCamel %>: <%= index.ValueInvalidIndex() %>,
                 <% } %>
 			},
-			err:     sdkerrors.ErrKeyNotFound,
+			err:     sdkerrortypes.ErrKeyNotFound,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}.go.plush
+++ b/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}.go.plush
@@ -5,7 +5,7 @@ import (
 
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 
@@ -15,7 +15,7 @@ func (k msgServer) Create<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
     // Check if the value already exists
     _, isFound := k.Get<%= TypeName.UpperCamel %>(ctx)
     if isFound {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "already set")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrInvalidRequest, "already set")
     }
 
     var <%= TypeName.LowerCamel %> = types.<%= TypeName.UpperCamel %>{
@@ -36,12 +36,12 @@ func (k msgServer) Update<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
     // Check if the value exists
     valFound, isFound := k.Get<%= TypeName.UpperCamel %>(ctx)
     if !isFound {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, "not set")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, "not set")
     }
 
     // Checks if the the msg <%= MsgSigner.LowerCamel %> is the same as the current owner
     if msg.<%= MsgSigner.UpperCamel %> != valFound.<%= MsgSigner.UpperCamel %> {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "incorrect owner")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "incorrect owner")
     }
 
     var <%= TypeName.LowerCamel %> = types.<%= TypeName.UpperCamel %>{
@@ -60,12 +60,12 @@ func (k msgServer) Delete<%= TypeName.UpperCamel %>(goCtx context.Context,  msg 
     // Check if the value exists
     valFound, isFound := k.Get<%= TypeName.UpperCamel %>(ctx)
     if !isFound {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, "not set")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrKeyNotFound, "not set")
     }
 
     // Checks if the the msg <%= MsgSigner.LowerCamel %> is the same as the current owner
     if msg.<%= MsgSigner.UpperCamel %> != valFound.<%= MsgSigner.UpperCamel %> {
-        return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "incorrect owner")
+        return nil, sdkerrors.Wrap(sdkerrortypes.ErrUnauthorized, "incorrect owner")
     }
 
 	k.Remove<%= TypeName.UpperCamel %>(ctx)

--- a/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
     keepertest "<%= ModulePath %>/testutil/keeper"
@@ -40,7 +40,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerUpdate(t *testing.T) {
 		{
 			desc:    "Unauthorized",
 			request: &types.MsgUpdate<%= TypeName.UpperCamel %>{<%= MsgSigner.UpperCamel %>: "B"},
-			err:     sdkerrors.ErrUnauthorized,
+			err:     sdkerrortypes.ErrUnauthorized,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -79,7 +79,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerDelete(t *testing.T) {
 		{
 			desc:    "Unauthorized",
 			request: &types.MsgDelete<%= TypeName.UpperCamel %>{<%= MsgSigner.UpperCamel %>: "B"},
-			err:     sdkerrors.ErrUnauthorized,
+			err:     sdkerrortypes.ErrUnauthorized,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -1,8 +1,9 @@
 package types
 
 import (
+    sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const (
@@ -44,7 +45,7 @@ func (msg *MsgCreate<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgCreate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
-  		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+  		return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   	}
   return nil
 }
@@ -82,7 +83,7 @@ func (msg *MsgUpdate<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgUpdate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
-    return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+    return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   }
    return nil
 }
@@ -118,7 +119,7 @@ func (msg *MsgDelete<%= TypeName.UpperCamel %>) GetSignBytes() []byte {
 func (msg *MsgDelete<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
-    return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
+    return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   }
   return nil
 }

--- a/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/types/messages_{{typeName}}_test.go.plush
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"<%= ModulePath %>/testutil/sample"
 )
@@ -19,7 +19,7 @@ func TestMsgCreate<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgCreate<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgCreate<%= TypeName.UpperCamel %>{
@@ -50,7 +50,7 @@ func TestMsgUpdate<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgUpdate<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgUpdate<%= TypeName.UpperCamel %>{
@@ -81,7 +81,7 @@ func TestMsgDelete<%= TypeName.UpperCamel %>_ValidateBasic(t *testing.T) {
 			msg: MsgDelete<%= TypeName.UpperCamel %>{
 				<%= MsgSigner.UpperCamel %>: "invalid_address",
 			},
-			err: sdkerrors.ErrInvalidAddress,
+			err: sdkerrortypes.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: MsgDelete<%= TypeName.UpperCamel %>{


### PR DESCRIPTION
Use the `cosmossdk.io/errors` package instead of the errors types found in `github.com/cosmos/cosmos-sdk/types`.  

As of `v0.46.x` the old type aliases are deprecated.

The defined error types (such as `ErrInsufficientFunds`) still exist under the `cosmos/cosmos-sdk` path.

The two new imports are:
```go
    sdkerrors "cosmossdk.io/errors"
    sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
```