### PR TITLE
chore(`network`): hide unused command sets

### DIFF
--- a/ignite/cmd/network_campaign.go
+++ b/ignite/cmd/network_campaign.go
@@ -8,8 +8,9 @@ import (
 // subcommands related to launching a network for a campaign.
 func NewNetworkCampaign() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "campaign",
-		Short: "Handle campaigns",
+		Use:    "campaign",
+		Short:  "Handle campaigns",
+		Hidden: true,
 	}
 	c.AddCommand(
 		NewNetworkCampaignPublish(),

--- a/ignite/cmd/network_profile.go
+++ b/ignite/cmd/network_profile.go
@@ -11,10 +11,11 @@ import (
 // NewNetworkProfile returns a new command to show the address profile info on Starport Network.
 func NewNetworkProfile() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "profile [campaign-id]",
-		Short: "Show the address profile info",
-		Args:  cobra.RangeArgs(0, 1),
-		RunE:  networkProfileHandler,
+		Use:    "profile [campaign-id]",
+		Short:  "Show the address profile info",
+		Args:   cobra.RangeArgs(0, 1),
+		RunE:   networkProfileHandler,
+		Hidden: true,
 	}
 	c.Flags().AddFlagSet(flagNetworkFrom())
 	c.Flags().AddFlagSet(flagSetKeyringBackend())

--- a/ignite/cmd/network_reward.go
+++ b/ignite/cmd/network_reward.go
@@ -7,8 +7,9 @@ import (
 // NewNetworkReward creates a new chain reward command
 func NewNetworkReward() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "reward",
-		Short: "Manage network rewards",
+		Use:    "reward",
+		Short:  "Manage network rewards",
+		Hidden: true,
 	}
 	c.AddCommand(
 		NewNetworkRewardSet(),


### PR DESCRIPTION
Hide command sets not used and in development for now
```
n campaign
n reward
n profile
```