### PR TITLE
ci: various improvements

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20

--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    open-pull-requests-limit: 20
   - package-ecosystem: gomod
     directory: "/"
     schedule:

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: golangci/golangci-lint-action@master
         if: env.GIT_DIFF
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45.2
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version, and the way to do that is to just use the word latest.
+          version: latest
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     paths-ignore:
-      - '**.md'
+      - "**.md"
     branches:
       - master
       - develop
@@ -21,10 +21,10 @@ jobs:
             go.mod
             go.sum
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         if: env.GIT_DIFF
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: golangci/golangci-lint-action@master
         if: env.GIT_DIFF
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,7 @@ run:
   tests: false
   skip-dirs:
     - ignite/ui
-#   # timeout for analysis, e.g. 30s, 5m, default is 1m
-#   timeout: 5m
+  timeout: 5m
 
 linters:
   disable-all: true
@@ -12,13 +11,11 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    # - errcheck
+    - errcheck
     - goconst
     - gocritic
-    - gofmt
-    - goimports
+    - gofumpt
     - revive
-    # - gosec
     - gosimple
     - govet
     - ineffassign
@@ -28,7 +25,6 @@ linters:
     - nakedret
     - exportloopref
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
@@ -36,7 +32,7 @@ linters:
     - unparam
     - misspell
     # - wsl
-    # - nolintlint
+    - nolintlint
 
 issues:
   max-issues-per-linter: 0

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- enableed errcheck in golangci-lint
 - Upgraded Cosmos SDK to v0.46.0 and IBC to v5 in CLI and scaffolding templates
 - Removed `handler.go` from scaffolded module template
 - Migrated to `cosmossdk.io` packages for `errors` and `math`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ignite/cli
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/math v1.0.0-beta.3

--- a/ignite/cmd/node_query_bank_balances.go
+++ b/ignite/cmd/node_query_bank_balances.go
@@ -1,8 +1,6 @@
 package ignitecmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ignite/cli/ignite/pkg/cliui"
@@ -54,7 +52,7 @@ func nodeQueryBankBalancesHandler(cmd *cobra.Command, args []string) error {
 
 	var rows [][]string
 	for _, b := range balances {
-		rows = append(rows, []string{fmt.Sprintf("%s", b.Amount), b.Denom})
+		rows = append(rows, []string{b.Amount.String(), b.Denom})
 	}
 
 	session.StopSpinner()

--- a/ignite/cmd/scaffold_module.go
+++ b/ignite/cmd/scaffold_module.go
@@ -202,10 +202,8 @@ func scaffoldModuleHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	_, err = io.Copy(cmd.OutOrStdout(), &msg)
-	if err != nil {
-		return err
-	}
-	return nil
+	
+	return err
 }
 
 // in previously scaffolded apps gov keeper is defined below the scaffolded module keeper definition

--- a/ignite/cmd/scaffold_module.go
+++ b/ignite/cmd/scaffold_module.go
@@ -201,7 +201,10 @@ func scaffoldModuleHandler(cmd *cobra.Command, args []string) error {
 		dependencyWarning(dependencies)
 	}
 
-	io.Copy(cmd.OutOrStdout(), &msg)
+	_, err = io.Copy(cmd.OutOrStdout(), &msg)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/ignite/internal/tools/gen-cli-docs/main.go
+++ b/ignite/internal/tools/gen-cli-docs/main.go
@@ -86,7 +86,10 @@ func generateCmd(cmd *cobra.Command, w io.Writer) error {
 			continue
 		}
 
