### PR TITLE
docs: fix formatting to get code blocks rendered

### DIFF
--- a/ignite/cmd/chain_build.go
+++ b/ignite/cmd/chain_build.go
@@ -31,21 +31,21 @@ installs the binary in the $(go env GOPATH)/bin directory.
 
 You can customize the output directory for the binary using a flag:
 
-  ignite chain build --output dist
+	ignite chain build --output dist
 
 To compile the binary Ignite first compiles protocol buffer (proto) files into
 Go source code. Proto files contain required type and services definitions. If
 you're using another program to compile proto files, you can use a flag to tell
 Ignite to skip the proto compilation step:
 
-  ignite chain build --skip-proto
+	ignite chain build --skip-proto
 
 Afterwards, Ignite install dependencies specified in the go.mod file. By default
 Ignite doesn't check that dependencies of the main module stored in the module
 cache have not been modified since they were downloaded. To enforce dependency
 checking (essentially, running "go mod verify") use a flag:
 
-  ignite chain build --check-dependencies
+	ignite chain build --check-dependencies
 
 Next, Ignite identifies the "main" package of the project. By default the "main"
 package is located in "cmd/{app}d" directory, where "{app}" is the name of the
@@ -53,21 +53,21 @@ scaffolded project and "d" stands for daemon. If your your project contains more
 than one "main" package, specify the path to the one that Ignite should compile
 in config.yml:
 
-build:
-  main: custom/path/to/main
+	build:
+		main: custom/path/to/main
 
 By default the binary name will match the top-level module name (specified in
 go.mod) with a suffix "d". This can be customized in config.yml:
 
-build:
-  binary: mychaind
+	build:
+		binary: mychaind
 
 You can also specify custom linker flags:
 
-build:
-  ldflags:
-    - "-X main.Version=development"
-    - "-X main.Date=01/05/2022T19:54"
+	build:
+		ldflags:
+			- "-X main.Version=development"
+			- "-X main.Date=01/05/2022T19:54"
 
 To build binaries for a release, use the --release flag. The binaries for one or
 more specified release targets are built in a "release/" directory in the
@@ -75,7 +75,7 @@ project's source directory. Specify the release targets with GOOS:GOARCH build
 tags. If the optional --release.targets is not specified, a binary is created
 for your current environment.
 
