### PR TITLE
fix: docs for scaffold map

### DIFF
--- a/ignite/cmd/scaffold_map.go
+++ b/ignite/cmd/scaffold_map.go
@@ -21,7 +21,7 @@ dictionary) in the blockchain state.
 
 The "map" command is very similar to "ignite scaffold list" with the main
 difference in how values are indexed. With "list" values are indexed by an
-incrementing integer, whereas "list" values are indexed by a user-provided value
+incrementing integer, whereas "map" values are indexed by a user-provided value
 (or multiple values).
 
 Let's use the same blog post example:


### PR DESCRIPTION
Looks like a simple typo, where you are trying to reference the difference between "map" and "list", but mention "list" twice.