### PR TITLE
fix(`network`): set validator set nil error up to date

### DIFF
--- a/ignite/services/scaffolder/init.go
+++ b/ignite/services/scaffolder/init.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/gobuffalo/genny"
+	vue "github.com/ignite/web"
+
 	"github.com/ignite/cli/ignite/pkg/cache"
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/exec"
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
@@ -19,7 +21,6 @@ import (
 	"github.com/ignite/cli/ignite/pkg/placeholder"
 	"github.com/ignite/cli/ignite/templates/app"
 	modulecreate "github.com/ignite/cli/ignite/templates/module/create"
-	vue "github.com/ignite/web"
 )
 
 var (


### PR DESCRIPTION
In the process of approving requests, we simulate genesis to check the chain can start

In this process, we ignore the error where validator set is still nil and chain can't start, so that the coordinator can approve requests before approving the first validator for the chain

We do this by comparing error string
Since the error statement for this has been updated in the SDK, we store the historical list of this error so we can ignore the the error for several version of the SDK