-		io.WriteString(w, "\n")
+		_, err := io.WriteString(w, "\n")
+		if err != nil {
+			return err
+		}
 
 		if err := generateCmd(cmd, w); err != nil {
 			return err

--- a/ignite/pkg/cliui/clispinner/clispinner.go
+++ b/ignite/pkg/cliui/clispinner/clispinner.go
@@ -46,7 +46,7 @@ func New(options ...Option) *Spinner {
 
 	sp := spinner.New(charset, refreshRate, underlyingSpinnerOptions...)
 
-	sp.Color(spinnerColor)
+	sp.Color(spinnerColor) //nolint:errcheck
 	s := &Spinner{
 		sp: sp,
 	}
@@ -77,7 +77,7 @@ func (s *Spinner) SetCharset(charset []string) *Spinner {
 
 // SetColor sets the prefix for spinner.
 func (s *Spinner) SetColor(color string) *Spinner {
-	s.sp.Color(color)
+	s.sp.Color(color) //nolint:errcheck
 	return s
 }
 
@@ -91,7 +91,7 @@ func (s *Spinner) Start() *Spinner {
 func (s *Spinner) Stop() *Spinner {
 	s.sp.Stop()
 	s.sp.Prefix = ""
-	s.sp.Color(spinnerColor)
+	s.sp.Color(spinnerColor) //nolint:errcheck
 	s.sp.UpdateCharSet(charset)
 	s.sp.Stop()
 	return s

--- a/ignite/pkg/cmdrunner/cmdrunner.go
+++ b/ignite/pkg/cmdrunner/cmdrunner.go
@@ -182,7 +182,7 @@ type cmdSignal struct {
 	*exec.Cmd
 }
 
-func (e *cmdSignal) Signal(s os.Signal) { e.Cmd.Process.Signal(s) }
+func (e *cmdSignal) Signal(s os.Signal) { e.Cmd.Process.Signal(s) } //nolint:errcheck
 
 func (e *cmdSignal) Write(data []byte) (n int, err error) { return 0, nil }
 
@@ -192,7 +192,7 @@ type cmdSignalWithWriter struct {
 	w io.WriteCloser
 }
 
-func (e *cmdSignalWithWriter) Signal(s os.Signal) { e.Cmd.Process.Signal(s) }
+func (e *cmdSignalWithWriter) Signal(s os.Signal) { e.Cmd.Process.Signal(s) } //nolint:errcheck
 
 func (e *cmdSignalWithWriter) Write(data []byte) (n int, err error) {
 	defer e.w.Close()

--- a/ignite/pkg/cosmoscmd/proxy.go
+++ b/ignite/pkg/cosmoscmd/proxy.go
@@ -47,7 +47,7 @@ func startProxyForTunneledPeers(clientCtx client.Context, cmd *cobra.Command) {
 		if peer.Name == networkchain.HTTPTunnelChisel {
 			peer := peer
 			go func() {
-				ctxticker.DoNow(ctx, TunnelRerunDelay, func() error {
+				ctxticker.DoNow(ctx, TunnelRerunDelay, func() error { //nolint:errcheck
 					serverCtx.Logger.Info("Starting chisel client", "tunnelAddress", peer.Address, "localPort", peer.LocalPort)
 					err := xchisel.StartClient(ctx, peer.Address, peer.LocalPort, "26656")
 					if err != nil {
@@ -65,7 +65,7 @@ func startProxyForTunneledPeers(clientCtx client.Context, cmd *cobra.Command) {
 
 	if gitpod.IsOnGitpod() {
 		go func() {
-			ctxticker.DoNow(ctx, TunnelRerunDelay, func() error {
+			ctxticker.DoNow(ctx, TunnelRerunDelay, func() error { //nolint:errcheck
 				serverCtx.Logger.Info("Starting chisel server", "port", xchisel.DefaultServerPort)
 				err := xchisel.StartServer(ctx, xchisel.DefaultServerPort)
 				if err != nil {

--- a/ignite/pkg/cosmoscmd/root.go
+++ b/ignite/pkg/cosmoscmd/root.go
@@ -309,7 +309,7 @@ func overwriteFlagDefaults(c *cobra.Command, defaults map[string]string) {
 	set := func(s *pflag.FlagSet, key, val string) {
 		if f := s.Lookup(key); f != nil {
 			f.DefValue = val
-			f.Value.Set(val)
+			f.Value.Set(val) //nolint:errcheck
 		}
 	}
 	for key, val := range defaults {

--- a/ignite/pkg/cosmosfaucet/http_faucet.go
+++ b/ignite/pkg/cosmosfaucet/http_faucet.go
@@ -68,7 +68,7 @@ type FaucetInfoResponse struct {
 }
 
 func (f Faucet) faucetInfoHandler(w http.ResponseWriter, r *http.Request) {
-	xhttp.ResponseJSON(w, http.StatusOK, FaucetInfoResponse{
+	xhttp.ResponseJSON(w, http.StatusOK, FaucetInfoResponse{ //nolint:errcheck
 		IsAFaucet: true,
 		ChainID:   f.chainID,
 	})
@@ -93,11 +93,11 @@ func (f Faucet) coinsFromRequest(req TransferRequest) (sdk.Coins, error) {
 }
 
 func responseSuccess(w http.ResponseWriter) {
-	xhttp.ResponseJSON(w, http.StatusOK, TransferResponse{})
+	xhttp.ResponseJSON(w, http.StatusOK, TransferResponse{}) //nolint:errcheck
 }
 
 func responseError(w http.ResponseWriter, code int, err error) {
-	xhttp.ResponseJSON(w, code, TransferResponse{
+	xhttp.ResponseJSON(w, code, TransferResponse{ //nolint:errcheck
 		Error: err.Error(),
 	})
 }

--- a/ignite/pkg/cosmosfaucet/http_openapi.go
+++ b/ignite/pkg/cosmosfaucet/http_openapi.go
@@ -21,5 +21,5 @@ type openAPIData struct {
 }
 
 func (f Faucet) openAPISpecHandler(w http.ResponseWriter, r *http.Request) {
-	tmplOpenAPISpec.Execute(w, f.openAPIData)
+	tmplOpenAPISpec.Execute(w, f.openAPIData) //nolint:errcheck
 }

--- a/ignite/pkg/looseerrgroup/looseerrgroup.go
+++ b/ignite/pkg/looseerrgroup/looseerrgroup.go
@@ -14,7 +14,7 @@ import (
 func Wait(ctx context.Context, g *errgroup.Group) error {
 	doneC := make(chan struct{})
 
-	go func() { g.Wait(); close(doneC) }()
+	go func() { g.Wait(); close(doneC) }() //nolint:errcheck
 
 	select {
 	case <-ctx.Done():

--- a/ignite/pkg/openapiconsole/console.go
+++ b/ignite/pkg/openapiconsole/console.go
@@ -14,7 +14,7 @@ func Handler(title, specURL string) http.HandlerFunc {
 	t, _ := template.ParseFS(index, "index.tpl")
 
 	return func(w http.ResponseWriter, req *http.Request) {
-		t.Execute(w, struct {
+		t.Execute(w, struct { //nolint:errcheck
 			Title string
 			URL   string
 		}{

--- a/ignite/pkg/xgenny/run.go
+++ b/ignite/pkg/xgenny/run.go
@@ -64,7 +64,7 @@ func RunWithValidation(
 			fileName := file.Name()
 			_, err := os.Stat(fileName)
 
-			// nolint:gocritic
+			//nolint:gocritic
 			if os.IsNotExist(err) {
 				// if the file doesn't exist in the source, it means it has been created by the runner
 				sm.AppendCreatedFiles(fileName)

--- a/ignite/pkg/xgenny/xgenny.go
+++ b/ignite/pkg/xgenny/xgenny.go
@@ -35,7 +35,7 @@ func (w Walker) walkDir(wl packd.WalkFunc, path string) error {
 
 	for _, entry := range entries {
 		if entry.IsDir() {
-			w.walkDir(wl, filepath.Join(path, entry.Name()))
+			w.walkDir(wl, filepath.Join(path, entry.Name())) //nolint:errcheck
 			continue
 		}
 
@@ -53,7 +53,7 @@ func (w Walker) walkDir(wl packd.WalkFunc, path string) error {
 			return err
 		}
 
-		wl(ppath, f)
+		wl(ppath, f) //nolint:errcheck
 	}
 
 	return nil

--- a/ignite/pkg/xhttp/response.go
+++ b/ignite/pkg/xhttp/response.go
@@ -16,7 +16,7 @@ func ResponseJSON(w http.ResponseWriter, status int, data interface{}) error {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	w.Write(bdata)
+	w.Write(bdata) //nolint:errcheck
 	return err
 }
 

--- a/ignite/pkg/xhttp/server.go
+++ b/ignite/pkg/xhttp/server.go
@@ -18,7 +18,7 @@ func Serve(ctx context.Context, s *http.Server) error {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), ShutdownTimeout)
 		defer cancel()
 
-		s.Shutdown(shutdownCtx)
+		s.Shutdown(shutdownCtx) //nolint:errcheck
 	}()
 
 	err := s.ListenAndServe()

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -342,7 +342,7 @@ func (c *Chain) serve(ctx context.Context, cacheStorage cache.Storage, forceRese
 	}
 
 	// init phase
-	// nolint:gocritic
+	//nolint:gocritic
 	if !isInit || (appModified && !exportGenesisExists) {
 		fmt.Fprintln(c.stdLog().out, "💿 Initializing the app...")
 

--- a/ignite/services/network/network.go
+++ b/ignite/services/network/network.go
@@ -43,7 +43,7 @@ type Network struct {
 	stakingQuery            stakingtypes.QueryClient
 	bankQuery               banktypes.QueryClient
 	monitoringConsumerQuery monitoringctypes.QueryClient
-	monitoringProviderQuery monitoringptypes.QueryClient //nolint:unused
+	monitoringProviderQuery monitoringptypes.QueryClient
 }
 
 //go:generate mockery --name Chain --case underscore

--- a/ignite/services/network/network.go
+++ b/ignite/services/network/network.go
@@ -43,7 +43,7 @@ type Network struct {
 	stakingQuery            stakingtypes.QueryClient
 	bankQuery               banktypes.QueryClient
 	monitoringConsumerQuery monitoringctypes.QueryClient
-	monitoringProviderQuery monitoringptypes.QueryClient
+	monitoringProviderQuery monitoringptypes.QueryClient //nolint:unused
 }
 
 //go:generate mockery --name Chain --case underscore

--- a/ignite/services/scaffolder/init.go
+++ b/ignite/services/scaffolder/init.go
@@ -88,7 +88,7 @@ func generate(
 	}
 
 	run := func(runner *genny.Runner, gen *genny.Generator) error {
-		runner.With(gen)
+		runner.With(gen) //nolint:errcheck
 		runner.Root = absRoot
 		return runner.Run()
 	}


### PR DESCRIPTION
This PR improves the ignite cli's CI flows:

* gofumpt instead of both gofmt and goimports
* enables errcheck
* bumps go to v1.19
* enables nolintlint
* uses the correct version of golangci-lint
* adds dependabot