### PR TITLE
feat: add test suite for the cli tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - [#3614](https://github.com/ignite/cli/pull/3614) feat: use DefaultBaseappOptions for app.New method
 - [#3536](https://github.com/ignite/cli/pull/3536) Change app.go to v2 and add AppWiring feature
 - [#3670](https://github.com/ignite/cli/pull/3670) Remove nodetime binaries
+- [#3715](https://github.com/ignite/cli/pull/3715) Add test suite for the cli tests
 
 ### Changes
 

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
@@ -2,39 +2,43 @@ package cli_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 
-    "<%= modulePath %>/testutil/network"
+	"<%= modulePath %>/testutil/network"
 )
 
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	network *network.Network
+	net *network.Network
+	cfg network.Config
+}
+
+func (s *IntegrationTestSuite) network() *network.Network {
+	s.net = network.New(s.T(), s.cfg)
+	return s.net
+}
+
+func (s *IntegrationTestSuite) waitForNextBlock() {
+	s.T().Log("wait for next block")
+	s.Require().NoError(s.net.WaitForNextBlock())
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.T().Log("setting up integration test suite")
-	s.network = network.New(s.T(), network.DefaultConfig())
-	h, err := s.network.WaitForHeight(1)
-	s.Require().NoError(err, "stalled at height %d", h)
+	s.cfg = network.DefaultConfig()
 }
 
 func (s *IntegrationTestSuite) TearDownTest() {
 	s.T().Log("tearing down test")
-	s.network.Config = network.DefaultConfig()
+	if s.net != nil {
+		s.net.Cleanup()
+	}
 }
 
 func (s *IntegrationTestSuite) TearDownSuite() {
 	s.T().Log("tearing down integration test suite")
-	s.network.Cleanup()
-}
-
-func (s *IntegrationTestSuite) TestNetwork_Liveness() {
-	h, err := s.network.WaitForHeightWithTimeout(10, time.Minute)
-	s.Require().NoError(err, "expected to reach 10 blocks; got %d", h)
 }
 
 func TestIntegrationTestSuite(t *testing.T) {

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
@@ -27,6 +27,11 @@ func (s *IntegrationTestSuite) waitForNextBlock() {
 	s.Require().NoError(s.net.WaitForNextBlock())
 }
 
+func (s *IntegrationTestSuite) SetupTest() {
+	s.T().Log("setting up test")
+	s.cfg = network.DefaultConfig()
+}
+
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.T().Log("setting up integration test suite")
 	s.cfg = network.DefaultConfig()

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
@@ -11,12 +11,14 @@ import (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	net *network.Network
-	cfg network.Config
+	locked bool
+	net    *network.Network
+	cfg    network.Config
 }
 
 func (s *IntegrationTestSuite) network() *network.Network {
 	s.net = network.New(s.T(), s.cfg)
+	s.locked = true
 	return s.net
 }
 
@@ -32,8 +34,9 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 func (s *IntegrationTestSuite) TearDownTest() {
 	s.T().Log("tearing down test")
-	if s.net != nil {
+	if s.net != nil && s.locked {
 		s.net.Cleanup()
+		s.locked = false
 	}
 }
 

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/client/cli/suite_test.go.plush
@@ -1,0 +1,42 @@
+package cli_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+    "<%= modulePath %>/testutil/network"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+
+	network *network.Network
+}
+
+func (s *IntegrationTestSuite) SetupSuite() {
+	s.T().Log("setting up integration test suite")
+	s.network = network.New(s.T(), network.DefaultConfig())
+	h, err := s.network.WaitForHeight(1)
+	s.Require().NoError(err, "stalled at height %d", h)
+}
+
+func (s *IntegrationTestSuite) TearDownTest() {
+	s.T().Log("tearing down test")
+	s.network.Config = network.DefaultConfig()
+}
+
+func (s *IntegrationTestSuite) TearDownSuite() {
+	s.T().Log("tearing down integration test suite")
+	s.network.Cleanup()
+}
+
+func (s *IntegrationTestSuite) TestNetwork_Liveness() {
+	h, err := s.network.WaitForHeightWithTimeout(10, time.Minute)
+	s.Require().NoError(err, "expected to reach 10 blocks; got %d", h)
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}

--- a/ignite/templates/testutil/files/testutil/network/network.go.plush
+++ b/ignite/templates/testutil/files/testutil/network/network.go.plush
@@ -42,7 +42,6 @@ func New(t *testing.T, configs ...Config) *Network {
 	require.NoError(t, err)
 	_, err = net.WaitForHeight(1)
 	require.NoError(t, err)
-	t.Cleanup(net.Cleanup)
 	return net
 }
 

--- a/ignite/templates/typed/list/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -26,16 +26,17 @@ func (s *IntegrationTestSuite) networkWith<%= TypeName.UpperCamel %>Objects(n in
 		nullify.Fill(&<%= TypeName.LowerCamel %>)
 		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, <%= TypeName.LowerCamel %>)
 	}
-	buf, err := s.network.Config.Codec.MarshalJSON(&state)
+	buf, err := s.cfg.Codec.MarshalJSON(&state)
 	s.Require().NoError(err)
-	s.network.Config.GenesisState[types.ModuleName] = buf
+	s.cfg.GenesisState[types.ModuleName] = buf
 	return state.<%= TypeName.UpperCamel %>List
 }
 
 func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 	var (
 		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(2)
-		ctx    = s.network.Validators[0].ClientCtx
+		net    = s.network()
+		ctx    = net.Validators[0].ClientCtx
 		common = []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 		}
@@ -72,7 +73,7 @@ func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>(t *testing.T) 
 			}
             require.NoError(t, err)
             var resp types.QueryGet<%= TypeName.UpperCamel %>Response
