### PR TITLE
chore(network): Bump network plugin version to `v0.1.1`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [#3559](https://github.com/ignite/cli/pull/3559) Bump network plugin version to `v0.1.1`
+
 ## [`v0.27.1`](https://github.com/ignite/cli/releases/tag/v0.27.1)
 
 ### Features

--- a/ignite/cmd/plugin_default.go
+++ b/ignite/cmd/plugin_default.go
@@ -18,7 +18,7 @@ type defaultPlugin struct {
 }
 
 const (
-	PluginNetworkVersion = "v0.1.0"
+	PluginNetworkVersion = "v0.1.1"
 	PluginNetworkPath    = "github.com/ignite/cli-plugin-network@" + PluginNetworkVersion
 )
 


### PR DESCRIPTION
the new version has the sdk `v0.47.3` without warnings into the `stdout`