### PR TITLE
fix: change return type to fit

### DIFF
--- a/ignite/pkg/cosmosgen/templates/root/client.ts.tpl
+++ b/ignite/pkg/cosmosgen/templates/root/client.ts.tpl
@@ -32,11 +32,11 @@ export class IgniteClient extends EventEmitter {
 
     if (Array.isArray(plugin)) {
       type Extension = UnionToIntersection<Return<T>['module']>
-      return AugmentedClient as typeof AugmentedClient & Constructor<Extension>;  
+      return AugmentedClient as typeof IgniteClient & Constructor<Extension>;  
     }
 
     type Extension = Return<T>['module']
-    return AugmentedClient as typeof AugmentedClient & Constructor<Extension>;
+    return AugmentedClient as typeof IgniteClient & Constructor<Extension>;
   }
 
   async signAndBroadcast(msgs: EncodeObject[], fee: StdFee, memo: string) {


### PR DESCRIPTION
Issue: As for now type declarations can not be build from generated ts-client. There is an issue with return type in `client.ts` and TS just can't solve type 

Solution: As workaround we can use `IgniteClient` type instead because these types are equivalent