### PR TITLE
fix: Disallow components with same name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -64,6 +64,7 @@
 - [#3187](https://github.com/ignite/cli/issues/3187) Change prompt text to fit within 80 characters width.
 - [#3203](https://github.com/ignite/cli/issues/3203) Fix relayer to work with multiple paths.
 - [#3320](https://github.com/ignite/cli/pull/3320) Allow `id` and `creator` as names when scaffolding a type.
+- [#3327](https://github.com/ignite/cli/issues/3327) Scaffolding messages with same name leads to aliasing.
 
 ## [`v0.25.2`](https://github.com/ignite/cli/releases/tag/v0.25.1)
 

--- a/ignite/services/scaffolder/component.go
+++ b/ignite/services/scaffolder/component.go
@@ -122,27 +122,22 @@ func checkGoReservedWord(name string) error {
 func checkComponentCreated(appPath, moduleName string, compName multiformatname.Name, noMessage bool) (err error) {
 	// associate the type to check with the component that scaffold this type
 	typesToCheck := map[string]string{
-		compName.UpperCamel:                           componentType,
-		"QueryAll" + compName.UpperCamel + "Request":  componentType,
-		"QueryAll" + compName.UpperCamel + "Response": componentType,
-		"QueryGet" + compName.UpperCamel + "Request":  componentType,
-		"QueryGet" + compName.UpperCamel + "Response": componentType,
-		"Query" + compName.UpperCamel + "Request":     componentQuery,
-		"Query" + compName.UpperCamel + "Response":    componentQuery,
-		compName.UpperCamel + "PacketData":            componentPacket,
+		compName.UpperCamel:                          componentType,
+		"queryall" + compName.LowerCase + "request":  componentType,
+		"queryall" + compName.LowerCase + "response": componentType,
+		"queryget" + compName.LowerCase + "request":  componentType,
+		"queryget" + compName.LowerCase + "response": componentType,
+		"query" + compName.LowerCase + "request":     componentQuery,
+		"query" + compName.LowerCase + "response":    componentQuery,
+		compName.LowerCase + "packetdata":            componentPacket,
 	}
 
 	if !noMessage {
-		typesToCheck["MsgCreate"+compName.UpperCamel] = componentType
-		typesToCheck["MsgUpdate"+compName.UpperCamel] = componentType
-		typesToCheck["MsgDelete"+compName.UpperCamel] = componentType
-		typesToCheck["Msg"+compName.UpperCamel] = componentMessage
-		typesToCheck["MsgSend"+compName.UpperCamel] = componentPacket
-	}
-	// Make all names lower case to handle cases of the same name with different cases
-	for k, v := range typesToCheck {
-		delete(typesToCheck, k)
-		typesToCheck[strings.ToLower(k)] = v
+		typesToCheck["msgcreate"+compName.LowerCase] = componentType
+		typesToCheck["msgupdate"+compName.LowerCase] = componentType
+		typesToCheck["msgdelete"+compName.LowerCase] = componentType
+		typesToCheck["msg"+compName.LowerCase] = componentMessage
+		typesToCheck["msgsend"+compName.LowerCase] = componentPacket
 	}
 
 	absPath, err := filepath.Abs(filepath.Join(appPath, "x", moduleName, "types"))

--- a/ignite/services/scaffolder/component.go
+++ b/ignite/services/scaffolder/component.go
@@ -139,6 +139,11 @@ func checkComponentCreated(appPath, moduleName string, compName multiformatname.
 		typesToCheck["Msg"+compName.UpperCamel] = componentMessage
 		typesToCheck["MsgSend"+compName.UpperCamel] = componentPacket
 	}
+	// Make all names lower case to handle cases of the same name with different cases
+	for k, v := range typesToCheck {
+		delete(typesToCheck, k)
+		typesToCheck[strings.ToLower(k)] = v
+	}
 
 	absPath, err := filepath.Abs(filepath.Join(appPath, "x", moduleName, "types"))
 	if err != nil {
@@ -163,7 +168,7 @@ func checkComponentCreated(appPath, moduleName string, compName multiformatname.
 				}
 
 				// Check if the parsed type is from a scaffolded component with the name
-				if compType, ok := typesToCheck[typeSpec.Name.Name]; ok {
+				if compType, ok := typesToCheck[strings.ToLower(typeSpec.Name.Name)]; ok {
 					err = fmt.Errorf("component %s with name %s is already created (type %s exists)",
 						compType,
 						compName.Original,

--- a/integration/other_components/cmd_message_test.go
+++ b/integration/other_components/cmd_message_test.go
@@ -62,6 +62,14 @@ func TestGenerateAnAppWithMessage(t *testing.T) {
 		envtest.ExecShouldError(),
 	))
 
+	env.Must(env.Exec("should prevent creating a message whose name only differs in capitalization",
+		step.NewSteps(step.New(
+			step.Exec(envtest.IgniteApp, "s", "message", "--yes", "do-Foo", "bar"),
+			step.Workdir(app.SourcePath()),
+		)),
+		envtest.ExecShouldError(),
+	))
+
 	env.Must(env.Exec("create a message with a custom signer name",
 		step.NewSteps(step.New(
 			step.Exec(envtest.IgniteApp, "s", "message", "--yes", "do-bar", "bar", "--signer", "bar-doer"),


### PR DESCRIPTION
Closes #3327. Instead of just uppercasing the component name, the change lowercases it so mixed capitalization doesn't cheat past it. 