-  ignite chain build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64
+	ignite chain build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64
 `,
 		Args: cobra.NoArgs,
 		RunE: chainBuildHandler,

--- a/ignite/cmd/chain_init.go
+++ b/ignite/cmd/chain_init.go
@@ -22,8 +22,8 @@ By default, the data directory will be initialized in $HOME/.mychain, where
 "mychain" is the name of the project. To set a custom data directory use the
 --home flag or set the value in config.yml:
 
-init:
-  home: "~/.customdir"
+	init:
+		home: "~/.customdir"
 
 The data directory contains three files in the "config" directory: app.toml,
 config.toml, client.toml. These files let you customize the behavior of your
@@ -31,15 +31,15 @@ blockchain node and the client executable. When a chain is re-initialized the
 data directory can be reset. To make some values in these files persistent, set
 them in config.yml:
 
-init:
-  app:
-    minimum-gas-prices: "0.025stake"
-  config:
-    consensus:
-      timeout_commit: "5s"
-      timeout_propose: "5s"
-  client:
-    output: "json"
+	init:
+		app:
+			minimum-gas-prices: "0.025stake"
+		config:
+			consensus:
+				timeout_commit: "5s"
+				timeout_propose: "5s"
+		client:
+			output: "json"
 
 The configuration above changes the minimum gas price of the validator (by
 default the gas price is set to 0 to allow "free" transactions), sets the block
@@ -60,11 +60,11 @@ directory "config" subdirectory and contains the initial state of the chain,
 including consensus and module parameters. You can customize the values of the
 genesis in config.yml:
 
-genesis:
-  app_state:
-    staking:
-      params:
-        bond_denom: "foo"
+	genesis:
+		app_state:
+			staking:
+				params:
+					bond_denom: "foo"
 
 The example above changes the staking token to "foo". If you change the staking
 denom, make sure the validator account has the right tokens.

--- a/ignite/cmd/chain_serve.go
+++ b/ignite/cmd/chain_serve.go
@@ -34,19 +34,19 @@ exporting and importing the genesis file.
 To force Ignite to start from a clean slate even if a genesis file exists, use
 the following flag:
 
-  ignite chain serve --reset-once
+	ignite chain serve --reset-once
 
 To force Ignite to reset the state every time the source code is modified, use
 the following flag:
 
-  ignite chain serve --force-reset
+	ignite chain serve --force-reset
 
 With Ignite it's possible to start more than one blockchain from the same source
 code using different config files. This is handy if you're building
 inter-blockchain functionality and, for example, want to try sending packets
 from one blockchain to another. To start a node using a specific config file:
 
-  ignite chain serve --config mars.yml
+	ignite chain serve --config mars.yml
 
 The serve command is meant to be used ONLY FOR DEVELOPMENT PURPOSES. Under the
 hood, it runs "appd start", where "appd" is the name of your chain's binary. For

--- a/ignite/cmd/network.go
+++ b/ignite/cmd/network.go
@@ -56,7 +56,7 @@ for launch.
 To publish the information about your chain as a coordinator run the following
 command (the URL should point to a repository with a Cosmos SDK chain):
 
-  ignite network chain publish github.com/ignite/example
+	ignite network chain publish github.com/ignite/example
 
 This command will return a launch identifier you will be using in the following
 commands. Let's say this identifier is 42.
@@ -65,26 +65,26 @@ Next, ask validators to initialize their nodes and request to join the network
 as validators. For a testnet you can use the default values suggested by the
 CLI.
 
-  ignite network chain init 42
+	ignite network chain init 42
 
-  ignite network chain join 42 --amount 95000000stake
+	ignite network chain join 42 --amount 95000000stake
 
 As a coordinator list all validator requests:
 
-  ignite network request list 42
+	ignite network request list 42
 
 Approve validator requests:
 
-  ignite network request approve 42 1,2
+	ignite network request approve 42 1,2
 
 Once you've approved all validators you need in the validator set, announce that
 the chain is ready for launch:
 
-  ignite network chain launch 42
+	ignite network chain launch 42
 
 Validators can now prepare their nodes for launch:
 
-  ignite network chain prepare 42
+	ignite network chain prepare 42
 
 The output of this command will show a command that a validator would use to
 launch their node, for example “exampled --home ~/.example”. After enough

--- a/ignite/cmd/network_chain_init.go
+++ b/ignite/cmd/network_chain_init.go
@@ -36,7 +36,7 @@ func NewNetworkChainInit() *cobra.Command {
 		Long: `Ignite network chain init is a command used by validators to initialize a
 validator node for a blockchain from the information stored on the Ignite chain.
 
-  ignite network chain init 42
+	ignite network chain init 42
 
 This command fetches the information about a chain with launch ID 42. The source
 code of the chain is cloned in a temporary directory, and the node's binary is
@@ -53,7 +53,7 @@ the values in non-interactive mode.
 Use the "--home" flag to choose a different path for the home directory of the
 blockchain:
 
