### PR TITLE
feat: add faucet compatibility for latest sdk chains

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,20 +6,6 @@
 
 - [#3544](https://github.com/ignite/cli/pull/3544) Add bidirectional communication to plugin system
 - [#3561](https://github.com/ignite/cli/pull/3561) Add GetChainInfo method to plugin system API
-- [#3756](https://github.com/ignite/cli/pull/3756) Add faucet compatibility for latest sdk chains.
-
-### Changes
-
-- [#3529](https://github.com/ignite/cli/pull/3529) Refactor plugin system to use gRPC
-- [#3750](https://github.com/ignite/cli/pull/3750) Update default Ignite network app to `v0.2.0`
-- [#3751](https://github.com/ignite/cli/pull/3751) Rename label to skip changelog check
-- [#3745](https://github.com/ignite/cli/pull/3745) Set tx fee amount as option
-- [#3748](https://github.com/ignite/cli/pull/3748) Change default rpc endpoint to a working one
-
-## [`v0.27.1`](https://github.com/ignite/cli/releases/tag/v0.27.1)
-
-### Features
-
 - [#3626](https://github.com/ignite/cli/pull/3626) Add logging levels to relayer
 - [#3476](https://github.com/ignite/cli/pull/3476) Use `buf.build` binary to code generate from proto files
 - [#3614](https://github.com/ignite/cli/pull/3614) feat: use DefaultBaseappOptions for app.New method
@@ -27,6 +13,7 @@
 - [#3670](https://github.com/ignite/cli/pull/3670) Remove nodetime binaries
 - [#3724](https://github.com/ignite/cli/pull/3724) Add or vendor proto packages from Go dependencies
 - [#3715](https://github.com/ignite/cli/pull/3715) Add test suite for the cli tests
+- [#3756](https://github.com/ignite/cli/pull/3756) Add faucet compatibility for latest sdk chains
 
 ### Changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - [#3544](https://github.com/ignite/cli/pull/3544) Add bidirectional communication to plugin system
 - [#3561](https://github.com/ignite/cli/pull/3561) Add GetChainInfo method to plugin system API
+- [#3756](https://github.com/ignite/cli/pull/3756) Add faucet compatibility for latest sdk chains.
 
 ### Changes
 

--- a/ignite/pkg/chaincmd/chaincmd.go
+++ b/ignite/pkg/chaincmd/chaincmd.go
@@ -540,6 +540,22 @@ func (c ChainCmd) QueryTxEventsCommand(query string) step.Option {
 	return c.cliCommand(command)
 }
 
+// QueryTxQueryCommand returns the command to query tx.
+func (c ChainCmd) QueryTxQueryCommand(query string) step.Option {
+	command := []string{
+		commandQuery,
+		"txs",
+		"--query",
+		query,
+		"--page", "1",
+		"--limit", "1000",
+		"--output", "json",
+	}
+
+	command = c.attachNode(command)
+	return c.cliCommand(command)
+}
+
 // StatusCommand returns the command that fetches node's status.
 func (c ChainCmd) StatusCommand() step.Option {
 	command := []string{

--- a/ignite/pkg/chaincmd/runner/chain.go
+++ b/ignite/pkg/chaincmd/runner/chain.go
@@ -268,27 +268,46 @@ type EventAttribute struct {
 	Value string
 }
 
-// QueryTxEvents queries tx events by event selectors.
-func (r Runner) QueryTxEvents(
+// QueryTxByEvents queries tx events by event selectors.
+func (r Runner) QueryTxByEvents(
 	ctx context.Context,
-	selector EventSelector,
-	moreSelectors ...EventSelector,
+	selectors ...EventSelector,
 ) ([]Event, error) {
-	// prepare the selector.
-	var list []string
-
-	eventsSelectors := append([]EventSelector{selector}, moreSelectors...)
-
-	for _, event := range eventsSelectors {
-		list = append(list, fmt.Sprintf("%s.%s=%s", event.typ, event.attr, event.value))
+	if len(selectors) == 0 {
+		return nil, errors.New("event selector list should be greater than zero")
 	}
-
+	list := make([]string, len(selectors))
+	for i, event := range selectors {
+		list[i] = fmt.Sprintf("%s.%s=%s", event.typ, event.attr, event.value)
+	}
 	query := strings.Join(list, "&")
+	return r.QueryTx(ctx, r.chainCmd.QueryTxEventsCommand(query))
+}
 
+// QueryTxByQuery queries tx events by event selectors.
+func (r Runner) QueryTxByQuery(
+	ctx context.Context,
+	selectors ...EventSelector,
+) ([]Event, error) {
+	if len(selectors) == 0 {
+		return nil, errors.New("event selector list should be greater than zero")
+	}
+	list := make([]string, len(selectors))
+	for i, query := range selectors {
+		list[i] = fmt.Sprintf("%s.%s='%s'", query.typ, query.attr, query.value)
+	}
+	query := strings.Join(list, " AND ")
+	return r.QueryTx(ctx, r.chainCmd.QueryTxQueryCommand(query))
+}
+
+// QueryTx queries tx events/query selectors.
+func (r Runner) QueryTx(
+	ctx context.Context,
+	option ...step.Option,
+) ([]Event, error) {
 	// execute the command and parse the output.
 	b := newBuffer()
-
-	if err := r.run(ctx, runOptions{stdout: b}, r.chainCmd.QueryTxEventsCommand(query)); err != nil {
+	if err := r.run(ctx, runOptions{stdout: b}, option...); err != nil {
 		return nil, err
 	}
 

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
+	"github.com/ignite/cli/ignite/pkg/cosmosver"
 )
 
 const (
@@ -63,6 +64,9 @@ type Faucet struct {
 
 	// openAPIData holds template data customizations for serving OpenAPI page & spec.
 	openAPIData openAPIData
+
+	// version holds the cosmos-sdk version.
+	version cosmosver.Version
 }
 
 // Option configures the faucetOptions.
@@ -116,6 +120,13 @@ func FeeAmount(amount sdkmath.Int, denom string) Option {
 func OpenAPI(apiAddress string) Option {
 	return func(f *Faucet) {
 		f.openAPIData.APIAddress = apiAddress
+	}
+}
+
+// Version configures the cosmos-sdk version.
+func Version(version cosmosver.Version) Option {
+	return func(f *Faucet) {
+		f.version = version
 	}
 }
 

--- a/ignite/pkg/cosmosfaucet/transfer.go
+++ b/ignite/pkg/cosmosfaucet/transfer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ignite/cli/ignite/pkg/chaincmd"
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
+	"github.com/ignite/cli/ignite/pkg/cosmosver"
 )
 
 // transferMutex is a mutex used for keeping transfer requests in a queue so checking account balance and sending tokens is atomic.
@@ -24,11 +25,22 @@ func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress, de
 		return sdkmath.NewInt(0), err
 	}
 
-	events, err := f.runner.QueryTxEvents(ctx,
+	opts := []chaincmdrunner.EventSelector{
 		chaincmdrunner.NewEventSelector("message", "sender", fromAccount.Address),
-		chaincmdrunner.NewEventSelector("transfer", "recipient", toAccountAddress))
-	if err != nil {
-		return sdkmath.NewInt(0), err
+		chaincmdrunner.NewEventSelector("transfer", "recipient", toAccountAddress),
+	}
+
+	var events []chaincmdrunner.Event
+	if f.version.GTE(cosmosver.StargateFiftyVersion) {
+		events, err = f.runner.QueryTxByQuery(ctx, opts...)
+		if err != nil {
+			return sdkmath.NewInt(0), err
+		}
+	} else {
+		events, err = f.runner.QueryTxByEvents(ctx, opts...)
+		if err != nil {
+			return sdkmath.NewInt(0), err
+		}
 	}
 
 	totalAmount = sdkmath.NewInt(0)

--- a/ignite/pkg/cosmosver/cosmosver.go
+++ b/ignite/pkg/cosmosver/cosmosver.go
@@ -22,6 +22,7 @@ var (
 	StargateFortyFourVersion      = newVersion("0.44.0-alpha")
 	StargateFortyFiveThreeVersion = newVersion("0.45.3")
 	StargateFortySevenTwoVersion  = newVersion("0.47.2")
+	StargateFiftyVersion          = newVersion("0.50.0")
 )
 
 var (

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
-
-	sdkmath "cosmossdk.io/math"
 
 	chainconfig "github.com/ignite/cli/ignite/config/chain"
 	chaincmdrunner "github.com/ignite/cli/ignite/pkg/chaincmd/runner"
@@ -82,6 +81,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 		cosmosfaucet.Account(*conf.Faucet.Name, "", ""),
 		cosmosfaucet.ChainID(id),
 		cosmosfaucet.OpenAPI(apiAddress),
+		cosmosfaucet.Version(c.Version),
 	}
 
 	// parse coins to pass to the faucet as coins.


### PR DESCRIPTION
## Description

This PR allows the faucet work with the new SDK chains and the old SDK chain

Query events are different after the sdk version `v0.50`. We should use the `query` flag, not the `events` flag, and the syntax changes slightly. The faucet tries to [get the funds](https://github.com/ignite/cli/blob/f400fbcdd4d84359991af2d31c856b92d563672d/ignite/pkg/cosmosfaucet/transfer.go#L65-L65) before sending, and the [query](https://github.com/ignite/cli/blob/f400fbcdd4d84359991af2d31c856b92d563672d/ignite/pkg/chaincmd/runner/chain.go#L272-L272) is falling.