### PR TITLE
feat(plugin): ✨ Add `marketplace` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#3585](https://github.com/ignite/cli/pull/3585) Add `marketplace` command for plugins
 - [#3476](https://github.com/ignite/cli/pull/3476) Use `buf.build` binary to code generate from proto files
 
 ### Changes

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/gobuffalo/plush/v4 v4.1.16
 	github.com/goccy/go-yaml v1.9.7
 	github.com/golangci/golangci-lint v1.50.1
+	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v48 v48.2.0
 	github.com/gookit/color v1.5.3
 	github.com/gorilla/mux v1.8.0
@@ -60,6 +61,7 @@ require (
 	go.etcd.io/bbolt v1.3.7
 	golang.org/x/exp v0.0.0-20230519143937-03e91628a987
 	golang.org/x/mod v0.10.0
+	golang.org/x/oauth2 v0.6.0
 	golang.org/x/sync v0.2.0
 	golang.org/x/term v0.8.0
 	golang.org/x/text v0.9.0
@@ -70,6 +72,8 @@ require (
 	mvdan.cc/gofumpt v0.5.0
 	sigs.k8s.io/yaml v1.3.0
 )
+
+require google.golang.org/appengine v1.6.7 // indirect
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -581,6 +581,8 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-dap v0.7.0 h1:088PdKBUkxAxrXrnY8FREUJXpS6Y6jhAyZIuJv3OGOM=
 github.com/google/go-dap v0.7.0/go.mod h1:5q8aYQFnHOAZEMP+6vmq25HKYAEwE+LF5yh7JKrrhSQ=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v48 v48.2.0 h1:68puzySE6WqUY9KWmpOsDEQfDZsso98rT6pZcz9HqcE=
 github.com/google/go-github/v48 v48.2.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
@@ -1422,6 +1424,7 @@ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.6.0 h1:Lh8GPgSKBfWSwFvtuWOfeI3aAAnbXTSutYxJiOJFgIw=
+golang.org/x/oauth2 v0.6.0/go.mod h1:ycmewcwgD4Rpr3eZJLSB4Kyyljb3qDh40vJ8STE5HKw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -79,6 +79,7 @@ To get started, create a blockchain:
 	c.AddCommand(NewVersion())
 	c.AddCommand(NewPlugin())
 	c.AddCommand(NewDoctor())
+	c.AddCommand(NewMarketplace())
 	c.AddCommand(deprecated()...)
 
 	// Load plugins if any

--- a/ignite/cmd/marketplace.go
+++ b/ignite/cmd/marketplace.go
@@ -71,7 +71,7 @@ func NewMarketplaceList() *cobra.Command {
 	return c
 }
 
-func listMarketplaceHandler(cmd *cobra.Command, args []string) error {
+func listMarketplaceHandler(_ *cobra.Command, _ []string) error {
 	session := cliui.New(cliui.StartSpinnerWithText(statusQuerying))
 	defer session.End()
 
@@ -91,7 +91,7 @@ func listMarketplaceHandler(cmd *cobra.Command, args []string) error {
 	return mpService.ListPlugins(queryCtx, c, opts)
 }
 
-func marketplaceInfoHandler(cmd *cobra.Command, args []string) error {
+func marketplaceInfoHandler(_ *cobra.Command, args []string) error {
 	session := cliui.New(cliui.StartSpinnerWithText(statusQuerying))
 	defer session.End()
 
@@ -106,7 +106,7 @@ func marketplaceInfoHandler(cmd *cobra.Command, args []string) error {
 	return mpService.InfoPlugin(queryCtx, c, args[0])
 }
 
-func marketplaceAddHandler(cmd *cobra.Command, args []string) error {
+func marketplaceAddHandler(_ *cobra.Command, args []string) error {
 	session := cliui.New(cliui.WithStdout(os.Stdout))
 	defer session.End()
 

--- a/ignite/cmd/marketplace.go
+++ b/ignite/cmd/marketplace.go
@@ -1,0 +1,118 @@
+package ignitecmd
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/google/go-github/github"
+	"github.com/ignite/cli/ignite/pkg/cliui"
+	mpService "github.com/ignite/cli/ignite/services/marketplace"
+	"github.com/spf13/cobra"
+)
+
+func NewMarketplace() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "marketplace [command] [args]",
+		Short: "Installing plugins from marketplace",
+		Long: `Instal a plugin from GitHub.
+
+Ignite CLI has a feature called plugins. It allows you
+to extend the functionality of the CLI without having
+to touch the core codebase. This command allows you to
+install a plugin from GitHub.
+    `,
+		Aliases: []string{"m"},
+		Args:    cobra.ExactArgs(1),
+	}
+
+	flagSetPath(c)
+	flagSetClearCache(c)
+	c.AddCommand(NewMarketplaceList())
+	c.AddCommand(NewMarketplaceInfo())
+	c.AddCommand(NewMarketplaceAdd())
+
+	return c
+}
+
+func NewMarketplaceAdd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "add",
+		Short: "For adding plugins from marketplace",
+		Args:  cobra.ExactArgs(1),
+		RunE:  marketplaceAddHandler,
+	}
+
+	c.Flags().AddFlagSet(flagSetYes())
+
+	return c
+}
+
+func NewMarketplaceInfo() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "info",
+		Short: "For getting info about plugins from marketplace",
+		RunE:  marketplaceInfoHandler,
+		Args:  cobra.ExactArgs(1),
+	}
+
+	c.Flags().AddFlagSet(flagSetYes())
+
+	return c
+}
+
+func NewMarketplaceList() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "list",
+		Short: "For listing plugins from marketplace",
+		RunE:  listMarketplaceHandler,
+	}
+
+	return c
+}
+
+func listMarketplaceHandler(cmd *cobra.Command, args []string) error {
+	session := cliui.New(cliui.StartSpinnerWithText(statusQuerying))
+	defer session.End()
+
+	var (
+		ctx              = context.Background()
+		c                = mpService.NewClient(ctx, getAccessToken())
+		queryCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+
+		opts = &github.SearchOptions{
+			Sort:  "stars",
+			Order: "desc",
+		}
+	)
+
+	defer cancel()
+
+	return mpService.ListPlugins(queryCtx, c, opts)
+}
+
+func marketplaceInfoHandler(cmd *cobra.Command, args []string) error {
+	session := cliui.New(cliui.StartSpinnerWithText(statusQuerying))
+	defer session.End()
+
+	var (
+		ctx              = context.Background()
+		c                = mpService.NewClient(ctx, getAccessToken())
+		queryCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	)
+
+	defer cancel()
+
+	return mpService.InfoPlugin(queryCtx, c, args[0])
+}
+
+func marketplaceAddHandler(cmd *cobra.Command, args []string) error {
+	session := cliui.New(cliui.WithStdout(os.Stdout))
+	defer session.End()
+
+	return mpService.AddPlugin(args[0])
+}
+
+func getAccessToken() string {
+	return os.Getenv("GITHUB_TOKEN")
+}

