### PR TITLE
feat(chain): Add `--build.tags` flag for `chain serve` and `chain build` commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 - [#2458](https://github.com/ignite/cli/issues/2458) New `chain serve` command UI.
 - [#2992](https://github.com/ignite/cli/issues/2992) Add `ignite chain debug` command.
 - [#2736](https://github.com/ignite/cli/issues/2736) Add `--skip-git` flag to skip git repository initialization.
+- [#3439](https://github.com/ignite/cli/pull/3439) Add `--build.tags` flag for `chain serve` and `chain build` commands.
 
 ### Changes
 

--- a/ignite/cmd/chain_init.go
+++ b/ignite/cmd/chain_init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ignite/cli/ignite/pkg/chaincmd"
 	"github.com/ignite/cli/ignite/pkg/cliui"
 	"github.com/ignite/cli/ignite/pkg/cliui/colors"
+	"github.com/ignite/cli/ignite/pkg/cosmosver"
 	"github.com/ignite/cli/ignite/services/chain"
 )
 
@@ -88,6 +89,7 @@ commands manually to ensure a production-level node initialization.
 	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	c.Flags().AddFlagSet(flagSetSkipProto())
 	c.Flags().AddFlagSet(flagSetDebug())
+	c.Flags().StringSlice(flagBuildTags, []string{cosmosver.DefaultVersion().String()}, "parameters to build the chain binary")
 
 	return c
 }
@@ -119,8 +121,11 @@ func chainInitHandler(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ctx := cmd.Context()
-	if _, err = c.Build(ctx, cacheStorage, "", flagGetSkipProto(cmd), flagGetDebug(cmd)); err != nil {
+	var (
+		ctx          = cmd.Context()
+		buildTags, _ = cmd.Flags().GetStringSlice(flagBuildTags)
+	)
+	if _, err = c.Build(ctx, cacheStorage, buildTags, "", flagGetSkipProto(cmd), flagGetDebug(cmd)); err != nil {
 		return err
 	}
 

--- a/ignite/pkg/cosmosver/app.go
+++ b/ignite/pkg/cosmosver/app.go
@@ -1,0 +1,19 @@
+package cosmosver
+
+type AppVersion string
+
+const (
+	AppV1 AppVersion = "app_v1"
+	AppV2 AppVersion = "app_v2"
+)
+
+// DefaultVersion returns the default app version for build.
+// TODO change the default value after update the version.
+func DefaultVersion() AppVersion {
+	return AppV1
+}
+
+// String returns the string value.
+func (v AppVersion) String() string {
+	return string(v)
+}

--- a/ignite/pkg/gocmd/gocmd.go
+++ b/ignite/pkg/gocmd/gocmd.go
@@ -52,6 +52,8 @@ const (
 	FlagGcflagsValueDebug = "all=-N -l"
 	// FlagLdflags represents ldflags go flag.
 	FlagLdflags = "-ldflags"
+	// FlagTags represents tags go flag.
+	FlagTags = "-tags"
 	// FlagMod represents mod go flag.
 	FlagMod = "-mod"
 	// FlagModValueReadOnly represents readonly go flag.
@@ -152,6 +154,11 @@ func Get(ctx context.Context, path string, pkgs []string, options ...exec.Option
 // Ldflags returns a combined ldflags set from flags.
 func Ldflags(flags ...string) string {
 	return strings.Join(flags, " ")
+}
+
+// Tags returns a combined tags set from flags.
+func Tags(tags ...string) string {
+	return strings.Join(tags, " ")
 }
 
 // BuildTarget builds a GOOS:GOARCH pair.

--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -69,6 +69,7 @@ type serveOptions struct {
 	skipProto       bool
 	quitOnFail      bool
 	generateClients bool
+	buildTags       []string
 }
 
 func newServeOption() serveOptions {
@@ -113,6 +114,13 @@ func GenerateClients() ServeOption {
 func ServeSkipProto() ServeOption {
 	return func(c *serveOptions) {
 		c.skipProto = true
+	}
+}
+
+// BuildTags set the build tags for the go build.
+func BuildTags(buildTags ...string) ServeOption {
+	return func(c *serveOptions) {
+		c.buildTags = buildTags
 	}
 }
 
@@ -177,6 +185,7 @@ func (c *Chain) Serve(ctx context.Context, cacheStorage cache.Storage, options .
 				err = c.serve(
 					serveCtx,
 					cacheStorage,
+					serveOptions.buildTags,
 					shouldReset,
 					serveOptions.skipProto,
 					serveOptions.generateClients,
@@ -307,6 +316,7 @@ func (c *Chain) watchAppBackend(ctx context.Context) error {
 func (c *Chain) serve(
 	ctx context.Context,
 	cacheStorage cache.Storage,
+	buildTags []string,
 	forceReset, skipProto, generateClients bool,
 ) error {
 	conf, err := c.Config()
@@ -389,7 +399,7 @@ func (c *Chain) serve(
 	// build phase
 	if !isInit || appModified {
 		// build the blockchain app
-		if err := c.build(ctx, cacheStorage, "", skipProto, generateClients, true); err != nil {
+		if err := c.build(ctx, cacheStorage, buildTags, "", skipProto, generateClients, true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description

Add the `--build.tags` flag for the `chain serve` and `chain build` commands so we can build the binary, passing a list of tags to use in the go build command.

This will set the `-tag` flag for the go build and also the `version.BuildTags` var for the cosmos-sdk `ldFlag`
E.g.:

```shell
go build -tags "app_v1 netgo ledger" -ldflags '-X "github.com/cosmos/cosmos-sdk/version.BuildTags=app_v1,netgo,ledger" ...
```

__By default, the `app_v1` flag is set.__

### How to test

```shell
ignite chain serve -r --clear-cache --build.tags app_v1,ledger,netgo
```

```shell
ignite chain build --clear-cache --build.tags app_v2,ledger
```