### PR TITLE
feat: `ignite n request remove-validator`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#2955](https://github.com/ignite/cli/pull/2955/) Add `ignite network request add-account` command.
+- [#2995](https://github.com/ignite/cli/pull/2995/) Add `ignite network request remove-validator` command.
 
 ### Changes
 

--- a/ignite/cmd/network_request.go
+++ b/ignite/cmd/network_request.go
@@ -17,6 +17,7 @@ func NewNetworkRequest() *cobra.Command {
 		NewNetworkRequestReject(),
 		NewNetworkRequestVerify(),
 		NewNetworkRequestAddAccount(),
+		NewNetworkRequestRemoveValidator(),
 	)
 
 	return c

--- a/ignite/cmd/network_request_remove_validator.go
+++ b/ignite/cmd/network_request_remove_validator.go
@@ -1,16 +1,11 @@
 package ignitecmd
 
 import (
-	"errors"
-	"fmt"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 
 	"github.com/ignite/cli/ignite/pkg/cliui"
 	"github.com/ignite/cli/ignite/pkg/cosmosutil"
 	"github.com/ignite/cli/ignite/services/network"
-	"github.com/ignite/cli/ignite/services/network/networkchain"
 	"github.com/ignite/cli/ignite/services/network/networktypes"
 )
 
@@ -57,40 +52,9 @@ func networkRequestRemoveValidatorHandler(cmd *cobra.Command, args []string) err
 		return err
 	}
 
-	chainLaunch, err := n.ChainLaunch(cmd.Context(), launchID)
-	if err != nil {
-		return err
-	}
-
-	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch))
-	if err != nil {
-		return err
-	}
-
-	var balance sdk.Coins
-	if c.IsAccountBalanceFixed() {
-		balance = c.AccountBalance()
-		if len(args) == 3 {
-			return fmt.Errorf(
-				"balance can't be provided, balance has been set by coordinator to %s",
-				balance.String(),
-			)
-		}
-	} else {
-		if len(args) < 3 {
-			return errors.New("account balance expected")
-		}
-		balanceStr := args[2]
-		balance, err = sdk.ParseCoinsNormalized(balanceStr)
-		if err != nil {
-			return err
-		}
-	}
-
-	return n.SendAccountRequest(
+	return n.SendValidatorRemoveRequest(
 		cmd.Context(),
 		launchID,
 		address,
-		balance,
 	)
 }

--- a/ignite/cmd/network_request_remove_validator.go
+++ b/ignite/cmd/network_request_remove_validator.go
@@ -1,0 +1,96 @@
+package ignitecmd
+
+import (
+	"errors"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
+	"github.com/ignite/cli/ignite/pkg/cliui"
+	"github.com/ignite/cli/ignite/pkg/cosmosutil"
+	"github.com/ignite/cli/ignite/services/network"
+	"github.com/ignite/cli/ignite/services/network/networkchain"
+	"github.com/ignite/cli/ignite/services/network/networktypes"
+)
+
+// NewNetworkRequestRemoveValidator creates a new command to send remove validator request
+func NewNetworkRequestRemoveValidator() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "remove-validator [launch-id] [address]",
+		Short: "Send request to remove validator",
+		RunE:  networkRequestRemoveValidatorHandler,
+		Args:  cobra.ExactArgs(2),
+	}
+
+	flagSetClearCache(c)
+	c.Flags().AddFlagSet(flagNetworkFrom())
+	c.Flags().AddFlagSet(flagSetHome())
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+	c.Flags().AddFlagSet(flagSetKeyringDir())
+	return c
+}
+
+func networkRequestRemoveValidatorHandler(cmd *cobra.Command, args []string) error {
+	session := cliui.New(cliui.StartSpinner())
+	defer session.End()
+
+	nb, err := newNetworkBuilder(cmd, CollectEvents(session.EventBus()))
+	if err != nil {
+		return err
+	}
+
+	// parse launch ID
+	launchID, err := network.ParseID(args[0])
+	if err != nil {
+		return err
+	}
+
+	// get the address for the account and change the prefix for Ignite Chain
+	address, err := cosmosutil.ChangeAddressPrefix(args[1], networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
+	n, err := nb.Network()
+	if err != nil {
+		return err
+	}
+
+	chainLaunch, err := n.ChainLaunch(cmd.Context(), launchID)
+	if err != nil {
+		return err
+	}
+
+	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch))
+	if err != nil {
+		return err
+	}
+
+	var balance sdk.Coins
+	if c.IsAccountBalanceFixed() {
+		balance = c.AccountBalance()
+		if len(args) == 3 {
+			return fmt.Errorf(
+				"balance can't be provided, balance has been set by coordinator to %s",
+				balance.String(),
+			)
+		}
+	} else {
+		if len(args) < 3 {
+			return errors.New("account balance expected")
+		}
+		balanceStr := args[2]
+		balance, err = sdk.ParseCoinsNormalized(balanceStr)
+		if err != nil {
+			return err
+		}
+	}
+
+	return n.SendAccountRequest(
+		cmd.Context(),
+		launchID,
+		address,
+		balance,
+	)
+}

