### PR TITLE
chore: fix labeler GitHub action config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,6 @@
 ":robot: CI":
+  - "!.github/labeler.yml"
+  - "!.github/labels.json"
   - .github/**/*
 
 ":book: docs":
@@ -27,4 +29,4 @@
   - ignite/version/**/*
 
 ":wrench: configs":
-  - *
+  - "*"


### PR DESCRIPTION
Fix issue with labeler config and exclude labeler GitHub action config files from the label trigger to avoid issues when any of the config files is broken.