### PR TITLE
refactor: change `generate ts-client` to ignore the cache by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,9 +46,10 @@
 - [#3106](https://github.com/ignite/cli/pull/3106) Add zoom image plugin.
 - [#3194](https://github.com/ignite/cli/issues/3194) Move config validators check to validate only when required.
 - [#3183](https://github.com/ignite/cli/pull/3183/) Make config optional for init phase.
-- [#3224](https://github.com/ignite/cli/pull/3224) Remove grpc_* prefix from query files in scaffolded chains
+- [#3224](https://github.com/ignite/cli/pull/3224) Remove `grpc_*` prefix from query files in scaffolded chains
 - [#3229](https://github.com/ignite/cli/pull/3229) Rename `campaign` to `project` in ignite network set of commands
 - [#3244](https://github.com/ignite/cli/pull/3244) updated actions.yml for resolving deprecation message
+- [#3122](https://github.com/ignite/cli/issues/3122) Change `generate ts-client` to ignore the cache by default.
 
 ### Breaking Changes
 

--- a/ignite/cmd/generate_typescript_client.go
+++ b/ignite/cmd/generate_typescript_client.go
@@ -8,16 +8,15 @@ import (
 	"github.com/ignite/cli/ignite/services/chain"
 )
 
+const (
+	flagUseCache = "use-cache"
+)
+
 func NewGenerateTSClient() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "ts-client",
 		Short: "TypeScript frontend client",
 		Long: `Generate a framework agnostic TypeScript client for your blockchain project.
-
-To generate all clients for custom and standard Cosmos SDK modules, run this
-command:
-
-	ignite generate ts-client --clear-cache
 
 By default the TypeScript client is generated in the "ts-client/" directory. You
 can customize the output directory in config.yml:
@@ -25,6 +24,10 @@ can customize the output directory in config.yml:
 	client:
 	  typescript:
 	    path: new-path
+
+Output can also be customized by using a flag:
+
+	ignite generate ts-client --output new-path
 
 TypeScript client code can be automatically regenerated on reset or source code
 changes when the blockchain is started with a flag:
@@ -37,6 +40,7 @@ changes when the blockchain is started with a flag:
 
 	c.Flags().AddFlagSet(flagSetYes())
 	c.Flags().StringP(flagOutput, "o", "", "TypeScript client output path")
+	c.Flags().Bool(flagUseCache, false, "use build cache to speed-up generation")
 
 	return c
 }
@@ -65,7 +69,12 @@ func generateTSClientHandler(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	err = c.Generate(cmd.Context(), cacheStorage, chain.GenerateTSClient(output))
+	useCache, err := cmd.Flags().GetBool(flagUseCache)
+	if err != nil {
+		return err
+	}
+
+	err = c.Generate(cmd.Context(), cacheStorage, chain.GenerateTSClient(output, useCache))
 	if err != nil {
 		return err
 	}

--- a/ignite/pkg/cosmosgen/cosmosgen.go
+++ b/ignite/pkg/cosmosgen/cosmosgen.go
@@ -16,6 +16,7 @@ import (
 type generateOptions struct {
 	includeDirs []string
 	gomodPath   string
+	useCache    bool
 
 	jsOut            func(module.Module) string
 	tsClientRootPath string
@@ -42,10 +43,11 @@ type Option func(*generateOptions)
 
 // WithTSClientGeneration adds Typescript Client code generation.
 // The tsClientRootPath is used to determine the root path of generated Typescript classes.
-func WithTSClientGeneration(out ModulePathFunc, tsClientRootPath string) Option {
+func WithTSClientGeneration(out ModulePathFunc, tsClientRootPath string, useCache bool) Option {
 	return func(o *generateOptions) {
 		o.jsOut = out
 		o.tsClientRootPath = tsClientRootPath
+		o.useCache = useCache
 	}
 }
 

--- a/ignite/pkg/cosmosgen/generate_typescript.go
+++ b/ignite/pkg/cosmosgen/generate_typescript.go
@@ -103,13 +103,19 @@ func (g *tsGenerator) generateModuleTemplates() error {
 			gg.Go(func() error {
 				cacheKey := m.Pkg.Path
 				paths := append([]string{m.Pkg.Path, g.g.o.jsOut(m)}, g.g.o.includeDirs...)
-				changed, err := dirchange.HasDirChecksumChanged(dirCache, cacheKey, sourcePath, paths...)
-				if err != nil {
-					return err
-				}
 
-				if !changed {
-					return nil
+				// Always generate module templates by default unless cache is enabled, in which
+				// case the module template is generated when one or more files were changed in
+				// the module since the last generation.
+				if g.g.o.useCache {
+					changed, err := dirchange.HasDirChecksumChanged(dirCache, cacheKey, sourcePath, paths...)
+					if err != nil {
+						return err
+					}
+
+					if !changed {
+						return nil
+					}
 				}
 
 				err = g.generateModuleTemplate(g.g.ctx, protocCmd, staCmd, tsprotoPluginPath, sourcePath, m)

--- a/ignite/services/chain/generate.go
+++ b/ignite/services/chain/generate.go
@@ -15,6 +15,7 @@ import (
 )
 
 type generateOptions struct {
+	useCache             bool
 	isGoEnabled          bool
 	isTSClientEnabled    bool
 	isComposablesEnabled bool
@@ -40,10 +41,11 @@ func GenerateGo() GenerateTarget {
 // GenerateTSClient enables generating proto based Typescript Client.
 // The path assigns the output path to use for the generated Typescript client
 // overriding the configured or default path. Path can be an empty string.
-func GenerateTSClient(path string) GenerateTarget {
+func GenerateTSClient(path string, useCache bool) GenerateTarget {
 	return func(o *generateOptions) {
 		o.isTSClientEnabled = true
 		o.tsClientPath = path
+		o.useCache = useCache
 	}
 }
 
@@ -93,7 +95,7 @@ func (c *Chain) generateFromConfig(ctx context.Context, cacheStorage cache.Stora
 
 	if generateClients {
 		if p := conf.Client.Typescript.Path; p != "" {
-			targets = append(targets, GenerateTSClient(p))
+			targets = append(targets, GenerateTSClient(p, true))
 		}
 
 		//nolint:staticcheck //ignore SA1019 until vuex config option is removed
@@ -177,6 +179,7 @@ func (c *Chain) Generate(
 			cosmosgen.WithTSClientGeneration(
 				cosmosgen.TypescriptModulePath(tsClientPath),
 				tsClientPath,
+				targetOptions.useCache,
 			),
 		)
 	}

--- a/ignite/services/scaffolder/scaffolder.go
+++ b/ignite/services/scaffolder/scaffolder.go
@@ -96,6 +96,7 @@ func protoc(ctx context.Context, cacheStorage cache.Storage, projectPath, gomodP
 			cosmosgen.WithTSClientGeneration(
 				cosmosgen.TypescriptModulePath(tsClientPath),
 				tsClientPath,
+				true,
 			),
 		)
 	}


### PR DESCRIPTION
Resolves #3122 