### PR TITLE
feat: bump action/cli image from ignitehq/cli:develop to ignitehq/cli:latest

### DIFF
--- a/actions/cli/Dockerfile
+++ b/actions/cli/Dockerfile
@@ -1,3 +1,3 @@
-FROM ignitehq/cli:develop
+FROM ignitehq/cli:latest
 
 USER root


### PR DESCRIPTION
The go version in the generated `go.mod` file of ignite `v0.26.1` is `1.19`, while the default `ignitehq/cli:develop` is built with Go `1.18`, causing an error during runtime with the message "Error while running command go mod tidy: go: go.mod file indicates go 1.19, but maximum version supported by tidy is 1.18".




