### PR TITLE
fix: correct checksum format

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - [#3444](https://github.com/ignite/cli/pull/3444) Add support for ICS chains in ts-client generation
 
+### Fixes
+
+- [#3481](https://github.com/ignite/cli/pull/3481) Use correct checksum format in release checksum file
+
 ## [`v0.26.1`](https://github.com/ignite/cli/releases/tag/v0.26.1)
 
 ### Features

--- a/ignite/pkg/checksum/checksum.go
+++ b/ignite/pkg/checksum/checksum.go
@@ -34,7 +34,7 @@ func Sum(dirPath, outPath string) error {
 			return err
 		}
 
-		if _, err := b.WriteString(fmt.Sprintf("%x %s\n", h.Sum(nil), info.Name())); err != nil {
+		if _, err := b.WriteString(fmt.Sprintf("%x  %s\n", h.Sum(nil), info.Name())); err != nil {
 			return err
 		}
 	}

--- a/ignite/pkg/checksum/checksum.go
+++ b/ignite/pkg/checksum/checksum.go
@@ -34,6 +34,9 @@ func Sum(dirPath, outPath string) error {
 			return err
 		}
 
+		// Note that checksum entry has two spaces as separator to follow
+		// FIPS-180-2 regarding the character prefix for text file types.
+		// This is required for tools like sha256sum with a strict verification.
 		if _, err := b.WriteString(fmt.Sprintf("%x  %s\n", h.Sum(nil), info.Name())); err != nil {
 			return err
 		}


### PR DESCRIPTION
Resolves https://github.com/ignite/cli/issues/3480

Checksum format `<sha256sum><space><space><file_name>` instead of `<sha256sum><space><file_name>`.

Reference see [here](https://linux.die.net/man/1/sha256sum):

> The sums are computed as described in FIPS-180-2. When checking, the input should be a former output of this program. The default mode is to print a line with checksum, a character indicating type ('*' for binary, ' ' for text), and name for each FILE.