### PR TITLE
fix: add missing ibc interfaces to chain client

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 - [#3825](https://github.com/ignite/cli/pull/3825) Fix a minor Keplr type-checking bug in TS client
 - [#3836](https://github.com/ignite/cli/pull/3836) Add missing IBC commands for scaffolded chain
 - [#3833](https://github.com/ignite/cli/pull/3833) Improve Cosmos SDK detection to support SDK forks
+- [#3851](https://github.com/ignite/cli/pull/3851) Add missing ibc interfaces to chain client
 
 ## [`v28.0.0`](https://github.com/ignite/cli/releases/tag/v28.0.0)
 

--- a/ignite/pkg/cosmosanalysis/app/app.go
+++ b/ignite/pkg/cosmosanalysis/app/app.go
@@ -260,7 +260,7 @@ func discoverIBCModules(ibcPath string) ([]string, error) {
 			return nil
 		}
 
-		if fn.Name.Name != "AddIBCModuleManager" {
+		if fn.Name.Name != "RegisterIBC" && fn.Name.Name != "AddIBCModuleManager" {
 			return nil
 		}
 

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -2,6 +2,7 @@ package app
 
 import (
 	storetypes "cosmossdk.io/store/types"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -179,11 +180,14 @@ func (app *App) registerIBCModules() {
 	}
 }
 
-// AddIBCModuleManager adds the missing IBC modules into the module manager.
-func AddIBCModuleManager(moduleManager module.BasicManager) {
+// RegisterIBC adds the missing IBC modules and interfaces into the module manager.
+func RegisterIBC(moduleManager module.BasicManager, registry cdctypes.InterfaceRegistry) {
 	moduleManager[ibcexported.ModuleName] = ibc.AppModule{}
 	moduleManager[ibctransfertypes.ModuleName] = ibctransfer.AppModule{}
 	moduleManager[ibcfeetypes.ModuleName] = ibcfee.AppModule{}
 	moduleManager[icatypes.ModuleName] = icamodule.AppModule{}
 	moduleManager[capabilitytypes.ModuleName] = capability.AppModule{}
+
+	ibctm.AppModuleBasic{}.RegisterInterfaces(registry)
+	solomachine.AppModuleBasic{}.RegisterInterfaces(registry)
 }

--- a/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/root.go.plush
+++ b/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/root.go.plush
@@ -58,7 +58,7 @@ func NewRootCmd() *cobra.Command {
 	// Since the IBC modules don't support dependency injection, we need to
 	// manually add the modules to the basic manager on the client side.
 	// This needs to be removed after IBC supports App Wiring.
-	app.AddIBCModuleManager(moduleBasicManager)
+	app.RegisterIBC(moduleBasicManager, clientCtx.InterfaceRegistry)
 
 	rootCmd := &cobra.Command{
 		Use:   app.Name + "d",


### PR DESCRIPTION
## Description

The CLI IBC commands are falling because we cannot unpack some interfaces into the client side; this PR adds this interfaces registry.