--- a/ignite/services/network/join.go
+++ b/ignite/services/network/join.go
@@ -2,14 +2,10 @@ package network
 
 import (
 	"context"
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 
-	"github.com/ignite/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite/cli/ignite/pkg/cosmosutil"
-	"github.com/ignite/cli/ignite/pkg/events"
 	"github.com/ignite/cli/ignite/pkg/xurl"
 	"github.com/ignite/cli/ignite/services/network/networkchain"
 	"github.com/ignite/cli/ignite/services/network/networktypes"
@@ -101,104 +97,4 @@ func (n Network) SendAccountRequestForCoordinator(ctx context.Context, launchID 
 	}
 
 	return n.SendAccountRequest(ctx, launchID, addr, amount)
-}
-
-// SendAccountRequest creates an add AddAccount request message.
-func (n Network) SendAccountRequest(
-	ctx context.Context,
-	launchID uint64,
-	address string,
-	amount sdk.Coins,
-) error {
-	addr, err := n.account.Address(networktypes.SPN)
-	if err != nil {
-		return err
-	}
-
-	msg := launchtypes.NewMsgSendRequest(
-		addr,
-		launchID,
-		launchtypes.NewGenesisAccount(
-			launchID,
-			address,
-			amount,
-		),
-	)
-
-	n.ev.Send("Broadcasting account transactions", events.ProgressStarted())
-
-	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
-	if err != nil {
-		return err
-	}
-
-	var requestRes launchtypes.MsgSendRequestResponse
-	if err := res.Decode(&requestRes); err != nil {
-		return err
-	}
-
-	if requestRes.AutoApproved {
-		n.ev.Send(
-			"Account added to the network by the coordinator!",
-			events.Icon(icons.Bullet),
-			events.ProgressFinished(),
-		)
-	} else {
-		n.ev.Send(
-			fmt.Sprintf("Request %d to add account to the network has been submitted!", requestRes.RequestID),
-			events.Icon(icons.Bullet),
-			events.ProgressFinished(),
-		)
-	}
-	return nil
-}
-
-// SendValidatorRequest creates the RequestAddValidator message into the SPN
-func (n Network) SendValidatorRequest(
-	ctx context.Context,
-	launchID uint64,
-	peer launchtypes.Peer,
-	valAddress string,
-	gentx []byte,
-	gentxInfo cosmosutil.GentxInfo,
-) error {
-	addr, err := n.account.Address(networktypes.SPN)
-	if err != nil {
-		return err
-	}
-
-	msg := launchtypes.NewMsgSendRequest(
-		addr,
-		launchID,
-		launchtypes.NewGenesisValidator(
-			launchID,
-			valAddress,
-			gentx,
-			gentxInfo.PubKey,
-			gentxInfo.SelfDelegation,
-			peer,
-		),
-	)
-
-	n.ev.Send("Broadcasting validator transaction", events.ProgressStarted())
-
-	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
-	if err != nil {
-		return err
-	}
-
-	var requestRes launchtypes.MsgSendRequestResponse
-	if err := res.Decode(&requestRes); err != nil {
-		return err
-	}
-
-	if requestRes.AutoApproved {
-		n.ev.Send("Validator added to the network by the coordinator!", events.ProgressFinished())
-	} else {
-		n.ev.Send(
-			fmt.Sprintf("Request %d to join the network as a validator has been submitted!", requestRes.RequestID),
-			events.ProgressFinished(),
-		)
-	}
-	return nil
 }

--- a/ignite/services/network/join.go
+++ b/ignite/services/network/join.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 

