### PR TITLE
docs: rename top-level categories

### DIFF
--- a/docs/docs/clients/_category_.json
+++ b/docs/docs/clients/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Build client apps",
-  "position": 6,
+  "label": "Build a client app",
+  "position": 3,
   "link": null
 }

--- a/docs/docs/guide/_category_.json
+++ b/docs/docs/guide/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Developer Tutorials",
-    "position": 2,
-    "link": null
-  }
+  "label": "Build a chain",
+  "position": 2,
+  "link": null
+}

--- a/docs/docs/kb/_category_.json
+++ b/docs/docs/kb/_category_.json
@@ -1,5 +1,4 @@
 {
-    "label": "Knowledge Base",
-    "position": 3,
-    "link": null
-  }
+  "label": "Knowledge Base",
+  "link": null
+}

--- a/docs/docs/migration/_category_.json
+++ b/docs/docs/migration/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "Migration",
-  "position": 4,
   "link": null
 }

--- a/docs/docs/network/_category_.json
+++ b/docs/docs/network/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Network",
-    "position": 7,
-    "link": null
-  }
+  "label": "Launch a chain",
+  "position": 4,
+  "link": null
+}


### PR DESCRIPTION
Renamed categories to:

* Build a chain
* Build a client-app
* Launch a chain

URL are unchanged, so no breaking links.