### PR TITLE
docs: use mdgofmt to format go snippets in markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ format:
 	@echo Formatting...
 	@go run mvdan.cc/gofumpt -w .
 	@go run golang.org/x/tools/cmd/goimports -w -local github.com/ignite/cli .
+	@go run github.com/tbruyelle/mdgofmt/cmd/mdgofmt -w docs
 
 ## lint: Run Golang CI Lint.
 lint:

--- a/docs/docs/guide/02-hello.md
+++ b/docs/docs/guide/02-hello.md
@@ -244,12 +244,12 @@ function that handles the query and returns data.
 
 ```go title="x/hello/keeper/grpc_query_hello.go"
 func (k Keeper) Hello(goCtx context.Context, req *types.QueryHelloRequest) (*types.QueryHelloResponse, error) {
- if req == nil {
-  return nil, status.Error(codes.InvalidArgument, "invalid request")
- }
- ctx := sdk.UnwrapSDKContext(goCtx)
- _ = ctx
- return &types.QueryHelloResponse{}, nil
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+	return &types.QueryHelloResponse{}, nil
 }
 ```
 
@@ -273,15 +273,15 @@ In the `query.proto` file, the response accepts `text`.
 
 ```go title="x/hello/keeper/grpc_query_hello.go"
 func (k Keeper) Hello(goCtx context.Context, req *types.QueryHelloRequest) (*types.QueryHelloResponse, error) {
-  if req == nil {
-    return nil, status.Error(codes.InvalidArgument, "invalid request")
-  }
-  ctx := sdk.UnwrapSDKContext(goCtx)
-  _ = ctx
-  // remove-next-line
-  return &types.QueryHelloResponse{}, nil
-  // highlight-next-line
-  return &types.QueryHelloResponse{Text: "Hello, Ignite CLI!"}, nil
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	_ = ctx
+	// remove-next-line
+	return &types.QueryHelloResponse{}, nil
+	// highlight-next-line
+	return &types.QueryHelloResponse{Text: "Hello, Ignite CLI!"}, nil
 }
 ```
 

--- a/docs/docs/guide/03-blog/00-build-blog.md
+++ b/docs/docs/guide/03-blog/00-build-blog.md
@@ -149,7 +149,7 @@ func (k msgServer) CreatePost(goCtx context.Context, msg *types.MsgCreatePost) (
 	// Get the context
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-  // highlight-start
+	// highlight-start
 	// Create variable of type Post
 	var post = types.Post{
 		Creator: msg.Creator,
@@ -162,7 +162,7 @@ func (k msgServer) CreatePost(goCtx context.Context, msg *types.MsgCreatePost) (
 
 	// Return the ID of the post
 	return &types.MsgCreatePostResponse{Id: id}, nil
-  //highlight-end
+	//highlight-end
 }
 ```
 

--- a/docs/docs/guide/03-blog/01-comment-blog.md
+++ b/docs/docs/guide/03-blog/01-comment-blog.md
@@ -168,7 +168,6 @@ import (
 	// ...
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	// ...
 )
 

--- a/docs/docs/guide/06-loan.md
+++ b/docs/docs/guide/06-loan.md
@@ -256,8 +256,7 @@ Add the following code to the `ValidateBasic()` function in the `x/loan/types/me
 ```go
 package types
 
-...
-
+// ...
 
 func (msg *MsgRequestLoan) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(msg.Creator); err != nil {

--- a/docs/docs/guide/08-interchange/04-creating-order-books.md
+++ b/docs/docs/guide/08-interchange/04-creating-order-books.md
@@ -63,7 +63,6 @@ package keeper
 
 import (
 	"errors"
-
 	// ...
 )
 
@@ -366,23 +365,23 @@ The `AppendOrder` function initializes and appends a new order to an order book 
 // x/dex/types/order_book.go
 
 func (book *OrderBook) appendOrder(creator string, amount int32, price int32, ordering Ordering) (int32, error) {
-if err := checkAmountAndPrice(amount, price); err != nil {
-return 0, err
-}
+	if err := checkAmountAndPrice(amount, price); err != nil {
+		return 0, err
+	}
 
-// Initialize the order
-var order Order
-order.Id = book.GetNextOrderID()
-order.Creator = creator
-order.Amount = amount
-order.Price = price
+	// Initialize the order
+	var order Order
+	order.Id = book.GetNextOrderID()
+	order.Creator = creator
+	order.Amount = amount
+	order.Price = price
 
-// Increment ID tracker
-book.IncrementNextOrderID()
+	// Increment ID tracker
+	book.IncrementNextOrderID()
 
-// Insert the order
-book.insertOrder(order, ordering)
-return order.Id, nil
+	// Insert the order
+	book.insertOrder(order, ordering)
+	return order.Id, nil
 }
 ```
 
@@ -394,21 +393,21 @@ The `checkAmountAndPrice` function checks for the correct amount or price:
 // x/dex/types/order_book.go
 
 func checkAmountAndPrice(amount int32, price int32) error {
-if amount == int32(0) {
-return ErrZeroAmount
-}
-if amount > MaxAmount {
-return ErrMaxAmount
-}
+	if amount == int32(0) {
+		return ErrZeroAmount
+	}
+	if amount > MaxAmount {
+		return ErrMaxAmount
+	}
 
-if price == int32(0) {
-return ErrZeroPrice
-}
-if price > MaxPrice {
-return ErrMaxPrice
-}
+	if price == int32(0) {
+		return ErrZeroPrice
+	}
+	if price > MaxPrice {
+		return ErrMaxPrice
+	}
 
-return nil
+	return nil
 }
 ```
 
@@ -420,7 +419,7 @@ The `GetNextOrderID` function gets the ID of the next order to append:
 // x/dex/types/order_book.go
 
 func (book OrderBook) GetNextOrderID() int32 {
-return book.IdCount
+	return book.IdCount
 }
 ```
 
@@ -432,8 +431,8 @@ The `IncrementNextOrderID` function updates the ID count for orders:
 // x/dex/types/order_book.go
 
 func (book *OrderBook) IncrementNextOrderID() {
-// Even numbers to have different ID than buy orders
-book.IdCount++
+	// Even numbers to have different ID than buy orders
+	book.IdCount++
 }
 ```
 
@@ -445,24 +444,24 @@ The `insertOrder` function inserts the order in the book with the provided order
 // x/dex/types/order_book.go
 
 func (book *OrderBook) insertOrder(order Order, ordering Ordering) {
-if len(book.Orders) > 0 {
-var i int
+	if len(book.Orders) > 0 {
+		var i int
 
-// get the index of the new order depending on the provided ordering
-if ordering == Increasing {
-i = sort.Search(len(book.Orders), func (i int) bool { return book.Orders[i].Price > order.Price })
-} else {
-i = sort.Search(len(book.Orders), func (i int) bool { return book.Orders[i].Price < order.Price })
-}
+		// get the index of the new order depending on the provided ordering
+		if ordering == Increasing {
+			i = sort.Search(len(book.Orders), func(i int) bool { return book.Orders[i].Price > order.Price })
+		} else {
+			i = sort.Search(len(book.Orders), func(i int) bool { return book.Orders[i].Price < order.Price })
+		}
 
-// insert order
-orders := append(book.Orders, &order)
-copy(orders[i+1:], orders[i:])
-orders[i] = &order
-book.Orders = orders
-} else {
-book.Orders = append(book.Orders, &order)
-}
+		// insert order
+		orders := append(book.Orders, &order)
+		copy(orders[i+1:], orders[i:])
+		orders[i] = &order
+		book.Orders = orders
+	} else {
+		book.Orders = append(book.Orders, &order)
+	}
 }
 ```
 

--- a/docs/docs/guide/08-interchange/08-cancelling-orders.md
+++ b/docs/docs/guide/08-interchange/08-cancelling-orders.md
@@ -79,13 +79,13 @@ Add this function to the `x/dex/types/order_book.go` function in the `types` dir
 // x/dex/types/order_book.go
 
 func (book OrderBook) GetOrderFromID(id int32) (Order, error) {
-for _, order := range book.Orders {
-if order.Id == id {
-return *order, nil
-}
-}
+	for _, order := range book.Orders {
+		if order.Id == id {
+			return *order, nil
+		}
+	}
 
-return Order{}, ErrOrderNotFound
+	return Order{}, ErrOrderNotFound
 }
 ```
 

--- a/docs/docs/migration/v0.18.md
+++ b/docs/docs/migration/v0.18.md
@@ -75,7 +75,6 @@ import (
 	ibcporttypes "github.com/cosmos/ibc-go/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/modules/core/keeper"
-
 	// Remove the following packages:
 	// transfer "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer"
 	// ibctransferkeeper "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/keeper"
@@ -108,7 +107,7 @@ type App struct {
 	FeeGrantKeeper feegrantkeeper.Keeper // <--
 }
 
-func New(...) {
+func New( /*...*/ ) {
 	//bApp.SetAppVersion(version.Version)
 	bApp.SetVersion(version.Version) // <--
 
@@ -205,7 +204,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 ```go
 // Replace codec.JSONMarshaler with codec.JSONCodec
 func NewDefaultGenesisState(cdc codec.JSONCodec) GenesisState {
-//...
+	// ...
 }
 ```
 
@@ -219,8 +218,6 @@ package keeper
 import (
 	"testing"
 
-	"github.com/username/mars/x/mars/keeper"
-	"github.com/username/mars/x/mars/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store"
@@ -230,6 +227,8 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmdb "github.com/tendermint/tm-db"
+	"github.com/username/mars/x/mars/keeper"
+	"github.com/username/mars/x/mars/types"
 )
 
 func MarsKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
@@ -262,8 +261,6 @@ package keeper
 import (
 	"testing"
 
-	"github.com/username/test/x/mars/keeper"
-	"github.com/username/test/x/mars/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store"
@@ -276,6 +273,8 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmdb "github.com/tendermint/tm-db"
+	"github.com/username/test/x/mars/keeper"
+	"github.com/username/test/x/mars/types"
 )
 
 func MarsKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
@@ -328,15 +327,15 @@ func MarsKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 
 ```go
 func DefaultConfig() network.Config {
-//...
-return network.Config{
-//...
-// Add sdk.DefaultPowerReduction
-AccountTokens:   sdk.TokensFromConsensusPower(1000, sdk.DefaultPowerReduction),
-StakingTokens:   sdk.TokensFromConsensusPower(500, sdk.DefaultPowerReduction),
-BondedTokens:    sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction),
-//...
-}
+	// ...
+	return network.Config{
+		// ...
+		// Add sdk.DefaultPowerReduction
+		AccountTokens: sdk.TokensFromConsensusPower(1000, sdk.DefaultPowerReduction),
+		StakingTokens: sdk.TokensFromConsensusPower(500, sdk.DefaultPowerReduction),
+		BondedTokens:  sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction),
+		// ...
+	}
 }
 ```
 
@@ -383,9 +382,9 @@ type (
 )
 
 func NewKeeper(
-// Replace Marshaler with BinaryCodec
+	// Replace Marshaler with BinaryCodec
 	cdc codec.BinaryCodec,
-//...
+	// ...
 ) *Keeper {
 	// ...
 }

--- a/docs/docs/migration/v0.24.0.md
+++ b/docs/docs/migration/v0.24.0.md
@@ -31,7 +31,7 @@ you're using) with `cosmos/ibc-go/v5` only in `*.go` files (to exclude unwated c
 Add an import:
 
 ```go
