### PR TITLE
chore: uin64 overflow fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,18 +9,20 @@
 ### Changes
 
 - [#3581](https://github.com/ignite/cli/pull/3581) Bump cometbft and cometbft-db in the template
-- [#3559](https://github.com/ignite/cli/pull/3559) Bump network plugin version to `v0.1.1` 
+- [#3559](https://github.com/ignite/cli/pull/3559) Bump network plugin version to `v0.1.1`
 - [#3522](https://github.com/ignite/cli/pull/3522) Remove indentation from `chain serve` output
 
 ### Fixes
 
 - [#3592](https://github.com/ignite/cli/pull/3592) Fix `pkg/protoanalysis` to support HTTP rule parameter arguments
 - [#3598](https://github.com/ignite/cli/pull/3598) Fix consensus param keeper constructor key in `app.go`
+- [#3610](https://github.com/ignite/cli/pull/3610) Fix overflow issue of cosmos faucet in `pkg/cosmosfaucet/transfer.go` and `pkg/cosmosfaucet/cosmosfaucet.go`
 
 ## [`v0.27.0`](https://github.com/ignite/cli/releases/tag/v0.27.0)
 
 ### Features
-- 
+
+-
 - [#3505](https://github.com/ignite/cli/pull/3505) Auto migrate dependency tools
 - [#3538](https://github.com/ignite/cli/pull/3538) bump sdk to `v0.47.3` and ibc to `v7.1.0`
 - [#2736](https://github.com/ignite/cli/issues/2736) Add `--skip-git` flag to skip git repository initialization.

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
 )
@@ -81,7 +81,7 @@ func Account(name, mnemonic string, coinType string) Option {
 // amount is the amount of the coin can be distributed per request.
 // maxAmount is the maximum amount of the coin that can be sent to a single account.
 // denom is denomination of the coin to be distributed by the faucet.
-func Coin(amount, maxAmount sdk.Int, denom string) Option {
+func Coin(amount, maxAmount sdkmath.Int, denom string) Option {
 	return func(f *Faucet) {
 		f.coins = append(f.coins, sdk.NewCoin(denom, amount))
 		f.coinsMax[denom] = maxAmount
@@ -114,7 +114,7 @@ func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Fau
 	f := Faucet{
 		runner:      ccr,
 		accountName: DefaultAccountName,
-		coinsMax:    make(map[string]sdk.Int),
+		coinsMax:    make(map[string]sdkmath.Int),
 		openAPIData: openAPIData{"Blockchain", "http://localhost:1317"},
 	}
 
@@ -123,7 +123,7 @@ func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Fau
 	}
 
 	if len(f.coins) == 0 {
-		Coin(sdk.NewInt(DefaultAmount), sdk.NewInt(DefaultMaxAmount), DefaultDenom)(&f)
+		Coin(sdkmath.NewInt(DefaultAmount), sdkmath.NewInt(DefaultMaxAmount), DefaultDenom)(&f)
 	}
 
 	if f.limitRefreshWindow == 0 {

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"time"
 
-	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
@@ -54,7 +53,7 @@ type Faucet struct {
 
 	// coinsMax is a denom-max pair.
 	// it holds the maximum amounts of coins that can be sent to a single account.
-	coinsMax map[string]uint64
+	coinsMax map[string]sdk.Int
 
 	limitRefreshWindow time.Duration
 
@@ -81,9 +80,9 @@ func Account(name, mnemonic string, coinType string) Option {
 // amount is the amount of the coin can be distributed per request.
 // maxAmount is the maximum amount of the coin that can be sent to a single account.
 // denom is denomination of the coin to be distributed by the faucet.
-func Coin(amount, maxAmount uint64, denom string) Option {
+func Coin(amount, maxAmount sdk.Int, denom string) Option {
 	return func(f *Faucet) {
-		f.coins = append(f.coins, sdk.NewCoin(denom, sdkmath.NewIntFromUint64(amount)))
+		f.coins = append(f.coins, sdk.NewCoin(denom, amount))
 		f.coinsMax[denom] = maxAmount
 	}
 }
@@ -114,7 +113,7 @@ func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Fau
 	f := Faucet{
 		runner:      ccr,
 		accountName: DefaultAccountName,
-		coinsMax:    make(map[string]uint64),
+		coinsMax:    make(map[string]sdk.Int),
 		openAPIData: openAPIData{"Blockchain", "http://localhost:1317"},
 	}
 
@@ -123,7 +122,7 @@ func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Fau
 	}
 
 	if len(f.coins) == 0 {
-		Coin(DefaultAmount, DefaultMaxAmount, DefaultDenom)(&f)
+		Coin(sdk.NewInt(DefaultAmount), sdk.NewInt(DefaultMaxAmount), DefaultDenom)(&f)
 	}
 
 	if f.limitRefreshWindow == 0 {

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkmath "cosmossdk.io/math"
 
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
 )
@@ -53,7 +54,7 @@ type Faucet struct {
 
 	// coinsMax is a denom-max pair.
 	// it holds the maximum amounts of coins that can be sent to a single account.
-	coinsMax map[string]sdk.Int
+	coinsMax map[string]sdkmath.Int
 
 	limitRefreshWindow time.Duration
 

--- a/ignite/pkg/cosmosfaucet/transfer.go
+++ b/ignite/pkg/cosmosfaucet/transfer.go
@@ -63,21 +63,21 @@ func (f *Faucet) Transfer(ctx context.Context, toAccountAddress string, coins sd
 		if err != nil {
 			return err
 		}
-
-		if !f.coinsMax[c.Denom].Equal(sdk.NewInt(0)) {
-			if totalSent.GTE(f.coinsMax[c.Denom]) {
+		coinMax, found := f.coinsMax[c.Denom]
+		if found && !coinMax.IsNil() && !coinMax.Equal(sdk.NewInt(0)) {
+			if totalSent.GTE(coinMax) {
 				return fmt.Errorf(
 					"account has reached to the max. allowed amount (%d) for %q denom",
-					f.coinsMax[c.Denom],
+					coinMax,
 					c.Denom,
 				)
 			}
 
-			if (totalSent.Add(c.Amount)).GT(f.coinsMax[c.Denom]) {
+			if (totalSent.Add(c.Amount)).GT(coinMax) {
 				return fmt.Errorf(
 					`ask less amount for %q denom. account is reaching to the limit (%d) that faucet can tolerate`,
 					c.Denom,
-					f.coinsMax[c.Denom],
+					coinMax,
 				)
 			}
 		}

--- a/ignite/pkg/cosmosfaucet/transfer.go
+++ b/ignite/pkg/cosmosfaucet/transfer.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
+	sdkmath "cosmossdk.io/math"
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
 )
 
@@ -19,14 +19,14 @@ var transferMutex = &sync.Mutex{}
 func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress, denom string) (totalAmount sdk.Int, err error) {
 	fromAccount, err := f.runner.ShowAccount(ctx, f.accountName)
 	if err != nil {
-		return sdk.NewInt(0), err
+		return sdkmath.NewInt(0), err
 	}
 
 	events, err := f.runner.QueryTxEvents(ctx,
 		chaincmdrunner.NewEventSelector("message", "sender", fromAccount.Address),
 		chaincmdrunner.NewEventSelector("transfer", "recipient", toAccountAddress))
 	if err != nil {
-		return sdk.NewInt(0), err
+		return sdkmath.NewInt(0), err
 	}
 
 	for _, event := range events {
@@ -35,11 +35,11 @@ func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress, de
 				if attr.Key == "amount" {
 					coins, err := sdk.ParseCoinsNormalized(attr.Value)
 					if err != nil {
-						return sdk.NewInt(0), err
+						return sdkmath.NewInt(0), err
 					}
 
 					amount := coins.AmountOf(denom)
-					if amount.GT(sdk.NewInt(0)) && time.Since(event.Time) < f.limitRefreshWindow {
+					if amount.GT(sdkmath.NewInt(0)) && time.Since(event.Time) < f.limitRefreshWindow {
 						totalAmount = totalAmount.Add(amount)
 					}
 				}
@@ -64,7 +64,7 @@ func (f *Faucet) Transfer(ctx context.Context, toAccountAddress string, coins sd
 			return err
 		}
 		coinMax, found := f.coinsMax[c.Denom]
-		if found && !coinMax.IsNil() && !coinMax.Equal(sdk.NewInt(0)) {
+		if found && !coinMax.IsNil() && !coinMax.Equal(sdkmath.NewInt(0)) {
 			if totalSent.GTE(coinMax) {
 				return fmt.Errorf(
 					"account has reached to the max. allowed amount (%d) for %q denom",

--- a/ignite/pkg/cosmosfaucet/transfer.go
+++ b/ignite/pkg/cosmosfaucet/transfer.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
 )
 
@@ -16,7 +16,7 @@ import (
 var transferMutex = &sync.Mutex{}
 
 // TotalTransferredAmount returns the total transferred amount from faucet account to toAccountAddress.
-func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress, denom string) (totalAmount sdk.Int, err error) {
+func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress, denom string) (totalAmount sdkmath.Int, err error) {
 	fromAccount, err := f.runner.ShowAccount(ctx, f.accountName)
 	if err != nil {
 		return sdkmath.NewInt(0), err
@@ -29,6 +29,7 @@ func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress, de
 		return sdkmath.NewInt(0), err
 	}
 
+	totalAmount = sdkmath.NewInt(0)
 	for _, event := range events {
 		if event.Type == "transfer" {
 			for _, attr := range event.Attributes {

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 
+	sdkmath "cosmossdk.io/math"
 	chainconfig "github.com/ignite/cli/ignite/config/chain"
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
 	"github.com/ignite/cli/ignite/pkg/cosmosfaucet"
@@ -89,7 +90,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 			return cosmosfaucet.Faucet{}, fmt.Errorf("%w: %s", err, coin)
 		}
 
-		var amountMax sdk.Int
+		var amountMax sdkmath.Int
 
 		// find out the max amount for this coin.
 		for _, coinMax := range conf.Faucet.CoinsMax {

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -89,7 +89,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 			return cosmosfaucet.Faucet{}, fmt.Errorf("%w: %s", err, coin)
 		}
 
-		var amountMax uint64
+		var amountMax sdk.Int
 
 		// find out the max amount for this coin.
 		for _, coinMax := range conf.Faucet.CoinsMax {
@@ -103,7 +103,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 			}
 		}
 
-		faucetOptions = append(faucetOptions, cosmosfaucet.Coin(parsedCoin.Amount.Uint64(), amountMax, parsedCoin.Denom))
+		faucetOptions = append(faucetOptions, cosmosfaucet.Coin(parsedCoin.Amount, amountMax, parsedCoin.Denom))
 	}
 
 	if conf.Faucet.RateLimitWindow != "" {

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -98,7 +98,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 				return cosmosfaucet.Faucet{}, fmt.Errorf("%w: %s", err, coin)
 			}
 			if parsedMax.Denom == parsedCoin.Denom {
-				amountMax = parsedMax.Amount.Uint64()
+				amountMax = parsedMax.Amount
 				break
 			}
 		}


### PR DESCRIPTION
cosmos faucet has overflow issue because uint64. Ethermint based chain is using decimal 18 so uint64 is not enough for them. 
Instead of that. it's more reasonable to use sdk.int of cosmos types.

Closes #3609 