### PR TITLE
fix: remove explicit "latest" for Go version release nightly

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -71,5 +71,4 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           ldflags: -s -w -X github.com/ignite/cli/ignite/version.Version=nightly
-          goversion: "latest"
           retry: 10


### PR DESCRIPTION
Latest version is used by default but it shouldn't be specified explicitly because the value "latest" is not supported.