### PR TITLE
chore: switch to broadcast mode sync

### DIFF
--- a/ignite/cmd/network_campaign_publish.go
+++ b/ignite/cmd/network_campaign_publish.go
@@ -48,7 +48,7 @@ func networkCampaignPublishHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	metadata, _ := cmd.Flags().GetString(flagMetadata)
-	campaignID, err := n.CreateCampaign(args[0], metadata, totalSupply)
+	campaignID, err := n.CreateCampaign(cmd.Context(), args[0], metadata, totalSupply)
 	if err != nil {
 		return err
 	}

--- a/ignite/cmd/network_campaign_update.go
+++ b/ignite/cmd/network_campaign_update.go
@@ -86,7 +86,7 @@ func networkCampaignUpdateHandler(cmd *cobra.Command, args []string) error {
 		proposals = append(proposals, network.WithCampaignTotalSupply(totalSupply))
 	}
 
-	if err = n.UpdateCampaign(campaignID, proposals...); err != nil {
+	if err = n.UpdateCampaign(cmd.Context(), campaignID, proposals...); err != nil {
 		return err
 	}
 

--- a/ignite/cmd/network_chain_publish.go
+++ b/ignite/cmd/network_chain_publish.go
@@ -262,13 +262,13 @@ func networkChainPublishHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	if !rewardCoins.IsZero() && rewardDuration > 0 {
-		if err := n.SetReward(launchID, rewardDuration, rewardCoins); err != nil {
+		if err := n.SetReward(cmd.Context(), launchID, rewardDuration, rewardCoins); err != nil {
 			return err
 		}
 	}
 
 	if !amountCoins.IsZero() {
-		if err := n.SendAccountRequestForCoordinator(launchID, amountCoins); err != nil {
+		if err := n.SendAccountRequestForCoordinator(cmd.Context(), launchID, amountCoins); err != nil {
 			return err
 		}
 	}

--- a/ignite/cmd/network_chain_revert_launch.go
+++ b/ignite/cmd/network_chain_revert_launch.go
@@ -55,5 +55,5 @@ func networkChainRevertLaunchHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return n.RevertLaunch(launchID, c)
+	return n.RevertLaunch(cmd.Context(), launchID, c)
 }

--- a/ignite/cmd/network_request_approve.go
+++ b/ignite/cmd/network_request_approve.go
@@ -84,7 +84,7 @@ func networkRequestApproveHandler(cmd *cobra.Command, args []string) error {
 	for _, id := range ids {
 		reviewals = append(reviewals, network.ApproveRequest(id))
 	}
-	if err := n.SubmitRequest(launchID, reviewals...); err != nil {
+	if err := n.SubmitRequest(cmd.Context(), launchID, reviewals...); err != nil {
 		return err
 	}
 

--- a/ignite/cmd/network_request_reject.go
+++ b/ignite/cmd/network_request_reject.go
@@ -57,7 +57,7 @@ func networkRequestRejectHandler(cmd *cobra.Command, args []string) error {
 	for _, id := range ids {
 		reviewals = append(reviewals, network.RejectRequest(id))
 	}
-	if err := n.SubmitRequest(launchID, reviewals...); err != nil {
+	if err := n.SubmitRequest(cmd.Context(), launchID, reviewals...); err != nil {
 		return err
 	}
 

--- a/ignite/cmd/network_reward_release.go
+++ b/ignite/cmd/network_reward_release.go
@@ -229,7 +229,7 @@ func createClient(
 
 	spnRelayer, err := n.RewardIBCInfo(cmd.Context(), launchID)
 	if errors.Is(err, network.ErrObjectNotFound) {
-		spnRelayer.ClientID, err = n.CreateClient(launchID, unboundingTime, rewardsInfo)
+		spnRelayer.ClientID, err = n.CreateClient(cmd.Context(), launchID, unboundingTime, rewardsInfo)
 	}
 	if err != nil {
 		return networktypes.RewardIBCInfo{}, networktypes.RewardIBCInfo{}, err

--- a/ignite/cmd/network_reward_set.go
+++ b/ignite/cmd/network_reward_set.go
@@ -58,5 +58,5 @@ func networkChainRewardSetHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return n.SetReward(launchID, lastRewardHeight, coins)
+	return n.SetReward(cmd.Context(), launchID, lastRewardHeight, coins)
 }

--- a/ignite/cmd/node.go
+++ b/ignite/cmd/node.go
@@ -38,7 +38,6 @@ func newNodeCosmosClient(cmd *cobra.Command) (cosmosclient.Client, error) {
 		gas            = getGas(cmd)
 		gasPrices      = getGasPrices(cmd)
 		fees           = getFees(cmd)
-		broadcastMode  = getBroadcastMode(cmd)
 		generateOnly   = getGenerateOnly(cmd)
 	)
 	if keyringBackend == "" {
@@ -53,7 +52,6 @@ func newNodeCosmosClient(cmd *cobra.Command) (cosmosclient.Client, error) {
 		cosmosclient.WithKeyringBackend(keyringBackend),
 		cosmosclient.WithKeyringDir(keyringDir),
 		cosmosclient.WithNodeAddress(xurl.HTTPEnsurePort(node)),
-		cosmosclient.WithBroadcastMode(broadcastMode),
 		cosmosclient.WithGenerateOnly(generateOnly),
 	}
 

--- a/ignite/cmd/node_tx.go
+++ b/ignite/cmd/node_tx.go
@@ -3,7 +3,6 @@ package ignitecmd
 import (
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 )
@@ -11,11 +10,10 @@ import (
 const (
 	flagGenerateOnly = "generate-only"
 
-	gasFlagAuto       = "auto"
-	flagGasPrices     = "gas-prices"
-	flagGas           = "gas"
-	flagFees          = "fees"
-	flagBroadcastMode = "broadcast-mode"
+	gasFlagAuto   = "auto"
+	flagGasPrices = "gas-prices"
+	flagGas       = "gas"
+	flagFees      = "fees"
 )
 
 func NewNodeTx() *cobra.Command {
@@ -30,7 +28,6 @@ func NewNodeTx() *cobra.Command {
 	c.PersistentFlags().AddFlagSet(flagSetGenerateOnly())
 	c.PersistentFlags().AddFlagSet(flagSetGasFlags())
 	c.PersistentFlags().String(flagFees, "", "Fees to pay along with transaction; eg: 10uatom")
-	c.PersistentFlags().String(flagBroadcastMode, flags.BroadcastSync, "Transaction broadcasting mode (sync|async|block)")
 
 	c.AddCommand(NewNodeTxBank())
 
@@ -68,9 +65,4 @@ func getGas(cmd *cobra.Command) string {
 func getFees(cmd *cobra.Command) string {
 	fees, _ := cmd.Flags().GetString(flagFees)
 	return fees
-}
-
-func getBroadcastMode(cmd *cobra.Command) string {
-	broadcastMode, _ := cmd.Flags().GetString(flagBroadcastMode)
-	return broadcastMode
 }

--- a/ignite/cmd/node_tx.go
+++ b/ignite/cmd/node_tx.go
@@ -30,7 +30,7 @@ func NewNodeTx() *cobra.Command {
 	c.PersistentFlags().AddFlagSet(flagSetGenerateOnly())
 	c.PersistentFlags().AddFlagSet(flagSetGasFlags())
 	c.PersistentFlags().String(flagFees, "", "Fees to pay along with transaction; eg: 10uatom")
-	c.PersistentFlags().String(flagBroadcastMode, flags.BroadcastBlock, "Transaction broadcasting mode (sync|async|block), use sync if you encounter timeouts")
+	c.PersistentFlags().String(flagBroadcastMode, flags.BroadcastSync, "Transaction broadcasting mode (sync|async|block)")
 
 	c.AddCommand(NewNodeTxBank())
 

--- a/ignite/cmd/node_tx_bank_send.go
+++ b/ignite/cmd/node_tx_bank_send.go
@@ -1,7 +1,6 @@
 package ignitecmd
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 
@@ -75,10 +74,5 @@ func nodeTxBankSendHandler(cmd *cobra.Command, args []string) error {
 	session.StopSpinner()
 	session.Printf("Transaction broadcast successful! (hash = %s)\n", resp.TxHash)
 	session.Printf("%s sent from %s to %s\n", amount, fromAccountInput, toAccountInput)
-	if getBroadcastMode(cmd) != flags.BroadcastBlock {
-		session.Println("Transaction waiting to be included in a block.")
-		session.Println("Run the following command to follow the transaction status:")
-		session.Printf("  ignite node --node %s q tx %s\n", getNode(cmd), resp.TxHash)
-	}
 	return nil
 }

--- a/ignite/cmd/node_tx_bank_send.go
+++ b/ignite/cmd/node_tx_bank_send.go
@@ -49,7 +49,7 @@ func nodeTxBankSendHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tx, err := client.BankSendTx(fromAccount, toAddress, coins)
+	tx, err := client.BankSendTx(cmd.Context(), fromAccount, toAddress, coins)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func nodeTxBankSendHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	session.StartSpinner("Sending transaction...")
-	resp, err := tx.Broadcast()
+	resp, err := tx.Broadcast(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/ignite/pkg/cosmosclient/bank.go
+++ b/ignite/pkg/cosmosclient/bank.go
@@ -25,7 +25,7 @@ func (c Client) BankBalances(ctx context.Context, address string, pagination *qu
 	return resp.Balances, nil
 }
 
-func (c Client) BankSendTx(fromAccount cosmosaccount.Account, toAddress string, amount sdk.Coins) (TxService, error) {
+func (c Client) BankSendTx(ctx context.Context, fromAccount cosmosaccount.Account, toAddress string, amount sdk.Coins) (TxService, error) {
 	addr, err := fromAccount.Address(c.addressPrefix)
 	if err != nil {
 		return TxService{}, err
@@ -37,5 +37,5 @@ func (c Client) BankSendTx(fromAccount cosmosaccount.Account, toAddress string, 
 		Amount:      amount,
 	}
 
-	return c.CreateTx(fromAccount, msg)
+	return c.CreateTx(ctx, fromAccount, msg)
 }

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -110,11 +110,10 @@ type Client struct {
 	keyringBackend     cosmosaccount.KeyringBackend
 	keyringDir         string
 
-	gas           string
-	gasPrices     string
-	fees          string
-	broadcastMode string
-	generateOnly  bool
+	gas          string
+	gasPrices    string
+	fees         string
+	generateOnly bool
 }
 
 // Option configures your client.
@@ -200,13 +199,6 @@ func WithFees(fees string) Option {
 	}
 }
 
-// WithBroadcastMode sets the broadcast mode
-func WithBroadcastMode(broadcastMode string) Option {
-	return func(c *Client) {
-		c.broadcastMode = broadcastMode
-	}
-}
-
 // WithGenerateOnly tells if txs will be generated only.
 func WithGenerateOnly(generateOnly bool) Option {
 	return func(c *Client) {
@@ -273,7 +265,6 @@ func New(ctx context.Context, options ...Option) (Client, error) {
 		faucetMinAmount: defaultFaucetMinAmount,
 		out:             io.Discard,
 		gas:             strconv.Itoa(defaultGasLimit),
-		broadcastMode:   flags.BroadcastSync,
 	}
 
 	var err error
@@ -701,7 +692,7 @@ func (c Client) newContext() client.Context {
 		WithInput(os.Stdin).
 		WithOutput(c.out).
 		WithAccountRetriever(c.accountRetriever).
-		WithBroadcastMode(c.broadcastMode).
+		WithBroadcastMode(flags.BroadcastSync).
 		WithHomeDir(c.homePath).
 		WithClient(c.RPC).
 		WithSkipConfirmation(true).

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -629,7 +629,6 @@ func handleBroadcastResult(resp *sdktypes.TxResponse, err error) error {
 		if strings.Contains(err.Error(), "not found") {
 			return errors.New("make sure that your account has enough balance")
 		}
-
 		return err
 	}
 

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -273,7 +273,7 @@ func New(ctx context.Context, options ...Option) (Client, error) {
 		faucetMinAmount: defaultFaucetMinAmount,
 		out:             io.Discard,
 		gas:             strconv.Itoa(defaultGasLimit),
-		broadcastMode:   flags.BroadcastBlock,
+		broadcastMode:   flags.BroadcastSync,
 	}
 
 	var err error

--- a/ignite/pkg/cosmosclient/cosmosclient_test.go
+++ b/ignite/pkg/cosmosclient/cosmosclient_test.go
@@ -412,6 +412,7 @@ func TestClientStatus(t *testing.T) {
 
 func TestClientCreateTx(t *testing.T) {
 	var (
+		ctx         = context.Background()
 		accountName = "bob"
 		passphrase  = "passphrase"
 	)
@@ -597,7 +598,7 @@ func TestClientCreateTx(t *testing.T) {
 			account, err := c.AccountRegistry.Import(accountName, key, passphrase)
 			require.NoError(err)
 
-			txs, err := c.CreateTx(account, tt.msg)
+			txs, err := c.CreateTx(ctx, account, tt.msg)
 
 			if tt.expectedError != "" {
 				require.EqualError(err, tt.expectedError)

--- a/ignite/pkg/cosmosclient/txservice.go
+++ b/ignite/pkg/cosmosclient/txservice.go
@@ -2,11 +2,12 @@ package cosmosclient
 
 import (
 	"context"
-	"errors"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/pkg/errors"
 )
 
 type TxService struct {
@@ -27,7 +28,7 @@ func (s TxService) Gas() uint64 {
 // it automatically filled with the default amount, and the tx is broadcasted
 // again. Note that this may still end with the same error if the amount is
 // greater than the amount dumped by the faucet.
-func (s TxService) Broadcast() (Response, error) {
+func (s TxService) Broadcast(ctx context.Context) (Response, error) {
 	defer s.client.lockBech32Prefix()()
 
 	accountName := s.clientContext.GetFromName()
@@ -36,27 +37,44 @@ func (s TxService) Broadcast() (Response, error) {
 	// validate msgs.
 	for _, msg := range s.txBuilder.GetTx().GetMsgs() {
 		if err := msg.ValidateBasic(); err != nil {
-			return Response{}, err
+			return Response{}, errors.WithStack(err)
 		}
 	}
 
 	if err := s.client.signer.Sign(s.txFactory, accountName, s.txBuilder, true); err != nil {
-		return Response{}, err
+		return Response{}, errors.WithStack(err)
 	}
 
 	txBytes, err := s.clientContext.TxConfig.TxEncoder()(s.txBuilder.GetTx())
 	if err != nil {
-		return Response{}, err
+		return Response{}, errors.WithStack(err)
 	}
 
 	resp, err := s.clientContext.BroadcastTx(txBytes)
 	if s.client.useFaucet && errors.Is(err, sdkerrors.ErrInsufficientFunds) {
 		err = s.client.makeSureAccountHasTokens(context.Background(), accountAddress.String())
 		if err != nil {
-			return Response{}, err
+			return Response{}, errors.WithStack(err)
 		}
 		resp, err = s.clientContext.BroadcastTx(txBytes)
 	}
+
+	if err := handleBroadcastResult(resp, err); err != nil {
+		return Response{}, err
+	}
+
+	res, err := s.client.WaitForTx(ctx, resp.TxHash)
+	if err != nil {
+		return Response{}, err
+	}
+	// NOTE(tb) second and third parameters are omitted:
+	// - second parameter represents the tx and should be of type sdktypes.Any,
+	// but it is very ugly to decode, not sure if it's worth it (see sdk code
+	// x/auth/query.go method makeTxResult)
+	// - third parameter represents the timestamp of the tx, which must be
+	// fetched from the block it self. So it requires an other API call to
+	// fetch the block from res.Height, not sure if it's worth it too.
+	resp = sdktypes.NewResponseResultTx(res, nil, "")
 
 	return Response{
 		Codec:      s.clientContext.Codec,

--- a/ignite/pkg/cosmosclient/txservice_test.go
+++ b/ignite/pkg/cosmosclient/txservice_test.go
@@ -1,6 +1,7 @@
 package cosmosclient_test
 
 import (
+	"context"
 	"encoding/hex"
 	"testing"
 
@@ -20,6 +21,7 @@ import (
 
 func TestTxServiceBroadcast(t *testing.T) {
 	var (
+		goCtx       = context.Background()
 		accountName = "bob"
 		passphrase  = "passphrase"
 		txHash      = []byte{1, 2, 3}
@@ -197,10 +199,10 @@ func TestTxServiceBroadcast(t *testing.T) {
 			ctx := c.Context().
 				WithFromName(accountName).
 				WithFromAddress(sdkaddress)
-			txService, err := c.CreateTx(account, tt.msg)
+			txService, err := c.CreateTx(goCtx, account, tt.msg)
 			require.NoError(err)
 
-			res, err := txService.Broadcast()
+			res, err := txService.Broadcast(goCtx)
 
 			if tt.expectedError != "" {
 				require.EqualError(err, tt.expectedError)

--- a/ignite/services/network/campaign.go
+++ b/ignite/services/network/campaign.go
@@ -79,7 +79,7 @@ func (n Network) Campaigns(ctx context.Context) ([]networktypes.Campaign, error)
 }
 
 // CreateCampaign creates a campaign in Network
-func (n Network) CreateCampaign(name, metadata string, totalSupply sdk.Coins) (uint64, error) {
+func (n Network) CreateCampaign(ctx context.Context, name, metadata string, totalSupply sdk.Coins) (uint64, error) {
 	n.ev.Send(events.New(events.StatusOngoing, fmt.Sprintf("Creating campaign %s", name)))
 	addr, err := n.account.Address(networktypes.SPN)
 	if err != nil {
@@ -91,7 +91,7 @@ func (n Network) CreateCampaign(name, metadata string, totalSupply sdk.Coins) (u
 		totalSupply,
 		[]byte(metadata),
 	)
-	res, err := n.cosmos.BroadcastTx(n.account, msgCreateCampaign)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msgCreateCampaign)
 	if err != nil {
 		return 0, err
 	}
@@ -106,6 +106,7 @@ func (n Network) CreateCampaign(name, metadata string, totalSupply sdk.Coins) (u
 
 // InitializeMainnet Initialize the mainnet of the campaign.
 func (n Network) InitializeMainnet(
+	ctx context.Context,
 	campaignID uint64,
 	sourceURL,
 	sourceHash string,
@@ -125,7 +126,7 @@ func (n Network) InitializeMainnet(
 		mainnetChainID,
 	)
 
-	res, err := n.cosmos.BroadcastTx(n.account, msg)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
 	if err != nil {
 		return 0, err
 	}
@@ -142,6 +143,7 @@ func (n Network) InitializeMainnet(
 
 // UpdateCampaign updates the campaign name or metadata
 func (n Network) UpdateCampaign(
+	ctx context.Context,
 	id uint64,
 	props ...Prop,
 ) error {
@@ -173,7 +175,7 @@ func (n Network) UpdateCampaign(
 		))
 	}
 
-	if _, err := n.cosmos.BroadcastTx(n.account, msgs...); err != nil {
+	if _, err := n.cosmos.BroadcastTx(ctx, n.account, msgs...); err != nil {
 		return err
 	}
 	n.ev.Send(events.New(events.StatusDone, fmt.Sprintf(

--- a/ignite/services/network/client.go
+++ b/ignite/services/network/client.go
@@ -12,6 +12,7 @@ import (
 
 // CreateClient send create client message to SPN
 func (n Network) CreateClient(
+	ctx context.Context,
 	launchID uint64,
 	unbondingTime int64,
 	rewardsInfo networktypes.Reward,
@@ -30,7 +31,7 @@ func (n Network) CreateClient(
 		rewardsInfo.RevisionHeight,
 	)
 
-	res, err := n.cosmos.BroadcastTx(n.account, msgCreateClient)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msgCreateClient)
 	if err != nil {
 		return "", err
 	}

--- a/ignite/services/network/join.go
+++ b/ignite/services/network/join.go
@@ -85,16 +85,17 @@ func (n Network) Join(
 	}
 
 	if !o.accountAmount.IsZero() {
-		if err := n.sendAccountRequest(launchID, accountAddress, o.accountAmount); err != nil {
+		if err := n.sendAccountRequest(ctx, launchID, accountAddress, o.accountAmount); err != nil {
 			return err
 		}
 	}
 
-	return n.sendValidatorRequest(launchID, peer, accountAddress, gentx, gentxInfo)
+	return n.sendValidatorRequest(ctx, launchID, peer, accountAddress, gentx, gentxInfo)
 }
 
 // sendValidatorRequest creates the RequestAddValidator message into the SPN
 func (n Network) sendValidatorRequest(
+	ctx context.Context,
 	launchID uint64,
 	peer launchtypes.Peer,
 	valAddress string,
@@ -121,7 +122,7 @@ func (n Network) sendValidatorRequest(
 
 	n.ev.Send(events.New(events.StatusOngoing, "Broadcasting validator transaction"))
 
-	res, err := n.cosmos.BroadcastTx(n.account, msg)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/join_test.go
+++ b/ignite/services/network/join_test.go
@@ -43,6 +43,7 @@ func TestJoin(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				launchtypes.NewMsgSendRequest(
 					addr,
@@ -96,6 +97,7 @@ func TestJoin(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				launchtypes.NewMsgSendRequest(
 					addr,
@@ -146,6 +148,7 @@ func TestJoin(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				launchtypes.NewMsgSendRequest(
 					addr,
@@ -202,6 +205,7 @@ func TestJoin(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				launchtypes.NewMsgSendRequest(
 					addr,
@@ -229,6 +233,7 @@ func TestJoin(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				launchtypes.NewMsgSendRequest(
 					addr,

--- a/ignite/services/network/launch.go
+++ b/ignite/services/network/launch.go
@@ -64,7 +64,7 @@ func (n Network) TriggerLaunch(ctx context.Context, launchID uint64, launchTime 
 
 	msg := launchtypes.NewMsgTriggerLaunch(address, launchID, launchTime)
 	n.ev.Send(events.New(events.StatusOngoing, "Setting launch time"))
-	res, err := n.cosmos.BroadcastTx(n.account, msg)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (n Network) TriggerLaunch(ctx context.Context, launchID uint64, launchTime 
 }
 
 // RevertLaunch reverts a launched chain as a coordinator
-func (n Network) RevertLaunch(launchID uint64, chain Chain) error {
+func (n Network) RevertLaunch(ctx context.Context, launchID uint64, chain Chain) error {
 	n.ev.Send(events.New(events.StatusOngoing, fmt.Sprintf("Reverting launched chain %d", launchID)))
 
 	address, err := n.account.Address(networktypes.SPN)
@@ -90,7 +90,7 @@ func (n Network) RevertLaunch(launchID uint64, chain Chain) error {
 	}
 
 	msg := launchtypes.NewMsgRevertLaunch(address, launchID)
-	_, err = n.cosmos.BroadcastTx(n.account, msg)
+	_, err = n.cosmos.BroadcastTx(ctx, n.account, msg)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/launch_test.go
+++ b/ignite/services/network/launch_test.go
@@ -38,6 +38,7 @@ func TestTriggerLaunch(t *testing.T) {
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgTriggerLaunch{
 					Coordinator: addr,
@@ -120,6 +121,7 @@ func TestTriggerLaunch(t *testing.T) {
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgTriggerLaunch{
 					Coordinator: addr,
@@ -153,6 +155,7 @@ func TestTriggerLaunch(t *testing.T) {
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgTriggerLaunch{
 					Coordinator: addr,
@@ -202,6 +205,7 @@ func TestRevertLaunch(t *testing.T) {
 		suite.ChainMock.On("ResetGenesisTime").Return(nil).Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgRevertLaunch{
 					Coordinator: addr,
@@ -210,7 +214,7 @@ func TestRevertLaunch(t *testing.T) {
 			Return(testutil.NewResponse(&launchtypes.MsgRevertLaunchResponse{}), nil).
 			Once()
 
-		revertError := network.RevertLaunch(testutil.LaunchID, suite.ChainMock)
+		revertError := network.RevertLaunch(context.Background(), testutil.LaunchID, suite.ChainMock)
 		require.NoError(t, revertError)
 		suite.AssertAllMocks(t)
 	})
@@ -227,6 +231,7 @@ func TestRevertLaunch(t *testing.T) {
 
 		suite.CosmosClientMock.
 			On("BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgRevertLaunch{
 					Coordinator: addr,
@@ -238,7 +243,7 @@ func TestRevertLaunch(t *testing.T) {
 			).
 			Once()
 
-		revertError := network.RevertLaunch(testutil.LaunchID, suite.ChainMock)
+		revertError := network.RevertLaunch(context.Background(), testutil.LaunchID, suite.ChainMock)
 		require.Error(t, revertError)
 		require.Equal(t, expectedError, revertError)
 		suite.AssertAllMocks(t)
@@ -260,6 +265,7 @@ func TestRevertLaunch(t *testing.T) {
 			Once()
 		suite.CosmosClientMock.
 			On("BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgRevertLaunch{
 					Coordinator: addr,
@@ -268,7 +274,7 @@ func TestRevertLaunch(t *testing.T) {
 			Return(testutil.NewResponse(&launchtypes.MsgRevertLaunchResponse{}), nil).
 			Once()
 
-		revertError := network.RevertLaunch(testutil.LaunchID, suite.ChainMock)
+		revertError := network.RevertLaunch(context.Background(), testutil.LaunchID, suite.ChainMock)
 		require.Error(t, revertError)
 		require.Equal(t, expectedError, revertError)
 		suite.AssertAllMocks(t)

--- a/ignite/services/network/mocks/cosmos_client.go
+++ b/ignite/services/network/mocks/cosmos_client.go
@@ -23,27 +23,27 @@ type CosmosClient struct {
 	mock.Mock
 }
 
-// BroadcastTx provides a mock function with given fields: account, msgs
-func (_m *CosmosClient) BroadcastTx(account cosmosaccount.Account, msgs ...types.Msg) (cosmosclient.Response, error) {
+// BroadcastTx provides a mock function with given fields: ctx, account, msgs
+func (_m *CosmosClient) BroadcastTx(ctx context.Context, account cosmosaccount.Account, msgs ...types.Msg) (cosmosclient.Response, error) {
 	_va := make([]interface{}, len(msgs))
 	for _i := range msgs {
 		_va[_i] = msgs[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, account)
+	_ca = append(_ca, ctx, account)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 cosmosclient.Response
-	if rf, ok := ret.Get(0).(func(cosmosaccount.Account, ...types.Msg) cosmosclient.Response); ok {
-		r0 = rf(account, msgs...)
+	if rf, ok := ret.Get(0).(func(context.Context, cosmosaccount.Account, ...types.Msg) cosmosclient.Response); ok {
+		r0 = rf(ctx, account, msgs...)
 	} else {
 		r0 = ret.Get(0).(cosmosclient.Response)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(cosmosaccount.Account, ...types.Msg) error); ok {
-		r1 = rf(account, msgs...)
+	if rf, ok := ret.Get(1).(func(context.Context, cosmosaccount.Account, ...types.Msg) error); ok {
+		r1 = rf(ctx, account, msgs...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/ignite/services/network/network.go
+++ b/ignite/services/network/network.go
@@ -25,7 +25,7 @@ import (
 //go:generate mockery --name CosmosClient --case underscore
 type CosmosClient interface {
 	Context() client.Context
-	BroadcastTx(account cosmosaccount.Account, msgs ...sdktypes.Msg) (cosmosclient.Response, error)
+	BroadcastTx(ctx context.Context, account cosmosaccount.Account, msgs ...sdktypes.Msg) (cosmosclient.Response, error)
 	Status(ctx context.Context) (*ctypes.ResultStatus, error)
 	ConsensusInfo(ctx context.Context, height int64) (cosmosclient.ConsensusInfo, error)
 }

--- a/ignite/services/network/publish.go
+++ b/ignite/services/network/publish.go
@@ -148,7 +148,7 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 			"",
 			"",
 		)
-		if _, err := n.cosmos.BroadcastTx(n.account, msgCreateCoordinator); err != nil {
+		if _, err := n.cosmos.BroadcastTx(ctx, n.account, msgCreateCoordinator); err != nil {
 			return 0, 0, err
 		}
 	} else if err != nil {
@@ -167,7 +167,7 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 	} else if o.mainnet {
 		// a mainnet is always associated to a campaign
 		// if no campaign is provided, we create one, and we directly initialize the mainnet
-		campaignID, err = n.CreateCampaign(c.Name(), o.metadata, o.totalSupply)
+		campaignID, err = n.CreateCampaign(ctx, c.Name(), o.metadata, o.totalSupply)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -202,7 +202,7 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 			campaignID,
 			campaigntypes.NewSharesFromCoins(sdk.NewCoins(coins...)),
 		)
-		_, err = n.cosmos.BroadcastTx(n.account, msgMintVouchers)
+		_, err = n.cosmos.BroadcastTx(ctx, n.account, msgMintVouchers)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -210,7 +210,7 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 
 	// depending on mainnet flag initialize mainnet or testnet
 	if o.mainnet {
-		launchID, err = n.InitializeMainnet(campaignID, c.SourceURL(), c.SourceHash(), chainID)
+		launchID, err = n.InitializeMainnet(ctx, campaignID, c.SourceURL(), c.SourceHash(), chainID)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -232,7 +232,7 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 			o.accountBalance,
 			nil,
 		)
-		res, err := n.cosmos.BroadcastTx(n.account, msgCreateChain)
+		res, err := n.cosmos.BroadcastTx(ctx, n.account, msgCreateChain)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -249,17 +249,18 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 	return launchID, campaignID, nil
 }
 
-func (n Network) SendAccountRequestForCoordinator(launchID uint64, amount sdk.Coins) error {
+func (n Network) SendAccountRequestForCoordinator(ctx context.Context, launchID uint64, amount sdk.Coins) error {
 	addr, err := n.account.Address(networktypes.SPN)
 	if err != nil {
 		return err
 	}
 
-	return n.sendAccountRequest(launchID, addr, amount)
+	return n.sendAccountRequest(ctx, launchID, addr, amount)
 }
 
 // SendAccountRequest creates an add AddAccount request message.
 func (n Network) sendAccountRequest(
+	ctx context.Context,
 	launchID uint64,
 	address string,
 	amount sdk.Coins,
@@ -280,7 +281,7 @@ func (n Network) sendAccountRequest(
 	)
 
 	n.ev.Send(events.New(events.StatusOngoing, "Broadcasting account transactions"))
-	res, err := n.cosmos.BroadcastTx(n.account, msg)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/publish_test.go
+++ b/ignite/services/network/publish_test.go
@@ -62,6 +62,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -120,6 +121,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -190,6 +192,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -265,6 +268,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				campaigntypes.NewMsgMintVouchers(
 					addr,
@@ -277,6 +281,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -341,6 +346,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -395,6 +401,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -452,6 +459,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&campaigntypes.MsgCreateCampaign{
 					Coordinator:  addr,
@@ -466,6 +474,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&campaigntypes.MsgInitializeMainnet{
 					Coordinator:    addr,
@@ -520,6 +529,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&campaigntypes.MsgCreateCampaign{
 					Coordinator:  addr,
@@ -534,6 +544,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&campaigntypes.MsgInitializeMainnet{
 					Coordinator:    addr,
@@ -554,7 +565,7 @@ func TestPublish(t *testing.T) {
 
 		_, _, publishError := network.Publish(context.Background(), suite.ChainMock, Mainnet())
 		require.Error(t, publishError)
-		require.Equal(t, expectedError, publishError)
+		require.ErrorIs(t, publishError, expectedError)
 		suite.AssertAllMocks(t)
 	})
 
@@ -591,6 +602,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -610,6 +622,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&profiletypes.MsgCreateCoordinator{
 					Address: addr,
@@ -649,7 +662,7 @@ func TestPublish(t *testing.T) {
 
 		_, _, publishError := network.Publish(context.Background(), suite.ChainMock)
 		require.Error(t, publishError)
-		require.Equal(t, expectedError, publishError)
+		require.ErrorIs(t, publishError, expectedError)
 		suite.AssertAllMocks(t)
 	})
 
@@ -667,7 +680,7 @@ func TestPublish(t *testing.T) {
 
 		_, _, publishError := network.Publish(context.Background(), suite.ChainMock)
 		require.Error(t, publishError)
-		require.Equal(t, expectedError, publishError)
+		require.ErrorIs(t, publishError, expectedError)
 		suite.AssertAllMocks(t)
 	})
 
@@ -705,7 +718,7 @@ func TestPublish(t *testing.T) {
 
 		_, _, publishError := network.Publish(context.Background(), suite.ChainMock, WithCampaign(testutil.CampaignID))
 		require.Error(t, publishError)
-		require.Equal(t, cosmoserror.ErrNotFound, publishError)
+		require.ErrorIs(t, publishError, cosmoserror.ErrNotFound)
 		suite.AssertAllMocks(t)
 	})
 
@@ -737,6 +750,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -791,6 +805,7 @@ func TestPublish(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&launchtypes.MsgCreateChain{
 					Coordinator:    addr,
@@ -817,7 +832,7 @@ func TestPublish(t *testing.T) {
 
 		_, _, publishError := network.Publish(context.Background(), suite.ChainMock)
 		require.Error(t, publishError)
-		require.Equal(t, expectedError, publishError)
+		require.ErrorIs(t, publishError, expectedError)
 		suite.AssertAllMocks(t)
 	})
 }

--- a/ignite/services/network/request.go
+++ b/ignite/services/network/request.go
@@ -73,7 +73,7 @@ func (n Network) RequestFromIDs(ctx context.Context, launchID uint64, requestIDs
 }
 
 // SubmitRequest submits reviewals for proposals in batch for chain.
-func (n Network) SubmitRequest(launchID uint64, reviewal ...Reviewal) error {
+func (n Network) SubmitRequest(ctx context.Context, launchID uint64, reviewal ...Reviewal) error {
 	n.ev.Send(events.New(events.StatusOngoing, "Submitting requests..."))
 
 	addr, err := n.account.Address(networktypes.SPN)
@@ -91,7 +91,7 @@ func (n Network) SubmitRequest(launchID uint64, reviewal ...Reviewal) error {
 		)
 	}
 
-	res, err := n.cosmos.BroadcastTx(n.account, messages...)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, messages...)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/reward.go
+++ b/ignite/services/network/reward.go
@@ -14,7 +14,7 @@ import (
 )
 
 // SetReward set a chain reward
-func (n Network) SetReward(launchID uint64, lastRewardHeight int64, coins sdk.Coins) error {
+func (n Network) SetReward(ctx context.Context, launchID uint64, lastRewardHeight int64, coins sdk.Coins) error {
 	n.ev.Send(events.New(
 		events.StatusOngoing,
 		fmt.Sprintf("Setting reward %s to the chain %d at height %d",
@@ -35,7 +35,7 @@ func (n Network) SetReward(launchID uint64, lastRewardHeight int64, coins sdk.Co
 		lastRewardHeight,
 		coins,
 	)
-	res, err := n.cosmos.BroadcastTx(n.account, msg)
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
 	if err != nil {
 		return err
 	}

--- a/ignite/services/network/reward_test.go
+++ b/ignite/services/network/reward_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -28,6 +29,7 @@ func TestSetReward(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&rewardtypes.MsgSetRewards{
 					Provider:         addr,
@@ -44,7 +46,7 @@ func TestSetReward(t *testing.T) {
 			}), nil).
 			Once()
 
-		setRewardError := network.SetReward(testutil.LaunchID, lastRewarHeight, coins)
+		setRewardError := network.SetReward(context.Background(), testutil.LaunchID, lastRewarHeight, coins)
 		require.NoError(t, setRewardError)
 		suite.AssertAllMocks(t)
 	})
@@ -63,6 +65,7 @@ func TestSetReward(t *testing.T) {
 		suite.CosmosClientMock.
 			On(
 				"BroadcastTx",
+				context.Background(),
 				account,
 				&rewardtypes.MsgSetRewards{
 					Provider:         addr,
@@ -73,7 +76,7 @@ func TestSetReward(t *testing.T) {
 			).
 			Return(testutil.NewResponse(&rewardtypes.MsgSetRewardsResponse{}), expectedErr).
 			Once()
-		setRewardError := network.SetReward(testutil.LaunchID, lastRewarHeight, coins)
+		setRewardError := network.SetReward(context.Background(), testutil.LaunchID, lastRewarHeight, coins)
 		require.Error(t, setRewardError)
 		require.Equal(t, expectedErr, setRewardError)
 		suite.AssertAllMocks(t)

--- a/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -32,7 +32,7 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 			args: []string{
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
@@ -64,7 +64,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{}
@@ -119,7 +119,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{}

--- a/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/stargate/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -40,7 +40,7 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 			args: []string{
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
@@ -74,7 +74,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{
@@ -138,7 +138,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{

--- a/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -31,7 +31,7 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 			args: []string{
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
@@ -62,7 +62,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     var args []string
@@ -109,7 +109,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     var args []string

--- a/integration/app.go
+++ b/integration/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ignite/cli/ignite/pkg/availableport"
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
 	"github.com/ignite/cli/ignite/pkg/gocmd"
+	"github.com/ignite/cli/ignite/pkg/goenv"
 	"github.com/ignite/cli/ignite/pkg/xurl"
 )
 
@@ -120,6 +121,11 @@ func (a App) Serve(msg string, options ...ExecOption) (ok bool) {
 	if a.configPath != "" {
 		serveCommand = append(serveCommand, "--config", a.configPath)
 	}
+	a.env.t.Cleanup(func() {
+		// Serve install the app binary in GOBIN, let's clean that.
+		appBinary := path.Join(goenv.Bin(), a.Binary())
+		os.Remove(appBinary)
+	})
 
 	return a.env.Exec(msg,
 		step.NewSteps(step.New(

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -1,0 +1,84 @@
+package network_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
+	envtest "github.com/ignite/cli/integration"
+)
+
+const (
+	spnURL    = "git@github.com:tendermint/spn"
+	spnBranch = "develop"
+	spnHash   = "5da0c7ae019d376f782fa3baeb2c0ac5654f2d1f"
+)
+
+func cloneSPN(t *testing.T) string {
+	path, err := os.MkdirTemp("", "spn")
+	require.NoError(t, err)
+	repo, err := git.PlainClone(path, false, &git.CloneOptions{
+		URL:           spnURL,
+		ReferenceName: plumbing.NewBranchReferenceName("develop"),
+		Progress:      os.Stdout,
+	})
+	w, err := repo.Worktree()
+	require.NoError(t, err)
+	err = w.Checkout(&git.CheckoutOptions{
+		Hash: plumbing.NewHash(spnHash),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(path)
+	})
+	return path
+}
+
+func TestNetworkPublish(t *testing.T) {
+	var (
+		spnPath = cloneSPN(t)
+		env     = envtest.New(t)
+		spn     = env.App(
+			spnPath,
+			envtest.AppHomePath("/tmp/spnhome"),
+			envtest.AppConfigPath(path.Join(spnPath, "config_2.yml")),
+		)
+		servers = spn.Config().Host
+	)
+
+	var (
+		ctx, cancel       = context.WithTimeout(env.Ctx(), envtest.ServeTimeout)
+		isBackendAliveErr error
+	)
+
+	go func() {
+		defer cancel()
+
+		if isBackendAliveErr = env.IsAppServed(ctx, servers); isBackendAliveErr != nil {
+			return
+		}
+		var b bytes.Buffer
+		env.Exec("publish planet chain to spn",
+			step.NewSteps(step.New(
+				step.Exec(
+					envtest.IgniteApp,
+					"network", "chain", "publish", "https://github.com/lubtd/planet",
+				),
+				step.Stdout(&b),
+			)),
+		)
+		require.False(t, env.HasFailed(), b.String())
+	}()
+
+	env.Must(spn.Serve("serve spn chain", envtest.ExecCtx(ctx)))
+
+	require.NoError(t, isBackendAliveErr, "spn cannot get online in time")
+}

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -70,7 +70,9 @@ func TestNetworkPublish(t *testing.T) {
 			step.NewSteps(step.New(
 				step.Exec(
 					envtest.IgniteApp,
-					"network", "chain", "publish", "https://github.com/lubtd/planet",
+					"network", "chain", "publish",
+					"https://github.com/lubtd/planet",
+					"--local",
 				),
 				step.Stdout(&b),
 			)),

--- a/integration/node/cmd_query_bank_test.go
+++ b/integration/node/cmd_query_bank_test.go
@@ -108,7 +108,7 @@ func TestNodeQueryBankBalances(t *testing.T) {
 			cosmosclient.WithNodeAddress(node),
 		)
 		require.NoError(t, err)
-		require.NoError(t, client.WaitForNextBlock(context.Background()))
+		waitForNextBlock(t, client)
 
 		b := &bytes.Buffer{}
 

--- a/integration/node/cmd_query_tx_test.go
+++ b/integration/node/cmd_query_tx_test.go
@@ -64,7 +64,6 @@ func TestNodeQueryTx(t *testing.T) {
 					"100token",
 					"--node", node,
 					"--keyring-dir", home,
-					"--broadcast-mode", "sync",
 				),
 				step.Stdout(b),
 			)),

--- a/integration/node/cmd_query_tx_test.go
+++ b/integration/node/cmd_query_tx_test.go
@@ -48,7 +48,7 @@ func TestNodeQueryTx(t *testing.T) {
 			cosmosclient.WithNodeAddress(node),
 		)
 		require.NoError(t, err)
-		require.NoError(t, client.WaitForNextBlock(context.Background()))
+		waitForNextBlock(t, client)
 
 		b := &bytes.Buffer{}
 		env.Exec("send 100token from alice to bob",
@@ -75,7 +75,7 @@ func TestNodeQueryTx(t *testing.T) {
 		res := regexp.MustCompile(`\(hash = (\w+)\)`).FindAllStringSubmatch(b.String(), -1)
 		require.Len(t, res[0], 2, "can't extract hash from command output")
 		hash := res[0][1]
-		require.NoError(t, client.WaitForNextBlock(context.Background()))
+		waitForNextBlock(t, client)
 
 		env.Must(env.Exec("query tx",
 			step.NewSteps(step.New(

--- a/integration/node/cmd_tx_bank_send_test.go
+++ b/integration/node/cmd_tx_bank_send_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,12 @@ import (
 	"github.com/ignite/cli/ignite/pkg/xurl"
 	envtest "github.com/ignite/cli/integration"
 )
+
+func waitForNextBlock(t *testing.T, client cosmosclient.Client) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	require.NoError(t, client.WaitForNextBlock(ctx))
+}
 
 func TestNodeTxBankSend(t *testing.T) {
 	var (
@@ -108,7 +115,7 @@ func TestNodeTxBankSend(t *testing.T) {
 			cosmosclient.WithNodeAddress(node),
 		)
 		require.NoError(t, err)
-		require.NoError(t, client.WaitForNextBlock(context.Background()))
+		waitForNextBlock(t, client)
 
 		env.Exec("send 100token from alice to bob",
 			step.NewSteps(step.New(


### PR DESCRIPTION
Fix #2721 

The main work of this PR was to ensure that `cosmosclient.BroadcastTx` continues to work as expected, meaning it continues to return the response tx once the tx is confirmed.

With the previous setting broadcast mode block it was easy, but with broadcast mode sync, you have to wait for the tx to be confirmed, and then reads it data. This is done thanks to a new method `WaitForTx` which relies on `WaitForNextBlock` that was previouisly added.

I also started some integration tests on the `network` commands, because they are the main consumers of `cosmosclient.BroadcastTx`.

The flag `--broadcast-mode` has been removed from the `node` command, because it has been added to prevent timeouts when broadcast mode block was used. Since this mode is no longer used, I thought it's no longer required to expose such setting.