### PR TITLE
fix: `plugin` tests

### DIFF
--- a/ignite/services/plugin/template/go.mod.plush
+++ b/ignite/services/plugin/template/go.mod.plush
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/hashicorp/go-plugin v1.4.4
-	github.com/ignite/cli v0.25.2-0.20221109124914-6e45a5559c65
+	github.com/ignite/cli v0.25.2-0.20221117140529-b69217cd8334
 )
 
 replace (


### PR DESCRIPTION
Fix an error where the `plugin` template `go.mod` used an old hash of `cli`  before we switched to using `main` instead of `develop`.