### PR TITLE
feat: PoC for passing data to plugins

### DIFF
--- a/ignite/cmd/plugin.go
+++ b/ignite/cmd/plugin.go
@@ -10,11 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+	"golang.org/x/exp/maps"
 
 	pluginsconfig "github.com/ignite/cli/ignite/config/plugins"
 	"github.com/ignite/cli/ignite/pkg/clictx"
 	"github.com/ignite/cli/ignite/pkg/cliui"
 	"github.com/ignite/cli/ignite/pkg/cliui/icons"
+	"github.com/ignite/cli/ignite/pkg/common"
 	"github.com/ignite/cli/ignite/pkg/cosmosanalysis"
 	"github.com/ignite/cli/ignite/pkg/xgit"
 	"github.com/ignite/cli/ignite/services/chain"
@@ -322,11 +324,15 @@ func linkPluginCmd(rootCmd *cobra.Command, p *plugin.Plugin, pluginCmd plugin.Co
 				if err != nil {
 					return err
 				}
+				if p.With == nil {
+					p.With = make(map[string]string)
+				}
 				if manifest.WithPaths {
-					if p.With == nil {
-						p.With = make(map[string]string)
-					}
 					p.With["appPath"] = c.AppPath()
+				}
+				if manifest.WithModuleAnalysis {
+					modules, _ := common.GetModuleList(cmd.Context(), c)
+					maps.Copy(p.With, modules)
 				}
 				execCmd := plugin.ExecutedCommand{
 					Use:    cmd.Use,

--- a/ignite/pkg/common/common.go
+++ b/ignite/pkg/common/common.go
@@ -1,0 +1,180 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/ignite/cli/ignite/pkg/cache"
+	"github.com/ignite/cli/ignite/pkg/cmdrunner"
+	"github.com/ignite/cli/ignite/pkg/cmdrunner/step"
+	"github.com/ignite/cli/ignite/pkg/cosmosanalysis/module"
+	"github.com/ignite/cli/ignite/pkg/cosmosgen"
+	"github.com/ignite/cli/ignite/pkg/gomodule"
+	"github.com/ignite/cli/ignite/services/chain"
+	"github.com/pkg/errors"
+	gomod "golang.org/x/mod/module"
+)
+
+const (
+	defaultSDKImport     = "github.com/cosmos/cosmos-sdk"
+	moduleCacheNamespace = "analyze.setup.module"
+)
+
+type ModulesInPath struct {
+	Path    string
+	Modules []module.Module
+}
+
+type Analyzer struct {
+	ctx          context.Context
+	appPath      string
+	protoDir     string
+	sdkImport    string
+	appModules   []module.Module
+	cacheStorage cache.Storage
+	deps         []gomod.Version
+	thirdModules map[string][]module.Module // app dependency-modules pair.
+}
+
+func GetModuleList(ctx context.Context, c *chain.Chain) (map[string]string, error) {
+
+	conf, err := c.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	cacheStorage, err := cache.NewStorage(filepath.Join(c.AppPath(), "analyzer_cache.db"))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cosmosgen.InstallDepTools(ctx, c.AppPath()); err != nil {
+		return nil, err
+	}
+
+	var errb bytes.Buffer
+	if err := cmdrunner.
+		New(
+			cmdrunner.DefaultStderr(&errb),
+			cmdrunner.DefaultWorkdir(c.AppPath()),
+		).Run(ctx, step.New(step.Exec("go", "mod", "download"))); err != nil {
+		return nil, errors.Wrap(err, errb.String())
+	}
+
+	modFile, err := gomodule.ParseAt(c.AppPath())
+	g := &Analyzer{
+		ctx:          ctx,
+		appPath:      c.AppPath(),
+		protoDir:     conf.Build.Proto.Path,
+		thirdModules: make(map[string][]module.Module),
+		cacheStorage: cacheStorage,
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	g.sdkImport = defaultSDKImport
+
+	// Check if the Cosmos SDK import path points to a different path
+	// and if so change the default one to the new location.
+	for _, r := range modFile.Replace {
+		if r.Old.Path == defaultSDKImport {
+			g.sdkImport = r.New.Path
+			break
+		}
+	}
+
+	// Read the dependencies defined in the `go.mod` file
+	g.deps, err = gomodule.ResolveDependencies(modFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Discover any custom modules defined by the user's app
+	g.appModules, err = g.discoverModules(g.appPath, g.protoDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Go through the Go dependencies of the user's app within go.mod, some of them might be hosting Cosmos SDK modules
+	// that could be in use by user's blockchain.
+	//
+	// Cosmos SDK is a dependency of all blockchains, so it's absolute that we'll be discovering all modules of the
+	// SDK as well during this process.
+	//
+	// Even if a dependency contains some SDK modules, not all of these modules could be used by user's blockchain.
+	// this is fine, we can still generate TS clients for those non modules, it is up to user to use (import in typescript)
+	// not use generated modules.
+	//
+	// TODO: we can still implement some sort of smart filtering to detect non used modules by the user's blockchain
+	// at some point, it is a nice to have.
+	moduleCache := cache.New[ModulesInPath](g.cacheStorage, moduleCacheNamespace)
+	for _, dep := range g.deps {
+		// Try to get the cached list of modules for the current dependency package
+		cacheKey := cache.Key(dep.Path, dep.Version)
+		modulesInPath, err := moduleCache.Get(cacheKey)
+		if err != nil && !errors.Is(err, cache.ErrorNotFound) {
+			return nil, err
+		}
+
+		// Discover the modules of the dependency package when they are not cached
+		if errors.Is(err, cache.ErrorNotFound) {
+			// Get the absolute path to the package's directory
+			path, err := gomodule.LocatePath(g.ctx, g.cacheStorage, c.AppPath(), dep)
+			if err != nil {
+				return nil, err
+			}
+
+			// Discover any modules defined by the package
+			modules, err := g.discoverModules(path, "")
+			if err != nil {
+				return nil, err
+			}
+
+			modulesInPath = ModulesInPath{
+				Path:    path,
+				Modules: modules,
+			}
+
+			if err := moduleCache.Put(cacheKey, modulesInPath); err != nil {
+				return nil, err
+			}
+		}
+
+		g.thirdModules[modulesInPath.Path] = append(g.thirdModules[modulesInPath.Path], modulesInPath.Modules...)
+	}
+
+	var modulelist []ModulesInPath
+	modulelist = append(modulelist, ModulesInPath{Path: c.AppPath(), Modules: g.appModules})
+	for sourcePath, modules := range g.thirdModules {
+		modulelist = append(modulelist, ModulesInPath{Path: sourcePath, Modules: modules})
+	}
+	ret := make(map[string]string)
+	jsonm, _ := json.Marshal(modulelist)
+	ret["ModuleAnalysis"] = string(jsonm)
+	return ret, nil
+}
+
+func (g *Analyzer) discoverModules(path, protoDir string) ([]module.Module, error) {
+	var filteredModules []module.Module
+
+	modules, err := module.Discover(g.ctx, g.appPath, path, protoDir)
+	if err != nil {
+		return nil, err
+	}
+
+	protoPath := filepath.Join(path, g.protoDir)
+
+	for _, m := range modules {
+		if !strings.HasPrefix(m.Pkg.Path, protoPath) {
+			continue
+		}
+
+		filteredModules = append(filteredModules, m)
+	}
+
+	return filteredModules, nil
+}

--- a/ignite/pkg/gomodule/gomodule.go
+++ b/ignite/pkg/gomodule/gomodule.go
@@ -68,9 +68,11 @@ func ResolveDependencies(f *modfile.File) ([]module.Version, error) {
 	}
 
 	for _, req := range f.Require {
-		if req.Indirect {
-			continue
-		}
+		/*	Commented out to include indirect dependencies as proto files may import from them
+			if req.Indirect {
+				continue
+			}
+		*/
 		if !isReplacementAdded(req.Mod) {
 			versions = append(versions, req.Mod)
 		}

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -295,6 +295,11 @@ func (c *Chain) Home() (string, error) {
 	return home, nil
 }
 
+// AppPath returns the configured App's path
+func (c *Chain) AppPath() string {
+	return c.app.Path
+}
+
 // DefaultHome returns the blockchain node's default home dir when not specified in the app.
 func (c *Chain) DefaultHome() (string, error) {
 	// check if home is defined in config

--- a/ignite/services/plugin/interface.go
+++ b/ignite/services/plugin/interface.go
@@ -61,7 +61,8 @@ type Manifest struct {
 	// commands.
 	Hooks []Hook
 
-	WithPaths bool
+	WithPaths          bool
+	WithModuleAnalysis bool
 	// SharedHost enables sharing a single plugin server across all running instances
 	// of a plugin. Useful if a plugin adds or extends long running commands
 	//

--- a/ignite/services/plugin/interface.go
+++ b/ignite/services/plugin/interface.go
@@ -60,6 +60,8 @@ type Manifest struct {
 	// Hooks contains the hooks that will be attached to the existing ignite
 	// commands.
 	Hooks []Hook
+
+	WithPaths bool
 	// SharedHost enables sharing a single plugin server across all running instances
 	// of a plugin. Useful if a plugin adds or extends long running commands
 	//

--- a/ignite/services/plugin/template/go.mod.plush
+++ b/ignite/services/plugin/template/go.mod.plush
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/hashicorp/go-plugin v1.4.4
-	github.com/ignite/cli v0.26.2-0.20230510130939-0da6600175ec
+	github.com/ignite/cli v0.26.2-0.20230511160815-7a63ab71c283
 )
 
 replace (

--- a/ignite/services/plugin/template/go.mod.plush
+++ b/ignite/services/plugin/template/go.mod.plush
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/hashicorp/go-plugin v1.4.4
-	github.com/ignite/cli v0.25.3-0.20230104184106-15d7be221737
+	github.com/ignite/cli v0.26.2-0.20230510130939-0da6600175ec
 )
 
 replace (

--- a/ignite/services/plugin/template/main.go.plush
+++ b/ignite/services/plugin/template/main.go.plush
@@ -45,6 +45,7 @@ func (p) Manifest() (plugin.Manifest, error) {
 		},
 		//
 		WithPaths: true,
+		WithModuleAnalysis: true,
 		// Add hooks here
 		Hooks: []plugin.Hook{},
 		SharedHost: <%= SharedHost %>,

--- a/ignite/services/plugin/template/main.go.plush
+++ b/ignite/services/plugin/template/main.go.plush
@@ -43,6 +43,8 @@ func (p) Manifest() (plugin.Manifest, error) {
 				*/
 			},
 		},
+		//
+		WithPaths: true,
 		// Add hooks here
 		Hooks: []plugin.Hook{},
 		SharedHost: <%= SharedHost %>,


### PR DESCRIPTION
After discussions with @tbruyelle I went with a simpler approach than what I originally had in mind in order to not break existing plugins.

The basic idea is that Manifest has flags that can be toggled in the plugin implementation.

Ignite command reads those toggles and augments the plugin config passed to the plugin with data generated/fetched on the fly.