### PR TITLE
chore: remove color from name styles

### DIFF
--- a/ignite/pkg/cliui/colors/colors.go
+++ b/ignite/pkg/cliui/colors/colors.go
@@ -22,7 +22,7 @@ var (
 	error    = lipgloss.NewStyle().Foreground(lipgloss.Color(Red))
 	success  = lipgloss.NewStyle().Foreground(lipgloss.Color(Green))
 	modified = lipgloss.NewStyle().Foreground(lipgloss.Color(Magenta))
-	name     = lipgloss.NewStyle().Foreground(lipgloss.Color(White)).Bold(true)
+	name     = lipgloss.NewStyle().Bold(true)
 	mnemonic = lipgloss.NewStyle().Foreground(lipgloss.Color(HiBlue))
 	faint    = lipgloss.NewStyle().Faint(true)
 )


### PR DESCRIPTION
Resolves #3297

The changeset leaves name style in bold to avoid contrast issues in terminals with different backgrounds.

Using `lipgloss.AdaptativeColor` doesn't work as expected so the simpler solution is just to remove foreground color in this case.