### PR TITLE
fix(github): change github action

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   consecutiveness:
     runs-on: ubuntu-latest
     steps:
-    - uses: ignite/consecutive-workflow-action@v1
+    - uses: ignite/consecutive-workflow-action@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   consecutiveness:
     runs-on: ubuntu-latest
     steps:
-    - uses: mktcode/consecutive-workflow-action@v1
+    - uses: ignite/consecutive-workflow-action@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -15,7 +15,7 @@ jobs:
   consecutiveness:
     runs-on: ubuntu-latest
     steps:
-    - uses: ignite/consecutive-workflow-action@v1
+    - uses: ignite/consecutive-workflow-action@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -15,7 +15,7 @@ jobs:
   consecutiveness:
     runs-on: ubuntu-latest
     steps:
-    - uses: mktcode/consecutive-workflow-action@v1
+    - uses: ignite/consecutive-workflow-action@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -16,7 +16,7 @@ jobs:
   consecutiveness:
     runs-on: ubuntu-latest
     steps:
-    - uses: ignite/consecutive-workflow-action@v1
+    - uses: ignite/consecutive-workflow-action@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -16,7 +16,7 @@ jobs:
   consecutiveness:
     runs-on: ubuntu-latest
     steps:
-    - uses: mktcode/consecutive-workflow-action@v1
+    - uses: ignite/consecutive-workflow-action@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Change Github action pointing to `ignite`. The upstream one is not anymore available.