### PR TITLE
chore: add back crisis module to SetOrderBeginBlockers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,6 @@
 - [#3581](https://github.com/ignite/cli/pull/3581) Bump cometbft and cometbft-db in the template
 - [#3559](https://github.com/ignite/cli/pull/3559) Bump network plugin version to `v0.1.1` 
 - [#3522](https://github.com/ignite/cli/pull/3522) Remove indentation from `chain serve` output
-- [#3593](https://github.com/ignite/cli/pull/3593) Remove crisis module from begin blockers in app template
 
 ## [`v0.27.0`](https://github.com/ignite/cli/releases/tag/v0.27.0)
 

--- a/ignite/templates/app/files/app/app.go.plush
+++ b/ignite/templates/app/files/app/app.go.plush
@@ -595,6 +595,7 @@ func New(
 		authtypes.ModuleName,
 		banktypes.ModuleName,
 		govtypes.ModuleName,
+		crisistypes.ModuleName,
 		ibctransfertypes.ModuleName,
 		ibcexported.ModuleName,
 		icatypes.ModuleName,


### PR DESCRIPTION
The module must be added to avoid triggering an assertion that requires that all modules are added to `SetOrderBeginBlockers` even if they don't implement `HasBeginBlocker`. Modules that don't implement it can be removed from the list once Cosmos SDK `v0.50.0` is released.