### PR TITLE
docs: typo in the Synopsis of documentation

### DIFF
--- a/docs/docs/08-references/01-cli.md
+++ b/docs/docs/08-references/01-cli.md
@@ -3657,7 +3657,7 @@ dictionary) in the blockchain state.
 
 The "map" command is very similar to "ignite scaffold list" with the main
 difference in how values are indexed. With "list" values are indexed by an
-incrementing integer, whereas "list" values are indexed by a user-provided value
+incrementing integer, whereas "map" values are indexed by a user-provided value
 (or multiple values).
 
 Let's use the same blog post example:


### PR DESCRIPTION
typo in the Synopsis of the map command replacing "list" with "map"