### PR TITLE
fix: cli action org in templates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix cli action org in templates.
+
 ## [`v0.24.0`](https://github.com/ignite/cli/releases/tag/v0.24.0)
 
 ### Features

--- a/ignite/templates/app/stargate/.github/workflows/release.yml
+++ b/ignite/templates/app/stargate/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
         
       - name: Prepare Release Variables 
         id: vars
-        uses: ignite-hq/cli/actions/release/vars@develop
+        uses: ignite/cli/actions/release/vars@develop
 
       - name: Issue Release Assets 
-        uses: ignite-hq/cli/actions/cli@develop
+        uses: ignite/cli/actions/cli@develop
         if: ${{ steps.vars.outputs.should_release == 'true' }}
         with:
           args: chain build --release --release.prefix ${{ steps.vars.outputs.tarball_prefix }} -t linux:amd64 -t darwin:amd64 -t darwin:arm64


### PR DESCRIPTION
A missing ignite-hq switch!

Tools like `ag` intentionally ignores directories that starts with a `.`, that's probably why we missed them.