### PR TITLE
docs(guide/hello): revert grpc registration removal

### DIFF
--- a/docs/docs/guide/02-hello.md
+++ b/docs/docs/guide/02-hello.md
@@ -227,7 +227,39 @@ func (k Keeper) Hello(c context.Context, req *types.QueryHelloRequest) (*types.Q
 ```
 
 - Save the file to restart your chain. 
-- After the chain has been started, visit [http://localhost:1317/hello/hello/hello](http://localhost:1317/hello/hello/hello) and see your text displayed:
+- In a web browser, visit the `hello` endpoint [http://localhost:1317/hello/hello/hello](http://localhost:1317/hello/hello/hello).
+
+  Because the query handlers are not yet registered with gRPC, you see a not implemented or localhost cannot connect error. This error is expected behavior, because you still need to register the query handlers.
+
+## Register query handlers
+
+Make the required changes to the `x/hello/module.go` file.
+
+1. Add `"context"` to the list of packages in the import statement.
+
+    ```go
+    import (
+      // ...
+
+      "context"
+
+      // ...
+    )
+    ```
+
+    Do not save the file yet, you need to continue with these modifications.
+
+1. Search for `RegisterGRPCGatewayRoutes`.
+
+1. Register the query handlers:
+
+    ```go
+    func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+      types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+    }
+    ```
+
+2. After the chain has been started, visit [http://localhost:1317/hello/hello/hello](http://localhost:1317/hello/hello/hello) and see your text displayed:
 
     ```json
     {


### PR DESCRIPTION
Fix #2817

Revert part of commit 7c836df5ec90e9a7abd15a114cd6ec2b10969a27

There's 2 reasons why this change should be reverted:
- the version that does the registration automatically is not released yet (0.24)
- the hello tutorial requires the use of cli 0.22, where the registration is always manual.

What could be changed in the 0.24 documentation:
- remove the 0.22 requirement (latest could be used w/o any problem I think)
- remove the manual grpc registration.