### PR TITLE
docs: network request approve

### DIFF
--- a/ignite/cmd/network_request_approve.go
+++ b/ignite/cmd/network_request_approve.go
@@ -35,7 +35,10 @@ initializing and launching the chain locally. If the chain starts successfully,
 requests are considered to be "verified" and are approved. If one or more
 requested changes stop the chain from launching locally, the verification
 process fails and the approval of all requests is canceled. To skip the
-verification process use the "--no-verification" flag.`,
+verification process use the "--no-verification" flag.
+
+Note that Ignite will try to approve requests in the same order as request IDs
+are submitted to the "approve" command.`,
 		RunE: networkRequestApproveHandler,
 		Args: cobra.ExactArgs(2),
 	}

--- a/ignite/cmd/network_request_approve.go
+++ b/ignite/cmd/network_request_approve.go
@@ -21,8 +21,23 @@ func NewNetworkRequestApprove() *cobra.Command {
 		Use:     "approve [launch-id] [number<,...>]",
 		Aliases: []string{"accept"},
 		Short:   "Approve requests",
-		RunE:    networkRequestApproveHandler,
-		Args:    cobra.ExactArgs(2),
+		Long: `The "approve" command is used by a chain's coordinator to approve requests.
+Multiple requests can be approved using a comma-separated list and/or using a
+dash syntax.
+
+  ignite network request approve 42 1,2,3-6,7,8
+
+The command above approves requests with IDs from 1 to 8 included on a chain
+with a launch ID 42.
+
+When requests are approved Ignite applies the requested changes and simulates
+initializing and launching the chain locally. If the chain starts successfully,
+requests are considered to be "verified" and are approved. If one or more
+requested changes stop the chain from launching locally, the verification
+process fails and the approval of all requests is canceled. To skip the
+verification process use the "--no-verification" flag.`,
+		RunE: networkRequestApproveHandler,
+		Args: cobra.ExactArgs(2),
 	}
 
 	flagSetClearCache(c)


### PR DESCRIPTION
Should we mention that the order of request IDs matter?