### PR TITLE
chore(simulation): fix wrong comment for simulation template file

### DIFF
--- a/ignite/templates/app/files/app/simulation_test.go.plush
+++ b/ignite/templates/app/files/app/simulation_test.go.plush
@@ -39,7 +39,7 @@ var defaultConsensusParams = &abci.ConsensusParams{
 
 // BenchmarkSimulation run the chain simulation
 // Running using starport command:
-// `starport chain simulate -v --numBlocks 200 --blockSize 50`
+// `ignite chain simulate -v --numBlocks 200 --blockSize 50`
 // Running as go benchmark test:
 // `go test -benchmem -run=^$ -bench ^BenchmarkSimulation ./app -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true`
 func BenchmarkSimulation(b *testing.B) {


### PR DESCRIPTION
## Description

The simulation file template has a comment instruction with Starport instead Ignite