### PR TITLE
refactor: remove unecessary boilerplate in module

### DIFF
--- a/ignite/templates/ibc/files/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
+++ b/ignite/templates/ibc/files/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
@@ -47,25 +47,6 @@ func NewMsg<%= queryName.UpperCamel %>Data(
 	}
 }
 
-// Route returns the message route
-func (m *Msg<%= queryName.UpperCamel %>Data) Route() string {
-	return RouterKey
-}
-
-// Type returns the message type
-func (m *Msg<%= queryName.UpperCamel %>Data) Type() string {
-	return TypeMsg<%= queryName.UpperCamel %>Data
-}
-
-// GetSigners returns the message signers
-func (m *Msg<%= queryName.UpperCamel %>Data) GetSigners() []sdk.AccAddress {
-	<%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(m.<%= MsgSigner.UpperCamel %>)
-	if err != nil {
-		panic(err)
-	}
-	return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 // ValidateBasic check the basic message validation
 func (m *Msg<%= queryName.UpperCamel %>Data) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.<%= MsgSigner.UpperCamel %>)

--- a/ignite/templates/ibc/files/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
+++ b/ignite/templates/ibc/files/oracle/x/{{moduleName}}/types/{{queryName}}.go.plush
@@ -6,8 +6,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const TypeMsg<%= queryName.UpperCamel %>Data = "<%= queryName.Snake %>_data"
-
 var (
 	_ sdk.Msg = &Msg<%= queryName.UpperCamel %>Data{}
 

--- a/ignite/templates/ibc/files/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}.go.plush
+++ b/ignite/templates/ibc/files/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}.go.plush
@@ -26,22 +26,6 @@ func NewMsgSend<%= packetName.UpperCamel %>(
 	}
 }
 
