### PR TITLE
chore: change default scaffolding branch to main

### DIFF
--- a/ignite/pkg/xgit/xgit.go
+++ b/ignite/pkg/xgit/xgit.go
@@ -33,7 +33,12 @@ func InitAndCommit(path string) error {
 			return fmt.Errorf("open git repo %s: %w", path, err)
 		}
 		// not a git repo, creates a new one
-		repo, err = git.PlainInit(path, false)
+		repo, err = git.PlainInitWithOptions(path, &git.PlainInitOptions{
+			InitOptions: git.InitOptions{
+				DefaultBranch: plumbing.Main,
+			},
+			Bare: false,
+		})
 		if err != nil {
 			return fmt.Errorf("init git repo %s: %w", path, err)
 		}


### PR DESCRIPTION
Tiny PR to change the default branch name used when scaffolding a chain.
It is more in line with the [default](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch) GH branch naming.