### PR TITLE
updated actions.yml for resolving deprecation message

### DIFF
--- a/actions/release/vars/action.yml
+++ b/actions/release/vars/action.yml
@@ -37,10 +37,10 @@ runs:
           should_release=false
         fi
 
-        echo ::set-output name=should_release::$should_release
-        echo ::set-output name=is_release_type_latest::$is_release_type_latest
-        echo ::set-output name=tag_name::$tag_name
-        echo ::set-output name=tarball_prefix::"$repo_name"_$tag_name
+        echo "should_release=$should_release" >> $GITHUB_OUTPUT
+        echo "is_release_type_latest=$is_release_type_latest" >> $GITHUB_OUTPUT
+        echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+        echo "tarball_prefix='$repo_name'_$tag_name" >> $GITHUB_OUTPUT
       shell: bash
     - run: |
         echo "- should_release: ${{ steps.vars.outputs.should_release }}"


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18GGSyyHX1EMakJhxTnbZgwt2zFq7is5w%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=qssYeyw) 

`set-ouput` command is being deprecated in a number of months, and we should migrate to Github's new recommend path. 
Its here https://github.com/ignite/cli/actions/runs/3618877364/jobs/6099257660

Proposed solution
A workflow using save-state or set-output like the following

- name: Save state
  run: echo "::save-state name={name}::{value}"
- name: Set output
  run: echo "::set-output name={name}::{value}"
should be updated to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files:

- name: Save state
  run: echo "{name}={value}" >> $GITHUB_STATE
- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT

Additional context
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files