### PR TITLE
feat: bump dev-drprasad/delete-tag-and-release to v0.2.1

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Delete the nightly release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         with:
           tag_name: nightly
           delete_release: true

--- a/ignite/templates/app/files/.github/workflows/release.yml
+++ b/ignite/templates/app/files/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           args: chain build --release --release.prefix ${{ steps.vars.outputs.tarball_prefix }} -t linux:amd64 -t darwin:amd64 -t darwin:arm64
 
       - name: Delete the "latest" Release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         if: ${{ steps.vars.outputs.is_release_type_latest == 'true' }}
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}


### PR DESCRIPTION
From https://github.com/dev-drprasad/delete-tag-and-release/releases, it can be seen that there is currently no version v0.2.0, and the latest version is v0.2.1.