-// x/{{moduleName}}/keeper/keeper.go
+// x/{moduleName}/keeper/keeper.go
 
 package keeper
 
@@ -46,7 +46,7 @@ import (
 In the `Keeper` struct replace `sdk.StoreKey` with `storetypes.StoreKey`:
 
 ```go
-// x/{{moduleName}}/keeper/keeper.go
+// x/{moduleName}/keeper/keeper.go
 
 package keeper
 
@@ -65,15 +65,14 @@ type (
 In the argument list of the `NewKeeper` function definition:
 
 ```go
-
 package keeper
 
 // ...
 
-// x/{{moduleName}}/keeper/keeper.go
+// x/{moduleName}/keeper/keeper.go
 
 func NewKeeper(
-//...
+	//...
 	memKey storetypes.StoreKey,
 )
 ```
@@ -81,20 +80,20 @@ func NewKeeper(
 Store type aliases have been removed from the Cosmos SDK `types` package and now have to be imported from `store/types`,
 instead.
 
-In the `testutil/keeper/{{moduleName}}.go` replace `types.StoreKey` with `storetypes.StoreKey` and `types.MemStoreKey`
+In the `testutil/keeper/{moduleName}.go` replace `types.StoreKey` with `storetypes.StoreKey` and `types.MemStoreKey`
 with `storetypes.MemStoreKey`.
 
 ```go
-// testutil/keeper/{{moduleName}}.go
+// testutil/keeper/{moduleName}.go
 
 package keeper
 
 // ...
 
-func {{moduleName}}Keeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-    storeKey := sdk.NewKVStoreKey(storetypes.StoreKey)
-    memStoreKey := storetypes.NewMemoryStoreKey(storetypes.MemStoreKey)
-    //...
+func {moduleName}Keeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
+	storeKey := sdk.NewKVStoreKey(storetypes.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(storetypes.MemStoreKey)
+	//...
 }
 ```
 
@@ -137,6 +136,7 @@ func DefaultConfig() network.Config {
 		},
 		//...
 	}
+}
 ```
 
 The `New` function in the Cosmos SDK `testutil/network` package now
@@ -163,7 +163,7 @@ func New(t *testing.T, configs ...network.Config) *network.Network {
 
 ### Testutil keeper package
 
-In the `{{moduleName}}Keeper` function make the following replacements:
+In the `{moduleName}Keeper` function make the following replacements:
 
 - `storetypes.StoreKey` → `types.StoreKey`
 - `storetypes.MemStoreKey` → `types.MemStoreKey`
@@ -171,19 +171,19 @@ In the `{{moduleName}}Keeper` function make the following replacements:
 - `sdk.StoreTypeMemory` → `storetypes.StoreTypeMemory`
 
 ```go
-// testutil/keeper/{{moduleName}}.go
+// testutil/keeper/{moduleName}.go
 
 package keeper
 
 // ...
 
-func {{moduleName}}Keeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
-    storeKey := sdk.NewKVStoreKey(types.StoreKey)
-    memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
-    //...
-    stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
-    stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
-    //...
+func {moduleName}Keeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+	//...
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
+	//...
 }
 ```
 
@@ -198,7 +198,7 @@ type that embeds the module's keeper and a method that returns a new `IBCModule`
 on this type.
 
 ```go
-// x/{{moduleName}}/module_ibc.go
+// x/{moduleName}/module_ibc.go
 
 package module_name
 
@@ -221,25 +221,25 @@ with `im.` to fix the errors.
 `OnChanOpenInit` now returns to values: a `string` and an `error`:
 
 ```go
-// x/{{moduleName}}/module_ibc.go
+// x/{moduleName}/module_ibc.go
 
 package module_name
 
 // ...
 
-func (im IBCModule) OnChanOpenInit(...) (string, error)
+func (im IBCModule) OnChanOpenInit( /*...*/ ) (string, error)
 ```
 
 Ensure that all return statements (five, in the default template) in `OnChanOpenInit` return two values. For example:
 
 ```go
-// x/{{moduleName}}/module_ibc.go
+// x/{moduleName}/module_ibc.go
 
 package module_name
 
 // ...
 
-func (im IBCModule) OnChanOpenInit(...) (string, error) {
+func (im IBCModule) OnChanOpenInit( /*...*/ ) (string, error) {
 	//...
 	return "", sdkerrors.Wrapf(porttypes.ErrInvalidPort, "invalid port: %s, expected %s", portID, boundPort)
 	//...
@@ -250,32 +250,37 @@ Error acknowledgments returned from Transfer `OnRecvPacket` now include a determ
 Remove the `.Error()` call:
 
 ```go
-// x/{{moduleName}}/module_ibc.go
+// x/{moduleName}/module_ibc.go
 
 package module_name
 
 // ...
 
-func (im IBCModule) OnRecvPacket(...) {
+func (im IBCModule) OnRecvPacket( /*...*/ ) {
 	//...
 	if err := modulePacketData.Unmarshal(modulePacket.GetData()); err != nil {
 		// return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error()).Error())
 		return channeltypes.NewErrorAcknowledgement(sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error()))
 	}
 
-//...
-default:
-// errMsg := fmt.Sprintf("unrecognized %s packet type: %T", types.ModuleName, packet)
-// return channeltypes.NewErrorAcknowledgement(errMsg)
-err := fmt.Errorf("unrecognized %s packet type: %T", types.ModuleName, packet)
-return channeltypes.NewErrorAcknowledgement(err)
+	// ...
+
+	// Dispatch packet
+	switch packet := modulePacketData.Packet.(type) {
+	// ...
+	default:
+		// errMsg := fmt.Sprintf("unrecognized %s packet type: %T", types.ModuleName, packet)
+		// return channeltypes.NewErrorAcknowledgement(errMsg)
+		err := fmt.Errorf("unrecognized %s packet type: %T", types.ModuleName, packet)
+		return channeltypes.NewErrorAcknowledgement(err)
+	}
 }
 ```
 
 After switching to using both `AppModule` and `IBCModule`, modifying the following line:
 
 ```go
-// x/{{moduleName}}/module.go
+// x/{moduleName}/module.go
 
 package module_name
 
@@ -305,18 +310,17 @@ func main() {
 		os.Exit(1)
 	}
 }
-
 ```
 
 ### Handler
 
 Cosmos SDK v0.46 no longer needs a `NewHandler` function that was used to handle messages and call appropriate keeper
-methods based on message types. Feel free to remove `x/{{moduleName}}/handler.go` file.
+methods based on message types. Feel free to remove `x/{moduleName}/handler.go` file.
 
 Since there is no `NewHandler` now, modify the deprecated `Route` function to return `sdk.Route{}`:
 
 ```go
-// x/{{moduleName}}/module.go
+// x/{moduleName}/module.go
 
 package module_name
 

--- a/docs/docs/migration/v0.25.0.md
+++ b/docs/docs/migration/v0.25.0.md
@@ -182,6 +182,7 @@ type SimApp interface {
 	InitChainer(ctx sdk.Context, req abci.RequestInitChain)
 	abci.ResponseInitChain
 }
+
 // remove-end
 
 // ...
@@ -316,6 +317,7 @@ func (app *App) Name() string { return app.BaseApp.Name() }
 // remove-start
 // GetBaseApp returns the base app of the application
 func (app App) GetBaseApp() *baseapp.BaseApp { return app.BaseApp }
+
 // remove-end
 
 // BeginBlocker application updates every begin block

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
+	github.com/tbruyelle/mdgofmt v0.1.2
 	github.com/tendermint/spn v0.2.1-0.20220921200247-8bafad876bdd
 	github.com/tendermint/tendermint v0.34.23
 	github.com/tendermint/tm-db v0.6.7

--- a/go.sum
+++ b/go.sum
@@ -1700,6 +1700,12 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tbruyelle/mdgofmt v0.1.0 h1:sk48Z/BoOccm6DaZI3zqgK+cs2BveF+DgiZqDIPzOh8=
+github.com/tbruyelle/mdgofmt v0.1.0/go.mod h1:D3fyKvx4oZq99YeQm5j/gnGmc9w4HogvQMujPVzW+zQ=
+github.com/tbruyelle/mdgofmt v0.1.1 h1:ZH/n+jGxWz7ilP9dpeIgSgjPHDRafDdfzPpkILjjjSQ=
+github.com/tbruyelle/mdgofmt v0.1.1/go.mod h1:D3fyKvx4oZq99YeQm5j/gnGmc9w4HogvQMujPVzW+zQ=
+github.com/tbruyelle/mdgofmt v0.1.2 h1:/UZaC5YTKdneMtLhDNe6328DjO2oDFCslmJJ1fqnjCQ=
+github.com/tbruyelle/mdgofmt v0.1.2/go.mod h1:D3fyKvx4oZq99YeQm5j/gnGmc9w4HogvQMujPVzW+zQ=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tdakkota/asciicheck v0.1.1 h1:PKzG7JUTUmVspQTDqtkX9eSiLGossXTybutHwTXuO0A=
 github.com/tdakkota/asciicheck v0.1.1/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=

--- a/ignite/internal/tools/tools.go
+++ b/ignite/internal/tools/tools.go
@@ -5,6 +5,7 @@ package tools
 
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "github.com/tbruyelle/mdgofmt/cmd/mdgofmt"
 	_ "github.com/vektra/mockery/v2"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/vuln/cmd/govulncheck"


### PR DESCRIPTION
[mdgofmt](https://github.com/tbruyelle/mdgofmt) is a small tool I wrote that runs `gofmt` on go snipppets inside markdown files.

By adding its usage in `make format`, it will run with the `Go Formatting` github action.

It can fail if the code isn't accepted by `gofmt`, so I had to fix some our snippets to accommodate that.