### PR TITLE
feat: remove gRPC info from Ignite Apps errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- [#3830](https://github.com/ignite/cli/pull/3830) Remove gRPC info from Ignite Apps errors
+
 ## [`v28.0.0`](https://github.com/ignite/cli/releases/tag/v28.0.0)
 
 ### Features

--- a/ignite/cmd/ignite/main.go
+++ b/ignite/cmd/ignite/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"sync"
 
+	"google.golang.org/grpc/status"
+
 	ignitecmd "github.com/ignite/cli/v28/ignite/cmd"
 	chainconfig "github.com/ignite/cli/v28/ignite/config/chain"
 	"github.com/ignite/cli/v28/ignite/internal/analytics"
@@ -41,6 +43,10 @@ func run() int {
 	analytics.SendMetric(&wg, subCmd)
 
 	err = cmd.ExecuteContext(ctx)
+	if err != nil {
+		err = ensureError(err)
+	}
+
 	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
 		fmt.Println("aborted")
 		return exitCodeOK
@@ -74,4 +80,29 @@ func run() int {
 	wg.Wait() // waits for all metrics to be sent
 
 	return exitCodeOK
+}
+
+func ensureError(err error) error {
+	// Extract gRPC error status.
+	// These errors are returned by the plugins.
+	s, ok := status.FromError(err)
+	if !ok {
+		// The error is not a gRPC error
+		return err
+	}
+
+	// Get the error message
+	cause := s.Proto().GetMessage()
+	if cause == "" {
+		return err
+	}
+
+	// Restore context canceled errors
+	if cause == context.Canceled.Error() {
+		return context.Canceled
+	}
+
+	// Use the gRPC description as error to avoid printing
+	// extra gRPC error information like code or prefix.
+	return errors.New(cause)
 }


### PR DESCRIPTION
Removes extra gRPC information from Ignite App errors to have consistent CLI error messages