### PR TITLE
chore: add lubtd as docs codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 *       @ilgooz @lubtd @jeronimoalbi @aljo242 @tbruyelle @fadeev
 
 # Docs
-*.md    @ilgooz @aljo242
+*.md    @ilgooz @aljo242 @lubtd


### PR DESCRIPTION
Add my handle in docs codeowner as a maintainer of the docs for Network features