### PR TITLE
chore: sdk 46 idioms (import nothing with "rest")

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/takuoki/gocase v1.0.0
 	github.com/tendermint/flutter/v2 v2.0.4
-	github.com/tendermint/spn v0.2.1-0.20220826123316-985b629a92dd
+	github.com/tendermint/spn v0.2.1-0.20220901140430-c65411cd5ab4
 	github.com/tendermint/tendermint v0.34.21
 	github.com/tendermint/tm-db v0.6.7
 	github.com/tendermint/vue v0.3.5
@@ -237,7 +237,7 @@ require (
 	golang.org/x/net v0.0.0-20220726230323-06994584191e // indirect
 	golang.org/x/sys v0.0.0-20220727055044-e65921a090b8 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
-	google.golang.org/genproto v0.0.0-20220805133916-01dd62135a58 // indirect
+	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -892,6 +892,7 @@ github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHL
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ignite/modules v0.0.0-20220830145312-d006783a7a21 h1:2eqRFOwuBtP5prBIslVokLwLkXqekbY4cENDf2mEyxQ=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -1473,8 +1474,8 @@ github.com/tendermint/flutter/v2 v2.0.4/go.mod h1:hnaVhWhzv2Od1LqZFWrRKwiOHeMons
 github.com/tendermint/fundraising v0.3.1 h1:S4uOV/T7YNBqXhsCZnq/TUoHB0d2kM+6tKeTD4WhLN0=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
-github.com/tendermint/spn v0.2.1-0.20220826123316-985b629a92dd h1:G50RK8x61pNFGVSAI5UmXaBDA4h/P2+SDdftha9jjSM=
-github.com/tendermint/spn v0.2.1-0.20220826123316-985b629a92dd/go.mod h1:5eAAx0g6FEXubQ1Sb7zJcDZqCSjb9yoJMVOQwjEt9qQ=
+github.com/tendermint/spn v0.2.1-0.20220901140430-c65411cd5ab4 h1:ygChw+C8EWL75bCSjrzAkF5CP0an5IoQgMxHAluWC1A=
+github.com/tendermint/spn v0.2.1-0.20220901140430-c65411cd5ab4/go.mod h1:CMzd3oBkjR9I1h/BEaU1K2V78XqARFWGjxPP9Xy/FIE=
 github.com/tendermint/tendermint v0.34.21 h1:UiGGnBFHVrZhoQVQ7EfwSOLuCtarqCSsRf8VrklqB7s=
 github.com/tendermint/tendermint v0.34.21/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
 github.com/tendermint/tm-db v0.6.7 h1:fE00Cbl0jayAoqlExN6oyQJ7fR/ZtoVOmvPJ//+shu8=
@@ -1736,7 +1737,7 @@ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c h1:q3gFqPqH7NVofKo3c3yETAP//pPI+G5mvB7qqj1Y5kY=
+golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 h1:2o1E+E8TpNLklK9nHiPiK1uzIYrIHt+cQx3ynCwq9V8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -2056,8 +2057,8 @@ google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210126160654-44e461bb6506/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20220805133916-01dd62135a58 h1:sRT5xdTkj1Kbk30qbYC7VyMj73N5pZYsw6v+Nrzdhno=
-google.golang.org/genproto v0.0.0-20220805133916-01dd62135a58/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
+google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc h1:Nf+EdcTLHR8qDNN/KfkQL0u0ssxt9OhbaWCl5C0ucEI=
+google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/ignite/pkg/cosmosanalysis/app/testdata/app_full.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/app_full.go
@@ -11,7 +11,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmodule "github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	authrest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 	"github.com/cosmos/cosmos-sdk/x/bank"

--- a/ignite/services/network/launch.go
+++ b/ignite/services/network/launch.go
@@ -30,8 +30,8 @@ func (n Network) TriggerLaunch(ctx context.Context, launchID uint64, remainingTi
 	}
 
 	var (
-		minLaunch = xtime.Seconds(params.LaunchTimeRange.MinLaunchTime)
-		maxLaunch = xtime.Seconds(params.LaunchTimeRange.MaxLaunchTime)
+		minLaunch = params.LaunchTimeRange.MinLaunchTime
+		maxLaunch = params.LaunchTimeRange.MaxLaunchTime
 	)
 	address, err := n.account.Address(networktypes.SPN)
 	if err != nil {
@@ -52,7 +52,7 @@ func (n Network) TriggerLaunch(ctx context.Context, launchID uint64, remainingTi
 			xtime.NowAfter(maxLaunch))
 	}
 
-	msg := launchtypes.NewMsgTriggerLaunch(address, launchID, int64(remainingTime.Seconds()))
+	msg := launchtypes.NewMsgTriggerLaunch(address, launchID, remainingTime)
 	n.ev.Send(events.New(events.StatusOngoing, "Setting launch time"))
 	res, err := n.cosmos.BroadcastTx(n.account, msg)
 	if err != nil {

--- a/ignite/services/network/launch_test.go
+++ b/ignite/services/network/launch_test.go
@@ -41,9 +41,8 @@ func TestTriggerLaunch(t *testing.T) {
 			On("BroadcastTx",
 				account,
 				&launchtypes.MsgTriggerLaunch{
-					Coordinator:   addr,
-					LaunchID:      testutil.LaunchID,
-					RemainingTime: TestMaxRemainingTime,
+					Coordinator: addr,
+					LaunchID:    testutil.LaunchID,
 				}).
 			Return(testutil.NewResponse(&launchtypes.MsgTriggerLaunchResponse{}), nil).
 			Once()
@@ -123,9 +122,8 @@ func TestTriggerLaunch(t *testing.T) {
 			On("BroadcastTx",
 				account,
 				&launchtypes.MsgTriggerLaunch{
-					Coordinator:   addr,
-					LaunchID:      testutil.LaunchID,
-					RemainingTime: TestMaxRemainingTime,
+					Coordinator: addr,
+					LaunchID:    testutil.LaunchID,
 				}).
 			Return(testutil.NewResponse(&launchtypes.MsgTriggerLaunch{}), expectedError).
 			Once()
@@ -156,9 +154,8 @@ func TestTriggerLaunch(t *testing.T) {
 			On("BroadcastTx",
 				account,
 				&launchtypes.MsgTriggerLaunch{
-					Coordinator:   addr,
-					LaunchID:      testutil.LaunchID,
-					RemainingTime: TestMaxRemainingTime,
+					Coordinator: addr,
+					LaunchID:    testutil.LaunchID,
 				}).
 			Return(testutil.NewResponse(&launchtypes.MsgCreateChainResponse{}), expectedError).
 			Once()

--- a/ignite/services/network/networktypes/chainlaunch.go
+++ b/ignite/services/network/networktypes/chainlaunch.go
@@ -33,11 +33,6 @@ func (n NetworkType) String() string {
 
 // ToChainLaunch converts a chain launch data from SPN and returns a ChainLaunch object
 func ToChainLaunch(chain launchtypes.Chain) ChainLaunch {
-	var launchTime int64
-	if chain.LaunchTriggered {
-		launchTime = chain.LaunchTimestamp
-	}
-
 	network := NetworkTypeTestnet
 	if chain.IsMainnet {
 		network = NetworkTypeMainnet
@@ -49,7 +44,6 @@ func ToChainLaunch(chain launchtypes.Chain) ChainLaunch {
 		ChainID:                chain.GenesisChainID,
 		SourceURL:              chain.SourceURL,
 		SourceHash:             chain.SourceHash,
-		LaunchTime:             launchTime,
 		CampaignID:             chain.CampaignID,
 		LaunchTriggered:        chain.LaunchTriggered,
 		Network:                network,

--- a/ignite/services/network/networktypes/chainlaunch_test.go
+++ b/ignite/services/network/networktypes/chainlaunch_test.go
@@ -46,7 +46,6 @@ func TestToChainLaunch(t *testing.T) {
 				SourceURL:       "bar.com",
 				SourceHash:      "0xbbb",
 				LaunchTriggered: true,
-				LaunchTimestamp: 100,
 				InitialGenesis: launchtypes.NewGenesisURL(
 					"genesisfoo.com",
 					"0xccc",

--- a/ignite/services/network/publish.go
+++ b/ignite/services/network/publish.go
@@ -221,7 +221,8 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 			genesisHash,
 			campaignID != 0,
 			campaignID,
-			nil,
+			// TODO: coinsgohere
+			// TODO: some byte slice here
 		)
 		res, err := n.cosmos.BroadcastTx(n.account, msgCreateChain)
 		if err != nil {


### PR DESCRIPTION
Basically, if we use the word "rest" anywhere, even once, the whole thing will come crashing down.  

```
faddat@Whites-MBP bcna % go get github.com/ignite-hq/cli/ignite/pkg/cosmoscmd@develop


go: module github.com/golang/protobuf is deprecated: Use the "google.golang.org/protobuf" module instead.
faddat@Whites-MBP bcna % 
faddat@Whites-MBP bcna % 
faddat@Whites-MBP bcna % go mod tidy
go: finding module for package github.com/cosmos/cosmos-sdk/types/rest
go: finding module for package github.com/cosmos/cosmos-sdk/x/auth/client/rest
go: finding module for package github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx
go: finding module for package github.com/cosmos/cosmos-sdk/x/gov/client/rest
github.com/BitCannaGlobal/bcna/app imports
        github.com/ignite/cli/ignite/pkg/cosmoscmd imports
        github.com/ignite/cli/ignite/pkg/cosmosutil imports
        github.com/tendermint/spn/x/launch/types imports
        github.com/tendermint/spn/pkg/types imports
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types tested by
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types.test imports
        github.com/cosmos/ibc-go/v3/testing/simapp imports
        github.com/cosmos/cosmos-sdk/x/auth/client/rest: module github.com/cosmos/cosmos-sdk@latest found (v0.46.1), but does not contain package github.com/cosmos/cosmos-sdk/x/auth/client/rest
github.com/BitCannaGlobal/bcna/app imports
        github.com/ignite/cli/ignite/pkg/cosmoscmd imports
        github.com/ignite/cli/ignite/pkg/cosmosutil imports
        github.com/tendermint/spn/x/launch/types imports
        github.com/tendermint/spn/pkg/types imports
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types tested by
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types.test imports
        github.com/cosmos/ibc-go/v3/testing/simapp imports
        github.com/cosmos/ibc-go/v3/modules/core/02-client/client imports
        github.com/cosmos/cosmos-sdk/types/rest: module github.com/cosmos/cosmos-sdk@latest found (v0.46.1), but does not contain package github.com/cosmos/cosmos-sdk/types/rest
github.com/BitCannaGlobal/bcna/app imports
        github.com/ignite/cli/ignite/pkg/cosmoscmd imports
        github.com/ignite/cli/ignite/pkg/cosmosutil imports
        github.com/tendermint/spn/x/launch/types imports
        github.com/tendermint/spn/pkg/types imports
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types tested by
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types.test imports
        github.com/cosmos/ibc-go/v3/testing/simapp imports
        github.com/cosmos/ibc-go/v3/modules/core/02-client/client imports
        github.com/cosmos/cosmos-sdk/x/gov/client/rest: module github.com/cosmos/cosmos-sdk@latest found (v0.46.1), but does not contain package github.com/cosmos/cosmos-sdk/x/gov/client/rest
github.com/BitCannaGlobal/bcna/app imports
        github.com/ignite/cli/ignite/pkg/cosmoscmd imports
        github.com/ignite/cli/ignite/pkg/cosmosutil imports
        github.com/tendermint/spn/x/launch/types imports
        github.com/tendermint/spn/pkg/types imports
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types tested by
        github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types.test imports
        github.com/cosmos/ibc-go/v3/testing/simapp imports
        github.com/cosmos/ibc-go/v3/testing/simapp/params imports
        github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx: module github.com/cosmos/cosmos-sdk@latest found (v0.46.1), but does not contain package github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx
```