### PR TITLE
feat: remove placeholders from `codec.go`

### DIFF
--- a/ignite/pkg/cosmosanalysis/cosmosanalysis_test.go
+++ b/ignite/pkg/cosmosanalysis/cosmosanalysis_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ignite/cli/ignite/pkg/cosmosanalysis"
@@ -202,9 +201,4 @@ func TestFindAppFilePath(t *testing.T) {
 	pathFound, err = cosmosanalysis.FindAppFilePath(tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(appFolder, "app.go"), pathFound)
-}
-
-func TestSomething(t *testing.T) {
-	err := errors.New("")
-	require.NoError(t, err)
 }

--- a/ignite/pkg/cosmosanalysis/cosmosanalysis_test.go
+++ b/ignite/pkg/cosmosanalysis/cosmosanalysis_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ignite/cli/ignite/pkg/cosmosanalysis"
@@ -201,4 +202,9 @@ func TestFindAppFilePath(t *testing.T) {
 	pathFound, err = cosmosanalysis.FindAppFilePath(tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(appFolder, "app.go"), pathFound)
+}
+
+func TestSomething(t *testing.T) {
+	err := errors.New("")
+	require.NoError(t, err)
 }

--- a/ignite/templates/module/create/stargate/x/{{moduleName}}/types/codec.go.plush
+++ b/ignite/templates/module/create/stargate/x/{{moduleName}}/types/codec.go.plush
@@ -8,11 +8,10 @@ import (
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	// this line is used by starport scaffolding # 2
+
 } 
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
-	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }


### PR DESCRIPTION
This is just a quick "what if". Not meant to be merged, because it's quick and dirty.

What if instead of placeholders we did quick `ast.Inspect` searches and added code to the right places?

The code in this PR just searches for `RegisterCodec` function in `x/module/types/codec.go` and adds the required code inside if found. The template becomes placeholder-less:

```go
func RegisterCodec(cdc *codec.LegacyAmino) {
}

func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
}
```

I've just made the change in `map` scaffolding.

This of course can be improved by recursively looking for the function in other files. wdyt?