### PR TITLE
fix: Minor keplr type-checking bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#3825](https://github.com/ignite/cli/pull/3825) Fix a minor Keplr type-checking bug in TS client
+
 ## [`v28.0.0`](https://github.com/ignite/cli/releases/tag/v28.0.0)
 
 ### Features

--- a/ignite/pkg/cosmosgen/templates/root/client.ts.tpl
+++ b/ignite/pkg/cosmosgen/templates/root/client.ts.tpl
@@ -135,8 +135,6 @@ export class IgniteClient extends EventEmitter {
           return y;
         }) ?? [];
 
-      let coinType = 118;
-
       if (chainId) {
         const suggestOptions: ChainInfo = {
           chainId,
@@ -148,7 +146,6 @@ export class IgniteClient extends EventEmitter {
           bech32Config,
           currencies,
           feeCurrencies,
-          coinType,
           ...keplrChainInfo,
         };
         await window.keplr.experimentalSuggestChain(suggestOptions);


### PR DESCRIPTION
Found this while doing some more extensive testing. `coinType` has been deprecated from the root keplr `ChainInfo` type and lives only in the `Bip44` field