### PR TITLE
fix: incorrect error message in `docs`

### DIFF
--- a/docs/docs/guide/03-blog/01-comment-blog.md
+++ b/docs/docs/guide/03-blog/01-comment-blog.md
@@ -178,7 +178,7 @@ func (k msgServer) CreateComment(goCtx context.Context, msg *types.MsgCreateComm
 	// Check if the Post Exists for which a comment is being created
 	post, found := k.GetPost(ctx, msg.PostID)
 	if !found {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.Id))
+		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, fmt.Sprintf("key %d doesn't exist", msg.PostID))
 	}
 
 	// Create variable of type comment


### PR DESCRIPTION
The error message uses the wrong id, it should be postID