### PR TITLE
fix: `v0.50` ibc genesis issue 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@
 - [#3726](https://github.com/ignite/cli/pull/3726) Update TS client dependencies. Bump vue/react template versions
 - [#3728](https://github.com/ignite/cli/pull/3728) Fix wrong parser for proto package names
 - [#3729](https://github.com/ignite/cli/pull/3729) Fix broken generator due to caching /tmp include folders
+- [#3767](https://github.com/ignite/cli/pull/3767) Fix `v0.50` ibc genesis issue
 
 ## [`v0.27.2`](https://github.com/ignite/cli/releases/tag/v0.27.2)
 

--- a/ignite/templates/app/files/app/app.go.plush
+++ b/ignite/templates/app/files/app/app.go.plush
@@ -323,7 +323,7 @@ func New(
 	// However, when registering a module manually (i.e. that does not support app wiring), the module version map
 	// must be set manually as follow. The upgrade module will de-duplicate the module version map.
 	//
-	// app.SetInitChainer(func(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
+	// app.SetInitChainer(func(ctx sdk.Context, req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
 	// 	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.ModuleManager.GetVersionMap())
 	// 	return app.App.InitChainer(ctx, req)
 	// })

--- a/ignite/templates/app/files/app/app.go.plush
+++ b/ignite/templates/app/files/app/app.go.plush
@@ -353,8 +353,7 @@ func (app *App) AppCodec() codec.Codec {
 
 // GetKey returns the KVStoreKey for the provided store key.
 func (app *App) GetKey(storeKey string) *storetypes.KVStoreKey {
-	sk := app.UnsafeFindStoreKey(storeKey)
-	kvStoreKey, ok := sk.(*storetypes.KVStoreKey)
+	kvStoreKey, ok := app.UnsafeFindStoreKey(storeKey).(*storetypes.KVStoreKey)
 	if !ok {
 		return nil
 	}

--- a/ignite/templates/app/files/app/app.go.plush
+++ b/ignite/templates/app/files/app/app.go.plush
@@ -177,15 +177,15 @@ func New(
 		appConfig = depinject.Configs(
 			AppConfig(),
 			depinject.Supply(
-				// supply the application options
+				// Supply the application options
 				appOpts,
                 // Supply with IBC keeper getter for the IBC modules with App Wiring.
                 // The IBC Keeper cannot be passed because it has not been initiated yet.
                 // Passing the getter, the app IBC Keeper will always be accessible.
-                // This needs to be removed after IBC supported App Wiring.
+                // This needs to be removed after IBC supports App Wiring.
                 app.GetIBCKeeper,
                 app.GetCapabilityScopedKeeper,
-				// supply the logger
+				// Supply the logger
 				logger,
 
 				// ADVANCED CONFIGURATION

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -165,10 +165,6 @@ func (app *App) registerIBCModules() {
 	app.ScopedICAHostKeeper = scopedICAHostKeeper
 	app.ScopedICAControllerKeeper = scopedICAControllerKeeper
 
-	// register additional types
-	ibctm.AppModuleBasic{}.RegisterInterfaces(app.interfaceRegistry)
-	solomachine.AppModuleBasic{}.RegisterInterfaces(app.interfaceRegistry)
-
 	// register IBC modules
 	if err := app.RegisterModules(
 		ibc.NewAppModule(app.IBCKeeper),
@@ -176,6 +172,8 @@ func (app *App) registerIBCModules() {
 		ibcfee.NewAppModule(app.IBCFeeKeeper),
 		icamodule.NewAppModule(&app.ICAControllerKeeper, &app.ICAHostKeeper),
 		capability.NewAppModule(app.appCodec, *app.CapabilityKeeper, false),
+		ibctm.AppModule{},
+		solomachine.AppModule{},
 	); err != nil {
 		panic(err)
 	}

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -2,6 +2,7 @@ package app
 
 import (
 	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
@@ -16,6 +17,7 @@ import (
 	icahost "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host"
 	icahostkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/keeper"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
 	ibcfee "github.com/cosmos/ibc-go/v8/modules/apps/29-fee"
 	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
 	ibcfeetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
@@ -32,6 +34,7 @@ import (
 	// this line is used by starport scaffolding # ibc/app/import
 )
 
+// registerIBCModules register IBC keepers and non dependency inject modules.
 func (app *App) registerIBCModules() {
 	// set up non depinject support modules store keys
 	if err := app.RegisterStores(
@@ -170,4 +173,13 @@ func (app *App) registerIBCModules() {
 	); err != nil {
 		panic(err)
 	}
+}
+
+// AddIBCModuleManager add the missing ibc modules into the module manager.
+func AddIBCModuleManager(moduleManager module.BasicManager) {
+	moduleManager[ibcexported.ModuleName] = ibc.AppModule{}
+	moduleManager[ibctransfertypes.ModuleName] = ibctransfer.AppModule{}
+	moduleManager[ibcfeetypes.ModuleName] = ibcfee.AppModule{}
+	moduleManager[icatypes.ModuleName] = icamodule.AppModule{}
+	moduleManager[capabilitytypes.ModuleName] = capability.AppModule{}
 }

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -181,7 +181,7 @@ func (app *App) registerIBCModules() {
 	}
 }
 
-// AddIBCModuleManager add the missing ibc modules into the module manager.
+// AddIBCModuleManager adds the missing IBC modules into the module manager.
 func AddIBCModuleManager(moduleManager module.BasicManager) {
 	moduleManager[ibcexported.ModuleName] = ibc.AppModule{}
 	moduleManager[ibctransfertypes.ModuleName] = ibctransfer.AppModule{}

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -30,6 +30,8 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
+	solomachine "github.com/cosmos/ibc-go/v8/modules/light-clients/06-solomachine"
+	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 
 	// this line is used by starport scaffolding # ibc/app/import
 )
@@ -162,6 +164,10 @@ func (app *App) registerIBCModules() {
 	app.ScopedIBCTransferKeeper = scopedIBCTransferKeeper
 	app.ScopedICAHostKeeper = scopedICAHostKeeper
 	app.ScopedICAControllerKeeper = scopedICAControllerKeeper
+
+	// register additional types
+	ibctm.AppModuleBasic{}.RegisterInterfaces(app.interfaceRegistry)
+	solomachine.AppModuleBasic{}.RegisterInterfaces(app.interfaceRegistry)
 
     // register IBC modules
 	if err := app.RegisterModules(

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -28,8 +28,6 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
-	solomachine "github.com/cosmos/ibc-go/v8/modules/light-clients/06-solomachine"
-	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 
 	// this line is used by starport scaffolding # ibc/app/import
 )
@@ -169,8 +167,6 @@ func (app *App) registerIBCModules() {
 		ibcfee.NewAppModule(app.IBCFeeKeeper),
 		icamodule.NewAppModule(&app.ICAControllerKeeper, &app.ICAHostKeeper),
 		capability.NewAppModule(app.appCodec, *app.CapabilityKeeper, false),
-		ibctm.AppModule{},
-		solomachine.AppModule{},
 	); err != nil {
 		panic(err)
 	}

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -169,7 +169,7 @@ func (app *App) registerIBCModules() {
 	ibctm.AppModuleBasic{}.RegisterInterfaces(app.interfaceRegistry)
 	solomachine.AppModuleBasic{}.RegisterInterfaces(app.interfaceRegistry)
 
-    // register IBC modules
+	// register IBC modules
 	if err := app.RegisterModules(
 		ibc.NewAppModule(app.IBCKeeper),
 		ibctransfer.NewAppModule(app.TransferKeeper),

--- a/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/root.go.plush
+++ b/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/root.go.plush
@@ -55,6 +55,7 @@ func NewRootCmd() *cobra.Command {
 	); err != nil {
 		panic(err)
 	}
+	app.AddIBCModuleManager(moduleBasicManager)
 
 	rootCmd := &cobra.Command{
 		Use:   app.Name + "d",

--- a/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/root.go.plush
+++ b/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/root.go.plush
@@ -55,6 +55,9 @@ func NewRootCmd() *cobra.Command {
 	); err != nil {
 		panic(err)
 	}
+	// Since the IBC modules don't support dependency injection, we need to
+	// manually add the modules to the basic manager on the client side.
+	// This needs to be removed after IBC supports App Wiring.
 	app.AddIBCModuleManager(moduleBasicManager)
 
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
## Description

The IBC modules are being registered only on the server side. So, every time the client side tries to generate a new genesis, it discards the IBC modules because they are outside the basic manager. 

With the missing entries into the genesis JSON, the export genesis command constantly crashes.

This PR adds a dummy IBC modules direct manager manually into the code.