### PR TITLE
ci: remove `go` snippet syntax from migration docs

### DIFF
--- a/docs/docs/06-migration/v0.27.1.md
+++ b/docs/docs/06-migration/v0.27.1.md
@@ -10,8 +10,8 @@ description: For chains that were scaffolded with Ignite CLI versions lower than
 
 To use the new cosmos SDK make sure you update `go.mod` dependencies:
 
-```go title="go.mod"
-go 1.19
+```text title="go.mod"
+go 1.20
 
 require (
 	// remove-start
@@ -66,7 +66,7 @@ You might need to replace the following imports:
 Applications scaffolded with older version of Ignite CLI would require the following changes
 to some of the app files:
 
-```go title="app/app.go"
+```text title="app/app.go"
 import (
 	//...
 
@@ -561,7 +561,7 @@ func (app *App) ModuleManager() *module.Manager {
 // highlight-end
 ```
 
-```go title="app/simulation_test.go"
+```text title="app/simulation_test.go"
 import (
 	// ...
 	// remove-start
@@ -751,7 +751,7 @@ func BenchmarkSimulation(b *testing.B) {
 }
 ```
 
-```go title="x/{{moduleName}}/module_simulation.go"
+```text title="x/{{moduleName}}/module_simulation.go"
 import (
 	// ...
 	// remove-next-line
@@ -785,7 +785,7 @@ func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.Wei
 
 The app module might contains some legacy methods that are deprecated and can be removed:
 
-```go title="x/{{moduleName}}/module.go"
+```text title="x/{{moduleName}}/module.go"
 // remove-start
 // Deprecated: use RegisterServices
 func (am AppModule) Route() sdk.Route { return sdk.Route{} }
@@ -804,7 +804,7 @@ func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
 
 Changes required to the network test util:
 
-```go title="testutil/network/network.go"
+```text title="testutil/network/network.go"
 import (
 	// ...
 
@@ -887,7 +887,7 @@ func DefaultConfig() network.Config {
 
 Update the collect genesis transactions command and add the new message validator argument:
 
-```go title="cmd/{{binaryNamePrefix}}d/cmd/root.go"
+```text title="cmd/{{binaryNamePrefix}}d/cmd/root.go"
 import (
 	// ...
 
@@ -983,7 +983,7 @@ func (a appCreator) appExport(
 
 Add the new extra argument to `ExportAppStateAndValidators`:
 
-```go title="app/export.go"
+```text title="app/export.go"
 func (app *App) ExportAppStateAndValidators(
 	forZeroHeight bool,
 	jailAllowedAddrs []string,
@@ -1015,7 +1015,7 @@ is required if you want to run the updated version keeping you current app state
 
 Query commands context initialization should be changed to:
 
-```go title="x/{moduleName}/client/cli/query_{typeName}.go"
+```text title="x/{moduleName}/client/cli/query_{typeName}.go"
 RunE: func(cmd *cobra.Command, args []string) (err error) {
 	// remove-next-line
 	clientCtx := client.GetClientContextFromCmd(cmd)
@@ -1038,7 +1038,7 @@ required to upgrade to the newest version of `ibc-go`.
 
 Applications scaffolded with older version of Ignite CLI require the following changes to the app file:
 
-```go title="app/app.go"
+```text title="app/app.go"
 import (
 	// ...
 	// remove-start

--- a/docs/versioned_docs/version-v0.27.1/06-migration/v0.27.1.md
+++ b/docs/versioned_docs/version-v0.27.1/06-migration/v0.27.1.md
@@ -10,7 +10,7 @@ description: For chains that were scaffolded with Ignite CLI versions lower than
 
 To use the new cosmos SDK make sure you update `go.mod` dependencies:
 
-```go title="go.mod"
+```text title="go.mod"
 go 1.19
 
 require (
@@ -66,7 +66,7 @@ You might need to replace the following imports:
 Applications scaffolded with older version of Ignite CLI would require the following changes
 to some of the app files:
 
-```go title="app/app.go"
+```text title="app/app.go"
 import (
 	//...
 
@@ -561,7 +561,7 @@ func (app *App) ModuleManager() *module.Manager {
 // highlight-end
 ```
 
-```go title="app/simulation_test.go"
+```text title="app/simulation_test.go"
 import (
 	// ...
 	// remove-start
@@ -751,7 +751,7 @@ func BenchmarkSimulation(b *testing.B) {
 }
 ```
 
-```go title="x/{{moduleName}}/module_simulation.go"
+```text title="x/{{moduleName}}/module_simulation.go"
 import (
 	// ...
 	// remove-next-line
@@ -785,7 +785,7 @@ func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.Wei
 
 The app module might contains some legacy methods that are deprecated and can be removed:
 
-```go title="x/{{moduleName}}/module.go"
+```text title="x/{{moduleName}}/module.go"
 // remove-start
 // Deprecated: use RegisterServices
 func (am AppModule) Route() sdk.Route { return sdk.Route{} }
@@ -804,7 +804,7 @@ func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
 
 Changes required to the network test util:
 
-```go title="testutil/network/network.go"
+```text title="testutil/network/network.go"
 import (
 	// ...
 
@@ -887,7 +887,7 @@ func DefaultConfig() network.Config {
 
 Update the collect genesis transactions command and add the new message validator argument:
 
-```go title="cmd/{{binaryNamePrefix}}d/cmd/root.go"
+```text title="cmd/{{binaryNamePrefix}}d/cmd/root.go"
 import (
 	// ...
 
@@ -983,7 +983,7 @@ func (a appCreator) appExport(
 
 Add the new extra argument to `ExportAppStateAndValidators`:
 
-```go title="app/export.go"
+```text title="app/export.go"
 func (app *App) ExportAppStateAndValidators(
 	forZeroHeight bool,
 	jailAllowedAddrs []string,
@@ -1015,7 +1015,7 @@ is required if you want to run the updated version keeping you current app state
 
 Query commands context initialization should be changed to:
 
-```go title="x/{moduleName}/client/cli/query_{typeName}.go"
+```text title="x/{moduleName}/client/cli/query_{typeName}.go"
 RunE: func(cmd *cobra.Command, args []string) (err error) {
 	// remove-next-line
 	clientCtx := client.GetClientContextFromCmd(cmd)
@@ -1038,7 +1038,7 @@ required to upgrade to the newest version of `ibc-go`.
 
 Applications scaffolded with older version of Ignite CLI require the following changes to the app file:
 
-```go title="app/app.go"
+```text title="app/app.go"
 import (
 	// ...
 	// remove-start

--- a/docs/versioned_docs/version-v0.27.1/06-migration/v0.27.1.md
+++ b/docs/versioned_docs/version-v0.27.1/06-migration/v0.27.1.md
@@ -11,7 +11,7 @@ description: For chains that were scaffolded with Ignite CLI versions lower than
 To use the new cosmos SDK make sure you update `go.mod` dependencies:
 
 ```text title="go.mod"
-go 1.19
+go 1.20
 
 require (
 	// remove-start


### PR DESCRIPTION
The `go` syntax changed to `text` to aviod CI errors when `mdgofmt` validates and format the snippets. Migration snippets are writen as "diffs" so the code within them is not valid Go code.