### PR TITLE
chore: reveal `network` command

### DIFF
--- a/ignite/cmd/network.go
+++ b/ignite/cmd/network.go
@@ -44,7 +44,6 @@ func NewNetwork() *cobra.Command {
 		Aliases: []string{"n"},
 		Short:   "Launch a blockchain network in production",
 		Args:    cobra.ExactArgs(1),
-		Hidden:  true,
 	}
 
 	// configure flags.


### PR DESCRIPTION
Fix #2888

The command will now appear in `ignite help` and in the CLI reference documentation.