### PR TITLE
feat(`network`): add `network add-account` command

### DIFF
--- a/ignite/cmd/network_request.go
+++ b/ignite/cmd/network_request.go
@@ -16,6 +16,7 @@ func NewNetworkRequest() *cobra.Command {
 		NewNetworkRequestApprove(),
 		NewNetworkRequestReject(),
 		NewNetworkRequestVerify(),
+		NewNetworkRequestAddAccount(),
 	)
 
 	return c

--- a/ignite/cmd/network_request_add_account.go
+++ b/ignite/cmd/network_request_add_account.go
@@ -1,6 +1,7 @@
 package ignitecmd
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,7 +18,7 @@ func NewNetworkRequestAddAccount() *cobra.Command {
 		Use:   "add-account [launch-id] [address] [coins]",
 		Short: "Send request to add account",
 		RunE:  networkRequestAddAccountHandler,
-		Args:  cobra.MaximumNArgs(3),
+		Args:  cobra.RangeArgs(2, 3),
 	}
 
 	flagSetClearCache(c)
@@ -76,6 +77,9 @@ func networkRequestAddAccountHandler(cmd *cobra.Command, args []string) error {
 			)
 		}
 	} else {
+		if len(args) < 3 {
+			return errors.New("account balance expected")
+		}
 		balanceStr := args[2]
 		balance, err = sdk.ParseCoinsNormalized(balanceStr)
 		if err != nil {

--- a/ignite/cmd/network_request_add_account.go
+++ b/ignite/cmd/network_request_add_account.go
@@ -1,0 +1,92 @@
+package ignitecmd
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
+	"github.com/ignite/cli/ignite/pkg/cliui"
+	"github.com/ignite/cli/ignite/services/network"
+	"github.com/ignite/cli/ignite/services/network/networkchain"
+)
+
+// NewNetworkRequestAddAccount creates a new command to send add account request
+func NewNetworkRequestAddAccount() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "add-account [launch-id] [address] [coins]",
+		Short: "Send request to add account",
+		RunE:  networkRequestAddAccountHandler,
+		Args:  cobra.MaximumNArgs(3),
+	}
+
+	flagSetClearCache(c)
+	c.Flags().AddFlagSet(flagNetworkFrom())
+	c.Flags().AddFlagSet(flagSetHome())
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+	c.Flags().AddFlagSet(flagSetKeyringDir())
+	return c
+}
+
+func networkRequestAddAccountHandler(cmd *cobra.Command, args []string) error {
+	session := cliui.New(cliui.StartSpinner())
+	defer session.End()
+
+	nb, err := newNetworkBuilder(cmd, CollectEvents(session.EventBus()))
+	if err != nil {
+		return err
+	}
+
+	// parse launch ID
+	launchID, err := network.ParseID(args[0])
+	if err != nil {
+		return err
+	}
+
+	address := args[1]
+
+	n, err := nb.Network()
+	if err != nil {
+		return err
+	}
+
+	chainLaunch, err := n.ChainLaunch(cmd.Context(), launchID)
+	if err != nil {
+		return err
+	}
+
+	var networkOptions []networkchain.Option
+
+	if flagGetCheckDependencies(cmd) {
+		networkOptions = append(networkOptions, networkchain.CheckDependencies())
+	}
+
+	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch), networkOptions...)
+	if err != nil {
+		return err
+	}
+
+	var balance sdk.Coins
+	if c.IsAccountBalanceFixed() {
+		balance = c.AccountBalance()
+		if len(args) == 3 {
+			return fmt.Errorf(
+				"balance can't be provided, balance has been set by coordinator to %s",
+				balance.String(),
+			)
+		}
+	} else {
+		balanceStr := args[2]
+		balance, err = sdk.ParseCoinsNormalized(balanceStr)
+		if err != nil {
+			return err
+		}
+	}
+
+	return n.SendAccountRequest(
+		cmd.Context(),
+		launchID,
+		address,
+		balance,
+	)
+}


### PR DESCRIPTION
```
ignite network request add-account [launch-id] [address] [coins] [flags]
```

Allows to send a request to be an account in a chain genesis (or add an account directly for coordinator)

```
ignite n request add-account 44 spn1pe5h2gelhu8aukmrnj0clmec56aspxzuxcy99y 1000bar
```

If a chain has been published with the `AccountBalance` option, no `coins` value is expected

```
ignite n chain publish https://github.com/ignite/example --account-balance 5000foo

ignite n request add-account 45 spn1pe5h2gelhu8aukmrnj0clmec56aspxzuxcy99y 50bar --from alice
Source code fetched
Blockchain set up
balance can't be provided, balance has been set by coordinator to 5000foo

ignite n request add-account 45 spn1pe5h2gelhu8aukmrnj0clmec56aspxzuxcy99y --from alice
Source code fetched
Blockchain set up
Request 1 to add account to the network has been submitted!

ignite n request list 45
Id 	Status 		Type 			Content
1 	PENDING 	Add Genesis Account 	spn1pe5h2gelhu8aukmrnj0clmec56aspxzuxcy99y, 5000foo
```