--- a/ignite/services/marketplace/add.go
+++ b/ignite/services/marketplace/add.go
@@ -1,0 +1,37 @@
+package marketplace
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func AddPlugin(repo string) error {
+	homeDir := os.Getenv("HOME")
+	futurePluginPath := homeDir + "/.ignite/plugins/" + repo
+
+	if _, err := os.Stat(futurePluginPath); err == nil {
+		return fmt.Errorf("plugin %s already exists", repo)
+	}
+
+	command := "git"
+	args := []string{"clone", "http://github.com/" + repo, futurePluginPath}
+
+	cmd := exec.Command(command, args...)
+
+	cmd.Stdout = os.Stdout
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	// Add plugin
+	igniteCmd := exec.Command("ignite", "plugin", "add", "-g", futurePluginPath)
+	igniteCmd.Stdout = os.Stdout
+	err = igniteCmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/ignite/services/marketplace/info.go
+++ b/ignite/services/marketplace/info.go
@@ -1,0 +1,26 @@
+package marketplace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/github"
+)
+
+func InfoPlugin(ctx context.Context, client *Client, repo string) error {
+	result, err := client.RepoQuery(ctx, &github.SearchOptions{}, Query{Qualifier: "repo", Value: repo})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf(`
+%s
+  - Name: %s
+  - Owner: %s
+  - Description: %s
+  - Stars: %d
+  - URL: %s
+`, repo, result[0].GetName(), result[0].GetOwner().GetLogin(), result[0].GetDescription(), result[0].GetStargazersCount(), result[0].GetHTMLURL())
+
+	return nil
+}

