### PR TITLE
fix: change faucet to allow C.O.R.S. preflight requests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Change vuex generation to use a default TS client path.
 - Fix cli action org in templates.
 - Seal the capability keeper in the `app.go` template
+- Change faucet to allow C.O.R.S. preflight requests.
 
 ## [`v0.24.0`](https://github.com/ignite/cli/releases/tag/v0.24.0)
 

--- a/ignite/pkg/cosmosfaucet/http.go
+++ b/ignite/pkg/cosmosfaucet/http.go
@@ -14,16 +14,20 @@ import (
 func (f Faucet) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	router := mux.NewRouter()
 
-	router.Handle("/", cors.Default().Handler(http.HandlerFunc(f.faucetHandler))).
-		Methods(http.MethodPost)
+	router.
+		Handle("/", cors.Default().Handler(http.HandlerFunc(f.faucetHandler))).
+		Methods(http.MethodPost, http.MethodOptions)
 
-	router.Handle("/info", cors.Default().Handler(http.HandlerFunc(f.faucetInfoHandler))).
+	router.
+		Handle("/info", cors.Default().Handler(http.HandlerFunc(f.faucetInfoHandler))).
+		Methods(http.MethodGet, http.MethodOptions)
+
+	router.
+		HandleFunc("/", openapiconsole.Handler("Faucet", "openapi.yml")).
 		Methods(http.MethodGet)
 
-	router.HandleFunc("/", openapiconsole.Handler("Faucet", "openapi.yml")).
-		Methods(http.MethodGet)
-
-	router.HandleFunc("/openapi.yml", f.openAPISpecHandler).
+	router.
+		HandleFunc("/openapi.yml", f.openAPISpecHandler).
 		Methods(http.MethodGet)
 
 	router.ServeHTTP(w, r)

--- a/ignite/pkg/cosmosfaucet/http_test.go
+++ b/ignite/pkg/cosmosfaucet/http_test.go
@@ -1,0 +1,42 @@
+package cosmosfaucet_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ignite/cli/ignite/pkg/cosmosfaucet"
+)
+
+func TestServeHTTPCORS(t *testing.T) {
+	f := cosmosfaucet.Faucet{}
+	cases := []struct {
+		name, method string
+	}{
+		{
+			name:   "root endpoint",
+			method: "POST",
+		},
+		{
+			name:   "info endpoint",
+			method: "GET",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			res := httptest.NewRecorder()
+			req, _ := http.NewRequest("OPTIONS", "/", nil)
+			req.Header.Set("Access-Control-Request-Method", tt.method)
+
+			// Act
+			f.ServeHTTP(res, req)
+
+			// Assert
+			require.Equal(t, http.StatusNoContent, res.Result().StatusCode)
+		})
+	}
+}

--- a/ignite/pkg/cosmosfaucet/http_test.go
+++ b/ignite/pkg/cosmosfaucet/http_test.go
@@ -13,15 +13,17 @@ import (
 func TestServeHTTPCORS(t *testing.T) {
 	f := cosmosfaucet.Faucet{}
 	cases := []struct {
-		name, method string
+		name, method, path string
 	}{
 		{
 			name:   "root endpoint",
 			method: "POST",
+			path:   "/",
 		},
 		{
 			name:   "info endpoint",
 			method: "GET",
+			path:   "/info",
 		},
 	}
 
@@ -29,7 +31,7 @@ func TestServeHTTPCORS(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Arrange
 			res := httptest.NewRecorder()
-			req, _ := http.NewRequest("OPTIONS", "/", nil)
+			req, _ := http.NewRequest("OPTIONS", tt.path, nil)
 			req.Header.Set("Access-Control-Request-Method", tt.method)
 
 			// Act


### PR DESCRIPTION
**Description**

Some of the faucet service endpoint are using C.O.R.S. but those endpoints are not allowing `OPTIONS` requests which are needed for the preflight one.

**Solution**

Change faucet's HTTP handler to allow `OPTIONS` request in all the endpoints that have C.O.R.S. enabled.