-func (msg *MsgSend<%= packetName.UpperCamel %>) Route() string {
-    return RouterKey
-}
-
-func (msg *MsgSend<%= packetName.UpperCamel %>) Type() string {
-    return TypeMsgSend<%= packetName.UpperCamel %>
-}
-
-func (msg *MsgSend<%= packetName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-    <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-    if err != nil {
-        panic(err)
-    }
-    return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *MsgSend<%= packetName.UpperCamel %>) ValidateBasic() error {
     _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
     if err != nil {

--- a/ignite/templates/ibc/files/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}.go.plush
+++ b/ignite/templates/ibc/files/packet/messages/x/{{moduleName}}/types/messages_{{packetName}}.go.plush
@@ -6,8 +6,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const TypeMsgSend<%= packetName.UpperCamel %> = "send_<%= packetName.Snake %>"
-
 var _ sdk.Msg = &MsgSend<%= packetName.UpperCamel %>{}
 
 func NewMsgSend<%= packetName.UpperCamel %>(

--- a/ignite/templates/message/files/message/x/{{moduleName}}/types/message_{{msgName}}.go.plush
+++ b/ignite/templates/message/files/message/x/{{moduleName}}/types/message_{{msgName}}.go.plush
@@ -17,22 +17,6 @@ func NewMsg<%= MsgName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%= for (
 	}
 }
 
-func (msg *Msg<%= MsgName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *Msg<%= MsgName.UpperCamel %>) Type() string {
-  return TypeMsg<%= MsgName.UpperCamel %>
-}
-
-func (msg *Msg<%= MsgName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *Msg<%= MsgName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {

--- a/ignite/templates/message/files/message/x/{{moduleName}}/types/message_{{msgName}}.go.plush
+++ b/ignite/templates/message/files/message/x/{{moduleName}}/types/message_{{msgName}}.go.plush
@@ -6,8 +6,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const TypeMsg<%= MsgName.UpperCamel %> = "<%= MsgName.Snake %>"
-
 var _ sdk.Msg = &Msg<%= MsgName.UpperCamel %>{}
 
 func NewMsg<%= MsgName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%= for (field) in Fields { %>, <%= field.Name.LowerCamel %> <%= field.DataType() %><% } %>) *Msg<%= MsgName.UpperCamel %> {

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/types/keys.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/types/keys.go.plush
@@ -7,9 +7,6 @@ const (
 	// StoreKey defines the primary module store key
 	StoreKey = ModuleName
 
-	// RouterKey defines the module's message routing key
-	RouterKey = ModuleName
-
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_<%= moduleName %>"
 

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/types/msg_update_params.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/types/msg_update_params.go.plush
@@ -7,12 +7,6 @@ import (
 
 var _ sdk.Msg = &MsgUpdateParams{}
 
-// GetSigners returns the expected signers for a MsgUpdateParams message.
-func (m *MsgUpdateParams) GetSigners() []sdk.AccAddress {
-	addr, _ := sdk.AccAddressFromBech32(m.Authority)
-	return []sdk.AccAddress{addr}
-}
-
 // ValidateBasic does a sanity check on the provided data.
 func (m *MsgUpdateParams) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(m.Authority); err != nil {

--- a/ignite/templates/module/create/files/msgserver/proto/{{appName}}/{{moduleName}}/tx.proto.plush
+++ b/ignite/templates/module/create/files/msgserver/proto/{{appName}}/{{moduleName}}/tx.proto.plush
@@ -15,14 +15,10 @@ service Msg {
 
   // UpdateParams defines a (governance) operation for updating the module
   // parameters. The authority defaults to the x/gov module account.
-  //
-  // Since: cosmos-sdk 0.47
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
 }
 
 // MsgUpdateParams is the Msg/UpdateParams request type.
-//
-// Since: cosmos-sdk 0.47
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
   option (amino.name) = "<%= appName %>/x/<%= moduleName %>/MsgUpdateParams";
@@ -41,6 +37,4 @@ message MsgUpdateParams {
 
 // MsgUpdateParamsResponse defines the response structure for executing a
 // MsgUpdateParams message.
-//
-// Since: cosmos-sdk 0.47
 message MsgUpdateParamsResponse {}

--- a/ignite/templates/typed/gogoproto.go
+++ b/ignite/templates/typed/gogoproto.go
@@ -1,7 +1,0 @@
-package typed
-
-// GoGoProtoImport is the import path for the gogoproto package.
-const (
-	GoGoProtoImport = "gogoproto/gogo.proto"
-	MsgSignerOption = "(cosmos.msg.v1.signer)"
-)

--- a/ignite/templates/typed/list/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/list/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -6,12 +6,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const (
-	TypeMsgCreate<%= TypeName.UpperCamel %> = "create_<%= TypeName.Snake %>"
-	TypeMsgUpdate<%= TypeName.UpperCamel %> = "update_<%= TypeName.Snake %>"
-	TypeMsgDelete<%= TypeName.UpperCamel %> = "delete_<%= TypeName.Snake %>"
-)
-
 var _ sdk.Msg = &MsgCreate<%= TypeName.UpperCamel %>{}
 
 func NewMsgCreate<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%= for (field) in Fields { %>, <%= field.Name.LowerCamel %> <%= field.DataType() %><% } %>) *MsgCreate<%= TypeName.UpperCamel %> {

--- a/ignite/templates/typed/list/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/list/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -21,22 +21,6 @@ func NewMsgCreate<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%
 	}
 }
 
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgCreate<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *MsgCreate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
@@ -55,22 +39,6 @@ func NewMsgUpdate<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string, 
 	}
 }
 
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgUpdate<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *MsgUpdate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
@@ -87,21 +55,6 @@ func NewMsgDelete<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string, 
 		<%= MsgSigner.UpperCamel %>: <%= MsgSigner.LowerCamel %>,
 	}
 } 
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgDelete<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
 
 func (msg *MsgDelete<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)

--- a/ignite/templates/typed/map/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/map/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -28,22 +28,6 @@ func NewMsgCreate<%= TypeName.UpperCamel %>(
 	}
 }
 
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgCreate<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *MsgCreate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
@@ -68,22 +52,6 @@ func NewMsgUpdate<%= TypeName.UpperCamel %>(
 	}
 }
 
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgUpdate<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *MsgUpdate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
@@ -104,21 +72,6 @@ func NewMsgDelete<%= TypeName.UpperCamel %>(
 		<%= for (index) in Indexes { %><%= index.Name.UpperCamel %>: <%= index.Name.LowerCamel %>,
         <% } %>
 	}
