### PR TITLE
fix: change Go version in nightly release config to `1.21.2`

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -61,7 +61,7 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v3
-      - uses: wangyoucao577/go-release-action@v1.38
+      - uses: wangyoucao577/go-release-action@v1.40
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           project_path: "./ignite/cmd/ignite"
@@ -71,5 +71,5 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           ldflags: -s -w -X github.com/ignite/cli/ignite/version.Version=nightly
-          goversion: "./go.mod"
+          goversion: "1.21.2"
           retry: 10

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -71,5 +71,5 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           ldflags: -s -w -X github.com/ignite/cli/ignite/version.Version=nightly
-          goversion: "1.21.2"
+          goversion: "latest"
           retry: 10


### PR DESCRIPTION
The release action requires a version that includes the patch version to be able to download the right tarball with the Go binary.

See https://github.com/wangyoucao577/go-release-action/blob/2ac3035fa4c4feed6a8272ce278b0577b93cf8e5/setup-go.sh#L24