### PR TITLE
fix: Optimise ts-client generation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@
 - [#3655](https://github.com/ignite/cli/pull/3655) Re-enable TS client generation
 - [#3661](https://github.com/ignite/cli/pull/3661) Change `pkg/cosmosanalysis` to find Cosmos SDK runtime app registered modules
 - [#3716](https://github.com/ignite/cli/pull/3716) Fix invalid plugin hook check
+- [#3725](https://github.com/ignite/cli/pull/3725) Fix flaky TS client generation issues on linux
 
 ## [`v0.27.0`](https://github.com/ignite/cli/releases/tag/v0.27.0)
 

--- a/ignite/pkg/cosmosgen/generate_openapi.go
+++ b/ignite/pkg/cosmosgen/generate_openapi.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ignite/cli/ignite/pkg/cache"
 	"github.com/ignite/cli/ignite/pkg/cosmosanalysis/module"
 	"github.com/ignite/cli/ignite/pkg/dirchange"
+	"github.com/ignite/cli/ignite/pkg/nodetime"
 	swaggercombine "github.com/ignite/cli/ignite/pkg/nodetime/programs/swagger-combine"
 	"github.com/ignite/cli/ignite/pkg/xos"
 )
@@ -39,7 +40,11 @@ func (g *generator) generateOpenAPISpec() error {
 			},
 		}
 	)
-
+	command, cleanup, err := nodetime.Command(nodetime.CommandSwaggerCombine)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 	defer func() {
 		for _, dir := range specDirs {
 			os.RemoveAll(dir)
@@ -157,7 +162,7 @@ func (g *generator) generateOpenAPISpec() error {
 	}
 
 	// combine specs into one and save to out.
-	if err := swaggercombine.Combine(g.ctx, conf, out); err != nil {
+	if err := swaggercombine.Combine(g.ctx, conf, command, out); err != nil {
 		return err
 	}
 
@@ -174,6 +179,11 @@ func (g *generator) generateModuleOpenAPISpec(m module.Module, out string) error
 			},
 		}
 	)
+	command, cleanup, err := nodetime.Command(nodetime.CommandSwaggerCombine)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
 	defer func() {
 		for _, dir := range specDirs {
@@ -242,7 +252,6 @@ func (g *generator) generateModuleOpenAPISpec(m module.Module, out string) error
 	if err := os.MkdirAll(outDir, 0o766); err != nil {
 		return err
 	}
-
 	// combine specs into one and save to out.
-	return swaggercombine.Combine(g.ctx, conf, out)
+	return swaggercombine.Combine(g.ctx, conf, command, out)
 }

--- a/ignite/pkg/nodetime/programs/swagger-combine/swagger-combine.go
+++ b/ignite/pkg/nodetime/programs/swagger-combine/swagger-combine.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 
 	"github.com/ignite/cli/ignite/pkg/cmdrunner/exec"
-	"github.com/ignite/cli/ignite/pkg/nodetime"
 )
 
 // Config represent swagger-combine config.
@@ -81,13 +80,7 @@ func (c *Config) AddSpec(id, path string, makeUnique bool) error {
 
 // Combine combines openapi specs into one and saves to out path.
 // specs is a spec id-fs path pair.
-func Combine(ctx context.Context, c Config, out string) error {
-	command, cleanup, err := nodetime.Command(nodetime.CommandSwaggerCombine)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
+func Combine(ctx context.Context, c Config, command []string, out string) error {
 	f, err := os.CreateTemp("", "*.json")
 	if err != nil {
 		return err

--- a/ignite/templates/app/files/go.mod.plush
+++ b/ignite/templates/app/files/go.mod.plush
@@ -18,7 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0
 	github.com/spf13/cast v1.5.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/ignite/templates/app/files/proto/buf.gen.sta.yaml
+++ b/ignite/templates/app/files/proto/buf.gen.sta.yaml
@@ -10,5 +10,6 @@ plugins:
     opt:
       - logtostderr=true
       - openapi_naming_strategy=simple
+      - ignore_comments=true
       - simple_operation_ids=false
       - json_names_for_fields=false


### PR DESCRIPTION
This fixes some flaky issues that were coming up for me while running on Linux:

Changes:
- Reuse `nodetime.CommandSwaggerCombine` command rather than generating a tmp binary each time (fixes flaky issues due to: https://github.com/golang/go/issues/22315)
- Bump `openapiv2` version to `v2.18.0` which introduces an `ignore_comments` flag which allows `swagger-combine` to merge multiple swagger.json files with no conflicts due to nom-matching comments/descriptions