### PR TITLE
fix: Don't cache modules with tmp includes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
 - [#3661](https://github.com/ignite/cli/pull/3661) Change `pkg/cosmosanalysis` to find Cosmos SDK runtime app registered modules
 - [#3716](https://github.com/ignite/cli/pull/3716) Fix invalid plugin hook check
 - [#3725](https://github.com/ignite/cli/pull/3725) Fix flaky TS client generation issues on linux
+- [#3729](https://github.com/ignite/cli/pull/3729) Fix broken generator due to caching /tmp include folders
 
 ## [`v0.27.0`](https://github.com/ignite/cli/releases/tag/v0.27.0)
 

--- a/ignite/pkg/cosmosgen/generate.go
+++ b/ignite/pkg/cosmosgen/generate.go
@@ -80,7 +80,7 @@ func (g *generator) setup() (err error) {
 	if err != nil {
 		return err
 	}
-	g.appIncludes, err = g.resolveIncludes(g.appPath)
+	g.appIncludes, _, err = g.resolveIncludes(g.appPath)
 	if err != nil {
 		return err
 	}
@@ -120,9 +120,10 @@ func (g *generator) setup() (err error) {
 			}
 
 			var includes []string
+			cacheable := true
 			if len(modules) > 0 {
 				// For versioning issues, we do dependency/includes resolution per module
-				includes, err = g.resolveIncludes(path)
+				includes, cacheable, err = g.resolveIncludes(path)
 				if err != nil {
 					return err
 				}
@@ -133,9 +134,10 @@ func (g *generator) setup() (err error) {
 				Modules:  modules,
 				Includes: includes,
 			}
-
-			if err := moduleCache.Put(cacheKey, modulesInPath); err != nil {
-				return err
+			if cacheable {
+				if err := moduleCache.Put(cacheKey, modulesInPath); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -197,21 +199,21 @@ func (g *generator) generateBufIncludeFolder(modpath string) (string, error) {
 	return protoPath, nil
 }
 
-func (g *generator) resolveIncludes(path string) (paths []string, err error) {
+func (g *generator) resolveIncludes(path string) (paths []string, cacheable bool, err error) {
 	// Init paths with the global include paths for protoc
 	paths, err = protocGlobalInclude()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// Check that the app proto directory exists
 	protoPath := filepath.Join(path, g.protoDir)
 	fi, err := os.Stat(protoPath)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, err
+		return nil, false, err
 	} else if !fi.IsDir() {
 		// Just return the global includes when a proto directory doesn't exist
-		return paths, nil
+		return paths, true, nil
 	}
 
 	// Add app's proto path to the list of proto paths
@@ -220,7 +222,7 @@ func (g *generator) resolveIncludes(path string) (paths []string, err error) {
 	// Check if a Buf config file is present
 	bufPath, err := g.findBufPath(protoPath)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// When a Buf config exists export all protos needed
@@ -228,17 +230,17 @@ func (g *generator) resolveIncludes(path string) (paths []string, err error) {
 	if bufPath != "" {
 		includePath, err := g.generateBufIncludeFolder(protoPath)
 		if err != nil && !errors.Is(err, cosmosbuf.ErrProtoFilesNotFound) {
-			return nil, err
+			return nil, false, err
 		}
 
 		// Use exported files only when the path contains ".proto" files
 		if includePath != "" {
-			return append(paths, includePath), nil
+			return append(paths, includePath), false, nil
 		}
 	}
 
 	// By default use the configured directories
-	return append(paths, g.getProtoIncludeFolders(path)...), nil
+	return append(paths, g.getProtoIncludeFolders(path)...), true, nil
 }
 
 func (g *generator) discoverModules(path, protoDir string) ([]module.Module, error) {


### PR DESCRIPTION
We should not add modules to the cache if their includes[] contains a tmp folder as generated by buf on the fly (looking at you cosmos-sdk)