### PR TITLE
docs: expand references section by default

### DIFF
--- a/docs/docs/references/_category_.json
+++ b/docs/docs/references/_category_.json
@@ -1,4 +1,5 @@
 {
   "label": "References",
-  "link": null
+  "link": null,
+  "collapsed": false
 }

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -20,7 +20,7 @@ const sidebars = {
     {
       type: "category",
       label: "Resources",
-      collapsed: false,
+      collapsed: true,
       items: [
         {
           type: "link",


### PR DESCRIPTION
Small tweak to make the "References" section expanded by default as it contains two important docs: CLI ref and config.yml ref.