-}
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgDelete<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
 }
 
 func (msg *MsgDelete<%= TypeName.UpperCamel %>) ValidateBasic() error {

--- a/ignite/templates/typed/map/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/map/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -6,12 +6,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const (
-	TypeMsgCreate<%= TypeName.UpperCamel %> = "create_<%= TypeName.Snake %>"
-	TypeMsgUpdate<%= TypeName.UpperCamel %> = "update_<%= TypeName.Snake %>"
-	TypeMsgDelete<%= TypeName.UpperCamel %> = "delete_<%= TypeName.Snake %>"
-)
-
 var _ sdk.Msg = &MsgCreate<%= TypeName.UpperCamel %>{}
 
 func NewMsgCreate<%= TypeName.UpperCamel %>(

--- a/ignite/templates/typed/proto.go
+++ b/ignite/templates/typed/proto.go
@@ -1,0 +1,8 @@
+package typed
+
+const (
+	// GoGoProtoImport is the import path for the gogoproto package.
+	GoGoProtoImport = "gogoproto/gogo.proto"
+	// MsgSignerOption correspond to the proto annotation for defining a message signer.
+	MsgSignerOption = "(cosmos.msg.v1.signer)"
+)

--- a/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -21,22 +21,6 @@ func NewMsgCreate<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%
 	}
 }
 
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgCreate<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgCreate<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *MsgCreate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
@@ -54,22 +38,6 @@ func NewMsgUpdate<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%
 	}
 }
 
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgUpdate<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgUpdate<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
-}
-
 func (msg *MsgUpdate<%= TypeName.UpperCamel %>) ValidateBasic() error {
   _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
@@ -84,21 +52,6 @@ func NewMsgDelete<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string) 
   return &MsgDelete<%= TypeName.UpperCamel %>{
 		<%= MsgSigner.UpperCamel %>: <%= MsgSigner.LowerCamel %>,
 	}
-}
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) Route() string {
-  return RouterKey
-}
-
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) Type() string {
-  return TypeMsgDelete<%= TypeName.UpperCamel %>
-}
-
-func (msg *MsgDelete<%= TypeName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
 }
 
 func (msg *MsgDelete<%= TypeName.UpperCamel %>) ValidateBasic() error {

--- a/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -6,12 +6,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const (
-	TypeMsgCreate<%= TypeName.UpperCamel %> = "create_<%= TypeName.Snake %>"
-	TypeMsgUpdate<%= TypeName.UpperCamel %> = "update_<%= TypeName.Snake %>"
-	TypeMsgDelete<%= TypeName.UpperCamel %> = "delete_<%= TypeName.Snake %>"
-)
-
 var _ sdk.Msg = &MsgCreate<%= TypeName.UpperCamel %>{}
 
 func NewMsgCreate<%= TypeName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%= for (field) in Fields { %>, <%= field.Name.LowerCamel %> <%= field.DataType() %><% } %>) *MsgCreate<%= TypeName.UpperCamel %> {


### PR DESCRIPTION
Improvements to https://github.com/ignite/cli/pull/3659.
I'll be submitting a few scoped PRs targeting that branch.

This PRs remove the legacy `Route()` and `Type()` from modules, as well as the `GetSigners` function.
In v0.50 `GetSigners` is inferred from the proto annotation (that was added here: https://github.com/ignite/cli/pull/3659/commits/e52af7506044d29ec509539a92c9a6547484d3c3) 