### PR TITLE
ci: change labeler to ignore root markdown files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,4 +29,5 @@
   - ignite/version/**/*
 
 ":wrench: configs":
+  - "!*.md"
   - "*"


### PR DESCRIPTION
Better not to include markdown files like changelog in the labeler, otherwise most PRs would be labeled as `doc` because of that.