-            require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+            require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
             require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
             require.Equal(t,
                 nullify.Fill(&tc.obj),
@@ -85,7 +86,8 @@ func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>(t *testing.T) 
 func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 	var (
 		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(5)
-		ctx    = s.network.Validators[0].ClientCtx
+		net    = s.network()
+		ctx    = net.Validators[0].ClientCtx
 	)
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
@@ -109,7 +111,7 @@ func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>(t *testing.T) 
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
             	nullify.Fill(objs),
@@ -125,7 +127,7 @@ func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>(t *testing.T) 
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
 				nullify.Fill(objs),
@@ -139,7 +141,7 @@ func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>(t *testing.T) 
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 		require.NoError(t, err)
 		var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-		require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
 		require.ElementsMatch(t,

--- a/ignite/templates/typed/list/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -11,15 +11,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"<%= ModulePath %>/testutil/network"
 	"<%= ModulePath %>/testutil/nullify"
 	"<%= ModulePath %>/x/<%= ModuleName %>/client/cli"
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
 )
 
-func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T, n int) (*network.Network, []types.<%= TypeName.UpperCamel %>) {
-	t.Helper()
-	cfg := network.DefaultConfig()
+func (s *IntegrationTestSuite) networkWith<%= TypeName.UpperCamel %>Objects(n int) []types.<%= TypeName.UpperCamel %> {
+	s.T().Helper()
 	state := types.GenesisState{<%= if (IsIBC) { %>PortId: types.PortID<% } %>}
 	for i := 0; i < n; i++ {
 		<%= TypeName.LowerCamel %> := types.<%= TypeName.UpperCamel %>{
@@ -28,19 +26,20 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T, n int) (*network
 		nullify.Fill(&<%= TypeName.LowerCamel %>)
 		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, <%= TypeName.LowerCamel %>)
 	}
-	buf, err := cfg.Codec.MarshalJSON(&state)
-	require.NoError(t, err)
-	cfg.GenesisState[types.ModuleName] = buf
-	return network.New(t, cfg), state.<%= TypeName.UpperCamel %>List
+	buf, err := s.network.Config.Codec.MarshalJSON(&state)
+	s.Require().NoError(err)
+	s.network.Config.GenesisState[types.ModuleName] = buf
+	return state.<%= TypeName.UpperCamel %>List
 }
 
-func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
-	net, objs := networkWith<%= TypeName.UpperCamel %>Objects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
-	common := []string{
-		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
-	}
+func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
+	var (
+		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(2)
+		ctx    = s.network.Validators[0].ClientCtx
+		common = []string{
+			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+		}
+	)
 	tests := []struct {
 		desc string
 		id   string
@@ -62,32 +61,32 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			args := []string{tc.id}
-			args = append(args, tc.args...)
+		s.T().Run(tc.desc, func(t *testing.T) {
+			args := append([]string{tc.id}, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShow<%= TypeName.UpperCamel %>(), args)
 			if tc.err != nil {
 				stat, ok := status.FromError(tc.err)
 				require.True(t, ok)
 				require.ErrorIs(t, stat.Err(), tc.err)
-			} else {
-				require.NoError(t, err)
-				var resp types.QueryGet<%= TypeName.UpperCamel %>Response
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-				require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
-				require.Equal(t,
-                	nullify.Fill(&tc.obj),
-                	nullify.Fill(&resp.<%= TypeName.UpperCamel %>),
-                )
+				return
 			}
+            require.NoError(t, err)
+            var resp types.QueryGet<%= TypeName.UpperCamel %>Response
+            require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+            require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
+            require.Equal(t,
+                nullify.Fill(&tc.obj),
+                nullify.Fill(&resp.<%= TypeName.UpperCamel %>),
+            )
 		})
 	}
 }
 
