### PR TITLE
fix: changelog links

### DIFF
--- a/docs/docs/guide/01-install.md
+++ b/docs/docs/guide/01-install.md
@@ -93,7 +93,7 @@ After all existing Ignite CLI installations are removed, follow the  [Installing
 instructions.
 
 For details on version features and changes, see
-the [changelog.md](https://github.com/ignite/cli/blob/develop/changelog.md)
+the [changelog.md](https://github.com/ignite/cli/blob/main/changelog.md)
 in the repo.
 
 ## Build from source

--- a/docs/versioned_docs/version-v0.25.2/guide/01-install.md
+++ b/docs/versioned_docs/version-v0.25.2/guide/01-install.md
@@ -87,7 +87,7 @@ To remove the current Ignite CLI installation:
 
 After all existing Ignite CLI installations are removed, follow the  [Installing Ignite CLI](#installing-ignite-cli) instructions.
 
-For details on version features and changes, see the [changelog.md](https://github.com/ignite/cli/blob/develop/changelog.md) in the repo.
+For details on version features and changes, see the [changelog.md](https://github.com/ignite/cli/blob/main/changelog.md) in the repo.
 
 ## Build from source
 


### PR DESCRIPTION
uses `main` instead of `develop` in changelog links