### PR TITLE
refactor(`plugins`): remove plugin flag

### DIFF
--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -33,7 +33,6 @@ const (
 	flagYes        = "yes"
 	flagClearCache = "clear-cache"
 	flagSkipProto  = "skip-proto"
-	flagPlugins    = "plugins"
 
 	checkVersionTimeout = time.Millisecond * 600
 	cacheFileName       = "ignite_cache.db"

--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -81,7 +81,6 @@ To get started, create a blockchain:
 	c.AddCommand(NewVersion())
 	c.AddCommand(NewPlugin())
 	c.AddCommand(deprecated()...)
-	c.PersistentFlags().AddFlagSet(flagSetPlugins())
 
 	return c
 }
@@ -128,17 +127,6 @@ func flagSetConfig() *flag.FlagSet {
 
 func getConfig(cmd *cobra.Command) (config string) {
 	config, _ = cmd.Flags().GetString(flagConfig)
-	return
-}
-
-func flagSetPlugins() *flag.FlagSet {
-	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.StringP(flagPlugins, "x", "", "path to Ignite plugins config file (default: ./plugins.yml)")
-	return fs
-}
-
-func getPlugins(cmd *cobra.Command) (config string) {
-	config, _ = cmd.Flags().GetString(flagPlugins)
 	return
 }
 

--- a/ignite/cmd/plugin.go
+++ b/ignite/cmd/plugin.go
@@ -46,15 +46,12 @@ func LoadPlugins(ctx context.Context, rootCmd *cobra.Command) error {
 
 func parseLocalPlugins(rootCmd *cobra.Command) (cfg *pluginsconfig.Config, path string, err error) {
 	appPath := flagGetPath(rootCmd)
-	pluginsPath := getPlugins(rootCmd)
-	if pluginsPath == "" {
-		if pluginsPath, err = pluginsconfig.LocateDefault(appPath); err != nil {
-			return cfg, appPath, err
-		}
+	pluginsPath, err := pluginsconfig.LocateDefault(appPath)
+	if err != nil {
+		return cfg, appPath, err
 	}
 
 	cfg, err = pluginsconfig.ParseFile(pluginsPath)
-
 	return cfg, pluginsPath, err
 }
 


### PR DESCRIPTION
Closes #3235

We decided to remove this flag entirely since any use cases should be covered by the local + global config options users have.