-func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
-	net, objs := networkWith<%= TypeName.UpperCamel %>Objects(t, 5)
-
-	ctx := net.Validators[0].ClientCtx
+func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>(t *testing.T) {
+	var (
+		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(5)
+		ctx    = s.network.Validators[0].ClientCtx
+	)
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -103,14 +102,14 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 		}
 		return args
 	}
-	t.Run("ByOffset", func(t *testing.T) {
+	s.T().Run("ByOffset", func(t *testing.T) {
 		step := 2
 		for i := 0; i < len(objs); i += step {
 			args := request(nil, uint64(i), uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
             	nullify.Fill(objs),
@@ -118,7 +117,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
             )
 		}
 	})
-	t.Run("ByKey", func(t *testing.T) {
+	s.T().Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
 		for i := 0; i < len(objs); i += step {
@@ -126,7 +125,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
 				nullify.Fill(objs),
@@ -135,12 +134,12 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			next = resp.Pagination.NextKey
 		}
 	})
-	t.Run("Total", func(t *testing.T) {
+	s.T().Run("Total", func(t *testing.T) {
 		args := request(nil, 0, uint64(len(objs)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 		require.NoError(t, err)
 		var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
 		require.ElementsMatch(t,

--- a/ignite/templates/typed/list/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -32,7 +32,7 @@ func (s *IntegrationTestSuite) networkWith<%= TypeName.UpperCamel %>Objects(n in
 	return state.<%= TypeName.UpperCamel %>List
 }
 
-func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
+func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
 	var (
 		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(2)
 		net    = s.network()
@@ -83,7 +83,7 @@ func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>(t *testing.T) 
 	}
 }
 
-func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>(t *testing.T) {
+func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>() {
 	var (
 		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(5)
 		net    = s.network()

--- a/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -17,7 +17,7 @@ import (
 
 func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 	var (
-		net = s.Network()
+		net = s.network()
 		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
@@ -35,7 +35,7 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.config.BondDenom, sdkmath.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	}
@@ -59,7 +59,7 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 
 func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	var (
-		net = s.Network()
+		net = s.network()
 		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
@@ -69,7 +69,7 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 	}
 	args := append([]string{}, fields...)
 	args = append(args, common...)
@@ -121,7 +121,7 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 
 func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	var (
-		net = s.Network()
+		net = s.network()
 		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
@@ -131,7 +131,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := append([]string{}, fields...)
 	args = append(args, common...)
@@ -173,7 +173,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }

--- a/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -12,14 +12,14 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
-	"<%= ModulePath %>/testutil/network"
 	"<%= ModulePath %>/x/<%= ModuleName %>/client/cli"
 )
 
-func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-	val := net.Validators[0]
-	ctx := val.ClientCtx
+func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
 
     fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	tests := []struct {
@@ -34,16 +34,15 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
-            args := []string{}
-            args = append(args, fields...)
+            args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 			if tc.err != nil {
@@ -54,29 +53,28 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
-func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-
-	val := net.Validators[0]
-	ctx := val.ClientCtx
+func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
 
     fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
-    args := []string{}
-	args = append(args, fields...)
+	args := append([]string{}, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
 	tests := []struct {
 		desc string
@@ -103,11 +101,10 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
-            args := []string{tc.id}
-            args = append(args, fields...)
+            args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdUpdate<%= TypeName.UpperCamel %>(), args)
 			if tc.err != nil {
@@ -118,29 +115,28 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
-func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-
-	val := net.Validators[0]
-	ctx := val.ClientCtx
+func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
 
 	fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
-    args := []string{}
-	args = append(args, fields...)
+    args := append([]string{}, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
 	tests := []struct {
 		desc string
@@ -167,8 +163,8 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdDelete<%= TypeName.UpperCamel %>(), append([]string{tc.id}, tc.args...))
 			if tc.err != nil {
@@ -179,7 +175,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }

--- a/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -103,7 +103,7 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            args := append([]string{}, fields...)
+            args := append([]string{tc.id}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdUpdate<%= TypeName.UpperCamel %>(), args)
 			if tc.err != nil {

--- a/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -137,6 +137,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 	s.Require().NoError(err)
+	s.waitForNextBlock()
 
 	tests := []struct {
 		desc string

--- a/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/list/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -17,7 +17,8 @@ import (
 
 func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.Network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 
@@ -34,14 +35,12 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
             args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
@@ -53,14 +52,15 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
 func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.Network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 
@@ -69,12 +69,13 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
 	args := append([]string{}, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 	s.Require().NoError(err)
+	s.waitForNextBlock()
 
 	tests := []struct {
 		desc string
@@ -102,8 +103,6 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
             args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdUpdate<%= TypeName.UpperCamel %>(), args)
@@ -115,14 +114,15 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
 func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.Network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 
@@ -131,7 +131,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := append([]string{}, fields...)
 	args = append(args, common...)
@@ -164,8 +164,6 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdDelete<%= TypeName.UpperCamel %>(), append([]string{tc.id}, tc.args...))
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)

--- a/ignite/templates/typed/map/files/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/files/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -31,16 +31,17 @@ func (s *IntegrationTestSuite) networkWith<%= TypeName.UpperCamel %>Objects(n in
 		nullify.Fill(&<%= TypeName.LowerCamel %>)
 		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, <%= TypeName.LowerCamel %>)
 	}
-	buf, err := s.network.Config.Codec.MarshalJSON(&state)
+	buf, err := s.cfg.Codec.MarshalJSON(&state)
 	s.Require().NoError(err)
-	s.network.Config.GenesisState[types.ModuleName] = buf
+	s.cfg.GenesisState[types.ModuleName] = buf
 	return state.<%= TypeName.UpperCamel %>List
 }
 
 func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
 	var (
 		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(2)
-		ctx    = s.network.Validators[0].ClientCtx
+		net    = s.network()
+		ctx    = net.Validators[0].ClientCtx
 		common = []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 		}
@@ -84,7 +85,7 @@ func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
 			}
             require.NoError(t, err)
             var resp types.QueryGet<%= TypeName.UpperCamel %>Response
-            require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+            require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
             require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
             require.Equal(t,
                 nullify.Fill(&tc.obj),
@@ -97,7 +98,8 @@ func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
 func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>() {
 	var (
 		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(5)
-		ctx    = s.network.Validators[0].ClientCtx
+		net    = s.network()
+		ctx    = net.Validators[0].ClientCtx
 	)
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
@@ -121,7 +123,7 @@ func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>() {
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
             	nullify.Fill(objs),
@@ -137,7 +139,7 @@ func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>() {
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
             	nullify.Fill(objs),
@@ -151,7 +153,7 @@ func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>() {
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 		require.NoError(t, err)
 		var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-		require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
 		require.ElementsMatch(t,

--- a/ignite/templates/typed/map/files/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/files/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"<%= ModulePath %>/testutil/network"
 	"<%= ModulePath %>/testutil/nullify"
 	"<%= ModulePath %>/x/<%= ModuleName %>/client/cli"
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
@@ -21,9 +20,8 @@ import (
 // Prevent strconv unused error
 var _ = strconv.IntSize
 
-func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T, n int) (*network.Network, []types.<%= TypeName.UpperCamel %>) {
-	t.Helper()
-	cfg := network.DefaultConfig()
+func (s *IntegrationTestSuite) networkWith<%= TypeName.UpperCamel %>Objects(n int) []types.<%= TypeName.UpperCamel %> {
+	s.T().Helper()
 	state := types.GenesisState{<%= if (IsIBC) { %>PortId: types.PortID<% } %>}
 	for i := 0; i < n; i++ {
 	<%= TypeName.LowerCamel %> := types.<%= TypeName.UpperCamel %>{
@@ -33,19 +31,20 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T, n int) (*network
 		nullify.Fill(&<%= TypeName.LowerCamel %>)
 		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, <%= TypeName.LowerCamel %>)
 	}
-	buf, err := cfg.Codec.MarshalJSON(&state)
-	require.NoError(t, err)
-	cfg.GenesisState[types.ModuleName] = buf
-	return network.New(t, cfg), state.<%= TypeName.UpperCamel %>List
+	buf, err := s.network.Config.Codec.MarshalJSON(&state)
+	s.Require().NoError(err)
+	s.network.Config.GenesisState[types.ModuleName] = buf
+	return state.<%= TypeName.UpperCamel %>List
 }
 
-func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
-	net, objs := networkWith<%= TypeName.UpperCamel %>Objects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
-	common := []string{
-		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
-	}
+func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
+	var (
+		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(2)
+		ctx    = s.network.Validators[0].ClientCtx
+		common = []string{
+			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+		}
+	)
 	tests := []struct {
 		desc string
 		<%= for (i, index) in Indexes { %>id<%= index.Name.UpperCamel %> <%= index.DataType() %>
@@ -70,7 +69,7 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
+		s.T().Run(tc.desc, func(t *testing.T) {
 			args := []string{
 			    <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
                 <% } %>
@@ -81,24 +80,25 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 				stat, ok := status.FromError(tc.err)
 				require.True(t, ok)
 				require.ErrorIs(t, stat.Err(), tc.err)
-			} else {
-				require.NoError(t, err)
-				var resp types.QueryGet<%= TypeName.UpperCamel %>Response
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-				require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
-				require.Equal(t,
-					nullify.Fill(&tc.obj),
-					nullify.Fill(&resp.<%= TypeName.UpperCamel %>),
-				)
+				return
 			}
+            require.NoError(t, err)
+            var resp types.QueryGet<%= TypeName.UpperCamel %>Response
+            require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+            require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
+            require.Equal(t,
+                nullify.Fill(&tc.obj),
+                nullify.Fill(&resp.<%= TypeName.UpperCamel %>),
+            )
 		})
 	}
 }
 
-func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
-	net, objs := networkWith<%= TypeName.UpperCamel %>Objects(t, 5)
-
-	ctx := net.Validators[0].ClientCtx
+func (s *IntegrationTestSuite) TestList<%= TypeName.UpperCamel %>() {
+	var (
+		objs   = s.networkWith<%= TypeName.UpperCamel %>Objects(5)
+		ctx    = s.network.Validators[0].ClientCtx
+	)
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -114,14 +114,14 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 		}
 		return args
 	}
-	t.Run("ByOffset", func(t *testing.T) {
+	s.T().Run("ByOffset", func(t *testing.T) {
 		step := 2
 		for i := 0; i < len(objs); i += step {
 			args := request(nil, uint64(i), uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
             	nullify.Fill(objs),
@@ -129,7 +129,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
             )
 		}
 	})
-	t.Run("ByKey", func(t *testing.T) {
+	s.T().Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
 		for i := 0; i < len(objs); i += step {
@@ -137,7 +137,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 			require.NoError(t, err)
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.<%= TypeName.UpperCamel %>), step)
 			require.Subset(t,
             	nullify.Fill(objs),
@@ -146,12 +146,12 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			next = resp.Pagination.NextKey
 		}
 	})
-	t.Run("Total", func(t *testing.T) {
+	s.T().Run("Total", func(t *testing.T) {
 		args := request(nil, 0, uint64(len(objs)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdList<%= TypeName.UpperCamel %>(), args)
 		require.NoError(t, err)
 		var resp types.QueryAll<%= TypeName.UpperCamel %>Response
-		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
 		require.Equal(t, len(objs), int(resp.Pagination.Total))
 		require.ElementsMatch(t,

--- a/ignite/templates/typed/map/files/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/files/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -20,7 +20,8 @@ var _ = strconv.IntSize
 
 func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 
@@ -41,14 +42,12 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			require.NoError(t, s.network.WaitForNextBlock())
-
             args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
                 <% } %>
@@ -64,14 +63,15 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
 func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 
@@ -80,7 +80,7 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{
         <%= for (i, index) in Indexes { %>"0",
@@ -90,6 +90,7 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 	s.Require().NoError(err)
+	s.waitForNextBlock()
 
 	tests := []struct {
 		desc string
@@ -115,8 +116,6 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
             args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
                 <% } %>
@@ -132,14 +131,15 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
 func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 
@@ -148,7 +148,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{
         <%= for (i, index) in Indexes { %>"0",
@@ -158,6 +158,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 	s.Require().NoError(err)
+	s.waitForNextBlock()
 
 	tests := []struct {
 		desc string
@@ -183,8 +184,6 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
 		    args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
                 <% } %>
@@ -199,7 +198,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }

--- a/ignite/templates/typed/map/files/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/map/files/tests/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -12,17 +12,17 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
-	"<%= ModulePath %>/testutil/network"
 	"<%= ModulePath %>/x/<%= ModuleName %>/client/cli"
 )
 
 // Prevent strconv unused error
 var _ = strconv.IntSize
 
-func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-	val := net.Validators[0]
-	ctx := val.ClientCtx
+func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
 
     fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	tests := []struct {
@@ -41,13 +41,13 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+			require.NoError(t, s.network.WaitForNextBlock())
 
             args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
@@ -64,22 +64,23 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
-func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-	val := net.Validators[0]
-	ctx := val.ClientCtx
+func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
 
     fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{
         <%= for (i, index) in Indexes { %>"0",
@@ -88,7 +89,7 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 	args = append(args, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
 	tests := []struct {
 		desc string
@@ -113,8 +114,8 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
             args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
@@ -131,23 +132,23 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
-func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-
-	val := net.Validators[0]
-	ctx := val.ClientCtx
+func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
 
 	fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := []string{
         <%= for (i, index) in Indexes { %>"0",
@@ -156,7 +157,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 	args = append(args, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
 	tests := []struct {
 		desc string
@@ -181,8 +182,8 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
 		    args := []string{
                 <%= for (i, index) in Indexes { %><%= index.ToString("tc.id" + index.Name.UpperCamel) %>,
@@ -198,7 +199,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }

--- a/ignite/templates/typed/singleton/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -20,16 +20,17 @@ func (s *IntegrationTestSuite) networkWith<%= TypeName.UpperCamel %>Objects() (t
 	<%= TypeName.LowerCamel %> := &types.<%= TypeName.UpperCamel %>{}
 	nullify.Fill(&<%= TypeName.LowerCamel %>)
 	state.<%= TypeName.UpperCamel %> = <%= TypeName.LowerCamel %>
-	buf, err := s.network.Config.Codec.MarshalJSON(&state)
+	buf, err := s.cfg.Codec.MarshalJSON(&state)
 	s.Require().NoError(err)
-	s.network.Config.GenesisState[types.ModuleName] = buf
+	s.cfg.GenesisState[types.ModuleName] = buf
 	return *state.<%= TypeName.UpperCamel %>
 }
 
 func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
 	var (
 		obj    = s.networkWith<%= TypeName.UpperCamel %>Objects()
-		ctx    = s.network.Validators[0].ClientCtx
+		net    = s.network()
+		ctx    = net.Validators[0].ClientCtx
 		common = []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 		}
@@ -58,7 +59,7 @@ func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
 			}
             require.NoError(t, err)
             var resp types.QueryGet<%= TypeName.UpperCamel %>Response
-            require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+            require.NoError(t, s.cfg.Codec.UnmarshalJSON(out.Bytes(), &resp))
             require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
             require.Equal(t,
                 nullify.Fill(&tc.obj),

--- a/ignite/templates/typed/singleton/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/files/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -9,32 +9,31 @@ import (
 	tmcli "github.com/cometbft/cometbft/libs/cli"
 	"google.golang.org/grpc/status"
 
-	"<%= ModulePath %>/testutil/network"
 	"<%= ModulePath %>/testutil/nullify"
 	"<%= ModulePath %>/x/<%= ModuleName %>/client/cli"
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
 )
 
-func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T) (*network.Network, types.<%= TypeName.UpperCamel %>) {
-	t.Helper()
-	cfg := network.DefaultConfig()
+func (s *IntegrationTestSuite) networkWith<%= TypeName.UpperCamel %>Objects() (types.<%= TypeName.UpperCamel %>) {
+	s.T().Helper()
 	state := types.GenesisState{<%= if (IsIBC) { %>PortId: types.PortID<% } %>}
 	<%= TypeName.LowerCamel %> := &types.<%= TypeName.UpperCamel %>{}
 	nullify.Fill(&<%= TypeName.LowerCamel %>)
 	state.<%= TypeName.UpperCamel %> = <%= TypeName.LowerCamel %>
-	buf, err := cfg.Codec.MarshalJSON(&state)
-	require.NoError(t, err)
-	cfg.GenesisState[types.ModuleName] = buf
-	return network.New(t, cfg), *state.<%= TypeName.UpperCamel %>
+	buf, err := s.network.Config.Codec.MarshalJSON(&state)
+	s.Require().NoError(err)
+	s.network.Config.GenesisState[types.ModuleName] = buf
+	return *state.<%= TypeName.UpperCamel %>
 }
 
-func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
-	net, obj := networkWith<%= TypeName.UpperCamel %>Objects(t)
-
-	ctx := net.Validators[0].ClientCtx
-	common := []string{
-		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
-	}
+func (s *IntegrationTestSuite) TestShow<%= TypeName.UpperCamel %>() {
+	var (
+		obj    = s.networkWith<%= TypeName.UpperCamel %>Objects()
+		ctx    = s.network.Validators[0].ClientCtx
+		common = []string{
+			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+		}
+	)
 	tests := []struct {
 		desc string
 		args []string
@@ -48,24 +47,23 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			var args []string
-			args = append(args, tc.args...)
+		s.T().Run(tc.desc, func(t *testing.T) {
+			args := append([]string{}, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShow<%= TypeName.UpperCamel %>(), args)
 			if tc.err != nil {
 				stat, ok := status.FromError(tc.err)
 				require.True(t, ok)
 				require.ErrorIs(t, stat.Err(), tc.err)
-			} else {
-				require.NoError(t, err)
-				var resp types.QueryGet<%= TypeName.UpperCamel %>Response
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
-				require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
-				require.Equal(t,
-					nullify.Fill(&tc.obj),
-					nullify.Fill(&resp.<%= TypeName.UpperCamel %>),
-				)
+				return
 			}
+            require.NoError(t, err)
+            var resp types.QueryGet<%= TypeName.UpperCamel %>Response
+            require.NoError(t, s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+            require.NotNil(t, resp.<%= TypeName.UpperCamel %>)
+            require.Equal(t,
+                nullify.Fill(&tc.obj),
+                nullify.Fill(&resp.<%= TypeName.UpperCamel %>),
+            )
 		})
 	}
 }

--- a/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -15,7 +15,8 @@ import (
 
 func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 	
@@ -32,14 +33,12 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
             args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
@@ -51,14 +50,15 @@ func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
 func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 	
@@ -67,12 +67,13 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := append([]string{}, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 	s.Require().NoError(err)
+	s.waitForNextBlock()
 
 	tests := []struct {
 		desc string
@@ -87,8 +88,6 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
             args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdUpdate<%= TypeName.UpperCamel %>(), args)
@@ -100,14 +99,15 @@ func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
 func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	var (
-		val = s.network.Validators[0]
+		net = s.network()
+		val = net.Validators[0]
 		ctx = val.ClientCtx
 	)
 	
@@ -116,12 +116,13 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdkmath.NewInt(10))).String()),
 	}
     args := append([]string{}, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 	s.Require().NoError(err)
+	s.waitForNextBlock()
 
 	tests := []struct {
 		desc string
@@ -136,8 +137,6 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 	}
 	for _, tc := range tests {
 		s.T().Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, s.network.WaitForNextBlock())
-
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdDelete<%= TypeName.UpperCamel %>(), append([]string{}, tc.args...))
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
@@ -147,7 +146,7 @@ func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
 		})
 	}
 }

--- a/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
+++ b/ignite/templates/typed/singleton/files/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}_test.go.plush
@@ -10,16 +10,15 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	"<%= ModulePath %>/testutil/network"
 	"<%= ModulePath %>/x/<%= ModuleName %>/client/cli"
 )
 
-func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-	val := net.Validators[0]
-	ctx := val.ClientCtx
-
-
+func (s *IntegrationTestSuite) TestCreate<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
+	
     fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	tests := []struct {
 		desc string
@@ -33,16 +32,15 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 			},
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
-            var args []string
-            args = append(args, fields...)
+            args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
 			if tc.err != nil {
@@ -53,28 +51,28 @@ func TestCreate<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
-func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-	val := net.Validators[0]
-	ctx := val.ClientCtx
-
+func (s *IntegrationTestSuite) TestUpdate<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
+	
     fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
-    var args []string
-	args = append(args, fields...)
+    args := append([]string{}, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
 	tests := []struct {
 		desc string
@@ -88,11 +86,10 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
-            var args []string
-            args = append(args, fields...)
+            args := append([]string{}, fields...)
             args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdUpdate<%= TypeName.UpperCamel %>(), args)
 			if tc.err != nil {
@@ -103,29 +100,28 @@ func TestUpdate<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }
 
-func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
-	net := network.New(t)
-
-	val := net.Validators[0]
-	ctx := val.ClientCtx
-
+func (s *IntegrationTestSuite) TestDelete<%= TypeName.UpperCamel %>() {
+	var (
+		val = s.network.Validators[0]
+		ctx = val.ClientCtx
+	)
+	
 	fields := []string{<%= for (field) in Fields { %> "<%= field.DefaultTestValue() %>", <% } %>}
 	common := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
-		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdkmath.NewInt(10))).String()),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.network.Config.BondDenom, sdkmath.NewInt(10))).String()),
 	}
-    var args []string
-	args = append(args, fields...)
+    args := append([]string{}, fields...)
 	args = append(args, common...)
 	_, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdCreate<%= TypeName.UpperCamel %>(), args)
-	require.NoError(t, err)
+	s.Require().NoError(err)
 
 	tests := []struct {
 		desc string
@@ -139,8 +135,8 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-            require.NoError(t, net.WaitForNextBlock())
+		s.T().Run(tc.desc, func(t *testing.T) {
+            require.NoError(t, s.network.WaitForNextBlock())
 
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdDelete<%= TypeName.UpperCamel %>(), append([]string{}, tc.args...))
 			if tc.err != nil {
@@ -151,7 +147,7 @@ func TestDelete<%= TypeName.UpperCamel %>(t *testing.T) {
 
 			var resp sdk.TxResponse
 			require.NoError(t, ctx.Codec.UnmarshalJSON(out.Bytes(), &resp))
-			require.NoError(t, clitestutil.CheckTxCode(net, ctx, resp.TxHash, tc.code))
+			require.NoError(t, clitestutil.CheckTxCode(s.network, ctx, resp.TxHash, tc.code))
 		})
 	}
 }


### PR DESCRIPTION
## Description

The mutex lock into the package [`cosmos-sdk/testutil/network/network`](https://github.com/cosmos/cosmos-sdk/blob/main/testutil/network/network.go#L356) is blocking the CLI tests into a scaffolded Chain

### Solution

Move to the suite test



_This PR also speeds up the chain and Ignite integration tests_