-  ignite network chain init 42 --home ~/mychain
+	ignite network chain init 42 --home ~/mychain
 
 The end result of the "init" command is a validator home directory with a
 genesis validator transaction (gentx) file.`,

--- a/ignite/cmd/network_chain_join.go
+++ b/ignite/cmd/network_chain_join.go
@@ -47,7 +47,7 @@ The following command will send a request to join blockchain with launch ID 42
 as a validator and request to be added as an account with a token balance of
 95000000 STAKE.
 
-  ignite network chain join 42 --amount 95000000stake
+	ignite network chain join 42 --amount 95000000stake
 
 A request to join as a validator contains a gentx file. Ignite looks for gentx
 in a home directory used by "ignite network chain init" by default. To use a

--- a/ignite/cmd/network_request_approve.go
+++ b/ignite/cmd/network_request_approve.go
@@ -25,7 +25,7 @@ func NewNetworkRequestApprove() *cobra.Command {
 Multiple requests can be approved using a comma-separated list and/or using a
 dash syntax.
 
-  ignite network request approve 42 1,2,3-6,7,8
+	ignite network request approve 42 1,2,3-6,7,8
 
 The command above approves requests with IDs from 1 to 8 included on a chain
 with a launch ID 42.

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -32,15 +32,15 @@ func NewScaffoldChain() *cobra.Command {
 For example, the following command will create a blockchain called "hello" in
 the "hello/" directory:
 
-  ignite scaffold chain hello
+	ignite scaffold chain hello
 
 A project name can be a simple name or a URL. The name will be used as the Go
 module path for the project. Examples of project names:
 
-  ignite scaffold chain foo
-  ignite scaffold chain foo/bar
-  ignite scaffold chain example.org/foo
-  ignite scaffold chain github.com/username/foo
+	ignite scaffold chain foo
+	ignite scaffold chain foo/bar
+	ignite scaffold chain example.org/foo
+	ignite scaffold chain github.com/username/foo
 		
 A new directory with source code files will be created in the current directory.
 To use a different path use the "--path" flag.
@@ -58,7 +58,7 @@ example, the Cosmos Hub blockchain uses the default "cosmos" prefix, so that
 addresses look like this: "cosmos12fjzdtqfrrve7zyg9sv8j25azw2ua6tvu07ypf". To
 use a custom address prefix use the "--address-prefix" flag. For example:
 
-  ignite scaffold chain foo --address-prefix bar
+	ignite scaffold chain foo --address-prefix bar
 
 By default when compiling a blockchain's source code Ignite creates a cache to
 speed up the build process. To clear the cache when building a blockchain use

--- a/ignite/cmd/scaffold_list.go
+++ b/ignite/cmd/scaffold_list.go
@@ -36,7 +36,7 @@ provides the logic to create, read, update, and delete instances of the type.
 For example, let's review a command that generates the code to handle a list of
 posts and each post has "title" and "body" fields:
 
-  ignite scaffold list post title body
+	ignite scaffold list post title body
 
 This provides you with a "Post" type, MsgCreatePost, MsgUpdatePost,
 MsgDeletePost and two queries: Post and PostAll. The compiled CLI, let's say the
@@ -53,13 +53,13 @@ different type, you can specify it after a colon ":". The following types are
 supported: string, bool, int, uint, coin, array.string, array.int, array.uint,
 array.coin. An example of using custom types:
 
-  ignite scaffold list pool amount:coin tags:array.string height:int
+	ignite scaffold list pool amount:coin tags:array.string height:int
   
 Ignite also supports custom types:
   
-  ignite scaffold list product-details name description
-  
-  ignite scaffold list product price:coin details:ProductDetails
+	ignite scaffold list product-details name description
+
+	ignite scaffold list product price:coin details:ProductDetails
 
 In the example above the "ProductDetails" type was defined first, and then used
 as a custom type for the "details" field. Ignite doesn't support arrays of
@@ -69,19 +69,19 @@ By default the code will be scaffolded in the module that matches your project's
 name. If you have several modules in your project, you might want to specify a
 different module:
 
-  ignite scaffold list post title body --module blog
+	ignite scaffold list post title body --module blog
 
 By default, each message comes with a "creator" field that represents the
 address of the transaction signer. You can customize the name of this field with
 a flag:
 
-  ignite scaffold list post title body --signer author
+	ignite scaffold list post title body --signer author
 
 It's possible to scaffold just the getter/setter logic without the CRUD
 messages. This is useful when you want the methods to handle a type, but would
 like to scaffold messages manually. Use a flag to skip message scaffolding:
 
-  ignite scaffold list post title body --no-message
+	ignite scaffold list post title body --no-message
 
 The "creator" field is not generated if a list is scaffolded with the
 "--no-message" flag.

--- a/ignite/cmd/scaffold_map.go
+++ b/ignite/cmd/scaffold_map.go
@@ -26,26 +26,26 @@ incrementing integer, whereas "list" values are indexed by a user-provided value
 
 Let's use the same blog post example:
 
-  ignite scaffold map post title body
+	ignite scaffold map post title body
 
 This command scaffolds a "Post" type and CRUD functionality to create, read,
 updated, and delete posts. However, when creating a new post with your chain's
 binary (or by submitting a transaction through the chain's API) you will be
 required to provide an "index":
 
-  blogd tx blog create-post [index] [title] [body]
+	blogd tx blog create-post [index] [title] [body]
 	blogd tx blog create-post hello "My first post" "This is the body"
 
 This command will create a post and store it in the blockchain's state under the
 "hello" index. You will be able to fetch back the value of the post by querying
 for the "hello" key.
 
-  blogd q blog show-post hello
+	blogd q blog show-post hello
 
 To customize the index, use the "--index" flag. Multiple indices can be
 provided, which simplifies querying values. For example:
 
-  ignite scaffold map product price desc --index category,guid
+	ignite scaffold map product price desc --index category,guid
 
 With this command, you would get a "Product" value indexed by both a category
 and a GUID (globally unique ID). This will let you programmatically fetch

--- a/ignite/cmd/scaffold_message.go
+++ b/ignite/cmd/scaffold_message.go
@@ -32,7 +32,7 @@ recipient's account.
 Ignite's message scaffolding lets you create new types of messages and add them
 to your chain. For example:
 
-  ignite scaffold message add-pool amount:coins denom active:bool --module dex
+	ignite scaffold message add-pool amount:coins denom active:bool --module dex
 
 The command above will create a new message MsgAddPool with three fields: amount
 (in tokens), denom (a string), and active (a boolean). The message will be added
@@ -50,7 +50,7 @@ Inside this function, you can implement message handling logic.
 When successfully processed a message can return data. Use the —response flag to
 specify response fields and their types. For example
 
-  ignite scaffold message create-post title body --response id:int,title
+	ignite scaffold message create-post title body --response id:int,title
 
 The command above will scaffold MsgCreatePost which returns both an ID (an
 integer) and a title (a string).

--- a/ignite/cmd/scaffold_module.go
+++ b/ignite/cmd/scaffold_module.go
@@ -69,7 +69,7 @@ sending tokens between accounts. The method for sending tokens is a defined in
 the "bank"'s module keeper. You can scaffold a "foo" module with the dependency
 on "bank" with the following command:
 
-  ignite scaffold module foo --dep bank
+	ignite scaffold module foo --dep bank
 
 You can then define which methods you want to import from the "bank" keeper in
 "expected_keepers.go".
@@ -77,7 +77,7 @@ You can then define which methods you want to import from the "bank" keeper in
 You can also scaffold a module with a list of dependencies that can include both
 standard and custom modules (provided they exist):
 
-  ignite scaffold module bar --dep foo,mint,account
+	ignite scaffold module bar --dep foo,mint,account
 
 Note: the "--dep" flag doesn't install third-party modules into your
 application, it just generates extra code that specifies which existing modules
@@ -90,7 +90,7 @@ blockchain is running. An example of a param is "Inflation rate change" of the
 that accepts a list of param names. By default params are of type "string", but
 you can specify a type for each param. For example:
 
-  ignite scaffold module foo --params baz:uint,bar:bool
+	ignite scaffold module foo --params baz:uint,bar:bool
 
 Refer to Cosmos SDK documentation to learn more about modules, dependencies and
 params.


### PR DESCRIPTION
Before:

<img width="1559" alt="199468558-650ea7bf-ca88-457b-ade6-53a6b23eafd5" src="https://user-images.githubusercontent.com/332151/200584127-e35a3d14-ee44-4506-ba46-93e2eecec381.png">

After:

<img width="1840" alt="Screenshot 2022-11-08 at 15 00 11" src="https://user-images.githubusercontent.com/332151/200584232-da6fe819-f1b3-45ec-a917-9476f3212ba9.png">
