### PR TITLE
docs: Increase required go version

### DIFF
--- a/docs/docs/01-welcome/02-install.md
+++ b/docs/docs/01-welcome/02-install.md
@@ -24,7 +24,7 @@ Ignite CLI is supported for the following operating systems:
 
 Ignite CLI is written in the Go programming language. To use Ignite CLI on a local system:
 
-- Install [Go](https://golang.org/doc/install) (**version 1.19** or higher)
+- Install [Go](https://golang.org/doc/install) (**version 1.21.1** or higher)
 - Ensure the Go environment variables are [set properly](https://golang.org/doc/gopath_code#GOPATH) on your system
 
 ## Verify your Ignite CLI version


### PR DESCRIPTION
Go version for Ignite is now 1.21.1 or higher, not 1.19 as mentioned in the installation process