### PR TITLE
fix: set correct docker container tag for GH action

### DIFF
--- a/actions/cli/Dockerfile
+++ b/actions/cli/Dockerfile
@@ -1,3 +1,3 @@
-FROM ignitehq/cli:develop
+FROM ignitehq/cli:latest
 
 USER root


### PR DESCRIPTION
At some point docker pipeline was updated and now produce "tagged/versioned" images & "latest" ("develop" => "latest"). 
At this moment action can't be used at all for "new" chains (GO 1.19), as it try to use outdated "develop" with GO 1.18 onboard.
This change should fix this.