### PR TITLE
fix: `availableport` doesn't repeat ports.

### DIFF
--- a/ignite/pkg/availableport/availableport.go
+++ b/ignite/pkg/availableport/availableport.go
@@ -14,6 +14,13 @@ func Find(n int) (ports []int, err error) {
 	min := 44000
 	max := 55000
 
+	// If the number of ports required is bigger than the range, this stops it
+	if n > (max - min) {
+		return nil, fmt.Errorf("Invalid amount of ports requested: limit is %d", min-max)
+	}
+
+	// Marker to point if a port is already added in the list
+	registered := make(map[int]bool)
 	for i := 0; i < n; i++ {
 		for {
 			r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -26,7 +33,13 @@ func Find(n int) (ports []int, err error) {
 				conn.Close()
 				continue
 			}
+			// if the port is already registered we skip it to the next one
+			// otherwise it's added to the ports list and pointed in our map
+			if registered[port] {
+				continue
+			}
 			ports = append(ports, port)
+			registered[port] = true
 			break
 		}
 	}

--- a/ignite/pkg/availableport/availableport.go
+++ b/ignite/pkg/availableport/availableport.go
@@ -1,4 +1,4 @@
-package main
+package availableport
 
 import (
 	"fmt"

--- a/ignite/pkg/availableport/availableport.go
+++ b/ignite/pkg/availableport/availableport.go
@@ -16,8 +16,8 @@ func Find(n int) (ports []int, err error) {
 
 	for i := 0; i < n; i++ {
 		for {
-			rand.Seed(time.Now().UnixNano())
-			port := rand.Intn(max-min+1) + min
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			port := r.Intn(max-min+1) + min
 
 			conn, err := net.Dial("tcp", fmt.Sprintf(":%d", port))
 			// if there is an error, this might mean that no one is listening from this port

--- a/ignite/pkg/availableport/availableport_test.go
+++ b/ignite/pkg/availableport/availableport_test.go
@@ -1,0 +1,49 @@
+package availableport_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/ignite/cli/ignite/pkg/availableport"
+)
+
+func TestFind(t *testing.T) {
+	for n := 0; n < 50; n++ {
+		ports, err := availableport.Find(n)
+		if err != nil {
+			t.Errorf("Error Find: %v", err)
+		}
+
+		if len(ports) != n {
+			t.Errorf("Expected %d ports, found %d", n, len(ports))
+		}
+
+		// Verifies ports are in range 44000 - 55000
+		minPort := 44000
+		maxPort := 55000
+		for _, port := range ports {
+			if port < minPort || port > maxPort {
+				t.Errorf("Port %d out of range %d-%d", port, minPort, maxPort)
+			}
+		}
+
+		// Verifica que los puertos encontrados no están siendo utilizados actualmente
+		for _, port := range ports {
+			conn, err := net.Dial("tcp", fmt.Sprintf(":%d", port))
+			if err == nil {
+				conn.Close()
+				t.Errorf("Port %d in use", port)
+			}
+		}
+	}
+
+	for idx := 11001; idx < 12000; idx++ {
+		_, err := availableport.Find(idx)
+		// You can't request more than 11000 ports (55000-44000 = 11000)
+		if err == nil {
+			t.Errorf("Ports overflow. %d bigger than the limit", idx)
+		}
+	}
+
+}


### PR DESCRIPTION
Given the wide range of ports the basic availableport function has, it's very unlikely the ports returned by the function would give a repeated port, but it's not impossible. With this improvement in the code this is avoided. 