### PR TITLE
docs: Added "Edit this page" link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -51,6 +51,9 @@ const config = {
           },
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/ignite/cli/main/editor/docs/docs/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/ignite/cli/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb