### PR TITLE
chore: set union merge strategy to changelog.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+changelog.md merge=union

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 ### Changes
 
+- Add changelog merge strategy in .gitattributes to avoid conflicts.
 - Refactor `templates/app` to remove `monitoringp` module from the default template
 - Updated keyring dependency to match what Cosmos SDK is using
 - Speed up the integration tests


### PR DESCRIPTION
Since we are forcing the updage of changelog.md on every PR, this leads to many conflicts when it's time to merge.

By forcing the merge strategy of this file to `union`, it decreases the chance of conflicts by ~90%. The downside is sometimes the merge gets wrong (repeated lines) so the dev should have a look at the result.