### PR TITLE
release: `v0.23.1`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [`v0.23.1`](https://github.com/ignite/cli/releases/tag/v0.23.1)
+
+NOTE: This release deprecates `v0.23.0` due to a security fix.  If you are using `v0.23.x` of `ignite/cli` please upgrade
+to this version or to a newer version with the security fix.
+
+### Fixes
+
+- Update `cosmos-sdk` to `v0.45.9` for a security fix
+- Update `cosmoscmd` baseapp options for a security fix
+
 ## [`v0.23.0`](https://github.com/ignite/cli/releases/tag/v0.23.0)
 
 ### Features

--- a/ignite/pkg/cosmoscmd/root.go
+++ b/ignite/pkg/cosmoscmd/root.go
@@ -374,6 +374,8 @@ func (a appCreator) newApp(
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
+		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagIAVLFastNode))),
 	)
 }
 


### PR DESCRIPTION
This PR creates a backported release for `v0.23.x` of CLI with the Dragonberry SDK security fixes.  Other according changes were made to allow the backport to work.

After approved, we can set to the release to track this branch.