--- a/ignite/services/network/request.go
+++ b/ignite/services/network/request.go
@@ -2,6 +2,9 @@ package network
 
 import (
 	"context"
+	"fmt"
+	"github.com/ignite/cli/ignite/pkg/cliui/icons"
+	"github.com/ignite/cli/ignite/pkg/cosmosutil"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
@@ -98,4 +101,148 @@ func (n Network) SubmitRequest(ctx context.Context, launchID uint64, reviewal ..
 
 	var requestRes launchtypes.MsgSettleRequestResponse
 	return res.Decode(&requestRes)
+}
+
+// SendAccountRequest creates an add AddAccount request message.
+func (n Network) SendAccountRequest(
+	ctx context.Context,
+	launchID uint64,
+	address string,
+	amount sdk.Coins,
+) error {
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
+	msg := launchtypes.NewMsgSendRequest(
+		addr,
+		launchID,
+		launchtypes.NewGenesisAccount(
+			launchID,
+			address,
+			amount,
+		),
+	)
+
+	n.ev.Send("Broadcasting account transactions", events.ProgressStarted())
+
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
+	if err != nil {
+		return err
+	}
+
+	var requestRes launchtypes.MsgSendRequestResponse
+	if err := res.Decode(&requestRes); err != nil {
+		return err
+	}
+
+	if requestRes.AutoApproved {
+		n.ev.Send(
+			"Account added to the network by the coordinator!",
+			events.Icon(icons.Bullet),
+			events.ProgressFinished(),
+		)
+	} else {
+		n.ev.Send(
+			fmt.Sprintf("Request %d to add account to the network has been submitted!", requestRes.RequestID),
+			events.Icon(icons.Bullet),
+			events.ProgressFinished(),
+		)
+	}
+	return nil
+}
+
+// SendValidatorRequest creates the RequestAddValidator message into the SPN
+func (n Network) SendValidatorRequest(
+	ctx context.Context,
+	launchID uint64,
+	peer launchtypes.Peer,
+	valAddress string,
+	gentx []byte,
+	gentxInfo cosmosutil.GentxInfo,
+) error {
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
+	msg := launchtypes.NewMsgSendRequest(
+		addr,
+		launchID,
+		launchtypes.NewGenesisValidator(
+			launchID,
+			valAddress,
+			gentx,
+			gentxInfo.PubKey,
+			gentxInfo.SelfDelegation,
+			peer,
+		),
+	)
+
+	n.ev.Send("Broadcasting validator transaction", events.ProgressStarted())
+
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
+	if err != nil {
+		return err
+	}
+
+	var requestRes launchtypes.MsgSendRequestResponse
+	if err := res.Decode(&requestRes); err != nil {
+		return err
+	}
+
+	if requestRes.AutoApproved {
+		n.ev.Send("Validator added to the network by the coordinator!", events.ProgressFinished())
+	} else {
+		n.ev.Send(
+			fmt.Sprintf("Request %d to join the network as a validator has been submitted!", requestRes.RequestID),
+			events.ProgressFinished(),
+		)
+	}
+	return nil
+}
+
+// SendValidatorRemoveRequest creates the RequestRemoveValidator message to SPN
+func (n Network) SendValidatorRemoveRequest(
+	ctx context.Context,
+	launchID uint64,
+	valAddress string,
+) error {
+	addr, err := n.account.Address(networktypes.SPN)
+	if err != nil {
+		return err
+	}
+
+	msg := launchtypes.NewMsgSendRequest(
+		addr,
+		launchID,
+		launchtypes.NewValidatorRemoval(
+			valAddress,
+		),
+	)
+
+	n.ev.Send("Broadcasting transaction", events.ProgressStarted())
+
+	res, err := n.cosmos.BroadcastTx(ctx, n.account, msg)
+	if err != nil {
+		return err
+	}
+
+	var requestRes launchtypes.MsgSendRequestResponse
+	if err := res.Decode(&requestRes); err != nil {
+		return err
+	}
+
+	if requestRes.AutoApproved {
+		n.ev.Send("Validator removed from network by the coordinator!", events.ProgressFinished())
+	} else {
+		n.ev.Send(
+			fmt.Sprintf(
+				"Request %d to remove validator from the network has been submitted!", requestRes.RequestID,
+			),
+			events.ProgressFinished(),
+		)
+	}
+	return nil
 }

--- a/ignite/services/network/request.go
+++ b/ignite/services/network/request.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
+
 	"github.com/ignite/cli/ignite/pkg/cliui/icons"
 	"github.com/ignite/cli/ignite/pkg/cosmosutil"
 


### PR DESCRIPTION
Closes #2966

Moves `Send**Request` functions from `join.go` to `request.go`