--- a/ignite/services/marketplace/list.go
+++ b/ignite/services/marketplace/list.go
@@ -1,0 +1,82 @@
+package marketplace
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/go-github/github"
+
+	"github.com/ignite/cli/ignite/pkg/cliui/icons"
+)
+
+func ListPlugins(ctx context.Context, client *Client, opts *github.SearchOptions) error {
+	result, err := client.RepoQuery(
+		ctx,
+		opts,
+		Query{Qualifier: "topic", Value: "ignite-plugin"},
+		// Query{Qualifier: "language", Value: "go"},
+		// Query{Qualifier: "license", Value: "MIT"},
+		// Query{Qualifier: "stars", Value: ">5"}, // TODO: Uncommend this line
+	)
+	if err != nil {
+		return err
+	}
+
+	homeDir := os.Getenv("HOME")
+
+	owners, err := allDirectoriesInDir(homeDir + "/.ignite/plugins")
+	if err != nil {
+		return err
+	}
+
+	plugins := make(map[string]bool)
+	for owner := range owners {
+		pl, err := allDirectoriesInDir(homeDir + "/.ignite/plugins/" + owner)
+		if err != nil {
+			return err
+		}
+
+		for p := range pl {
+			plugins[owner+"/"+p] = true
+		}
+	}
+
+	for _, repo := range result {
+		fullName := *repo.Owner.Login + "/" + *repo.Name
+
+		if _, ok := plugins[fullName]; ok {
+			fmt.Printf("\n%s %s: ", icons.OK, fullName)
+		} else {
+			fmt.Printf("\n%s %s: ", icons.NotOK, fullName)
+		}
+
+		if repo.Description != nil {
+			fmt.Printf("%s", *repo.Description)
+		}
+	}
+
+	return nil
+}
+
+func allDirectoriesInDir(dirpath string) (map[string]bool, error) {
+	dir, err := os.Open(dirpath)
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+
+	fileInfos, err := dir.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := make(map[string]bool)
+	for _, p := range fileInfos {
+		if p.IsDir() {
+			dirs[p.Name()] = true
+		}
+	}
+
+	return dirs, nil
+}

--- a/ignite/services/marketplace/xgithub.go
+++ b/ignite/services/marketplace/xgithub.go
@@ -9,10 +9,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const (
-	igniteTopic = "ignite-plugin"
-)
-
 type (
 	Client struct {
 		ts     oauth2.TokenSource

--- a/ignite/services/marketplace/xgithub.go
+++ b/ignite/services/marketplace/xgithub.go
@@ -1,0 +1,74 @@
+package marketplace
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+const (
+	igniteTopic = "ignite-plugin"
+)
+
+type (
+	Client struct {
+		ts     oauth2.TokenSource
+		tc     *http.Client
+		client *github.Client
+	}
+
+	Query struct {
+		Qualifier string
+		Value     string
+	}
+)
+
+func (c *Client) RepoQuery(ctx context.Context, opts *github.SearchOptions, queries ...Query) ([]github.Repository, error) {
+	query, err := CreateQuery(queries)
+	if err != nil {
+		return nil, err
+	}
+
+	result, _, err := c.client.Search.Repositories(ctx, query, opts)
+	if err != nil {
+		return nil, err
+	}
+	return result.Repositories, nil
+}
+
+func NewClient(ctx context.Context, accessToken string) *Client {
+	var (
+		ts = oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: accessToken},
+		)
+		tc     = oauth2.NewClient(ctx, ts)
+		client = github.NewClient(tc)
+	)
+
+	return &Client{
+		ts:     ts,
+		tc:     tc,
+		client: client,
+	}
+}
+
+func CreateQuery(queries []Query) (string, error) {
+	var (
+		qMap = make(map[string]string)
+		q    = ""
+	)
+
+	for _, query := range queries {
+		if _, ok := qMap[query.Qualifier]; ok {
+			return "", fmt.Errorf("duplicate qualifier: %s", query.Qualifier)
+		}
+
+		qMap[query.Qualifier] = query.Value
+		q += fmt.Sprintf("%s:%s ", query.Qualifier, query.Value)
+	}
+
+	return q, nil
+}


### PR DESCRIPTION
# Description

This PR adds a new command for listing and fetching Ignite plugins from GitHub. Resolves #3453 

# How to use

- Listing: `ignite marketplace list`
- Info: `ignite marketplace info owner/repo`
- Add: `ignite marketplace add owner/repo`

# Known Issues

I am a newbie open-source developer. At some things, I wasn't sure what to do. Here is the list of them:
- Getting the GitHub access key: Currently, we are getting them using the os environments. There are some options too, but this one is the easiest to use. Other options that came to my mind:
    - Using a credentials file: We can store the access key in `~/.ignite/plugins/credentials.json`.
    - Take as a parameter: I wouldn't want to give the access key repeatedly.
- Using CLI commands: I used a couple of times GitHub and Ignite CLI commands in this code. I would like to learn and implement better ways of it.
- Can't use without access token: I don't know if there is any other option.
- Using queries for listing: There are a few repositories with `ignite-plugin` topic right now. Because of that, I had to comment some of the query lines. Is that a good idea to get them from flags (stars, license, etc)?


Please tell you the change requests. Those will be fulfilled quickly.