### PR TITLE
fix: update instruction link for ignite CLI version upgradation

### DIFF
--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -262,7 +262,7 @@ func checkNewVersion(ctx context.Context) {
 	fmt.Printf(`·
 · 🛸 Ignite CLI %s is available!
 ·
-· To upgrade your Ignite CLI version, see the upgrade doc: https://docs.ignite.com/guide/install#upgrading-your-ignite-cli-installation
+· To upgrade your Ignite CLI version, see the upgrade doc: https://docs.ignite.com/welcome/install#upgrading-your-ignite-cli-installation
 ·
 ··
 


### PR DESCRIPTION
Previous link(getting 404) : https://docs.ignite.com/guide/install#upgrading-your-ignite-cli-installation
Correct link : https://docs.ignite.com/welcome/install#upgrading-your-ignite-cli-installation