### PR TITLE
fix(pkg/protoanalysis): support HTTP rule parameter arguments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,10 @@
 - [#3559](https://github.com/ignite/cli/pull/3559) Bump network plugin version to `v0.1.1` 
 - [#3522](https://github.com/ignite/cli/pull/3522) Remove indentation from `chain serve` output
 
+### Fixes
+
+- [#3592](https://github.com/ignite/cli/pull/3592) fix(pkg/protoanalysis): support HTTP rule parameter arguments
+
 ## [`v0.27.0`](https://github.com/ignite/cli/releases/tag/v0.27.0)
 
 ### Features

--- a/ignite/pkg/protoanalysis/builder.go
+++ b/ignite/pkg/protoanalysis/builder.go
@@ -158,7 +158,11 @@ func (b builder) elementsToHTTPRules(requestMessage *proto.Message, elems []prot
 	return
 }
 
-var urlParamRe = regexp.MustCompile(`(?m){(.+?)}`)
+// Regexp to extract HTTP rule URL parameter names.
+// The expression extracts parameter names defined within "{}".
+// Extra parameter arguments are ignored. These arguments are normally
+// defined after an "=", for example as "{param=**}".
+var urlParamRe = regexp.MustCompile(`(?m){([^=]+?)(?:=.+?)?}`)
 
 func (b builder) constantToHTTPRules(requestMessage *proto.Message, constant proto.Literal) (httpRules []HTTPRule) {
 	// find out the endpoint template.


### PR DESCRIPTION
Proto HTTP rule parameters can have extra arguments which are defined after a "=", for example `/foo/{bar=**}`.

Fixes #3554 