### PR TITLE
ci: add golangci depguard rule for the errors package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
   enable:
     - bodyclose
     - decorder
-    # - depguard
+    - depguard
     - dogsled
     - dupword
     # - errcheck
@@ -44,6 +44,16 @@ linters:
     - misspell
     # - wrapcheck
     # - wsl
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "errors"
+            desc: Should be replaced by 'errors "github.com/ignite/cli/ignite/pkg/xerrors"'
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by 'errors "github.com/ignite/cli/ignite/pkg/xerrors"'
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
Added to enforce using `github.com/ignite/cli/ignite/pkg/xerrors` for errors