### PR TITLE
fix: fix `app update` command and duplicated apps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 ### Bug Fixes
 
 - [#3905](https://github.com/ignite/cli/pull/3905) Fix `ignite completion`
+- [#3931](https://github.com/ignite/cli/pull/3931) Fix `app update` command and duplicated apps 
 
 ## [`v28.1.1`](https://github.com/ignite/cli/releases/tag/v28.1.1)
 

--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -86,10 +86,14 @@ To get started, create a blockchain:
 	c.AddCommand(deprecated()...)
 
 	// Load plugins if any
-	if err := LoadPlugins(ctx, c); err != nil {
+	session := cliui.New(cliui.WithStdout(os.Stdout))
+	if err := LoadPlugins(ctx, c, session); err != nil {
 		return nil, nil, errors.Errorf("error while loading apps: %w", err)
 	}
-	return c, UnloadPlugins, nil
+	return c, func() {
+		UnloadPlugins()
+		session.End()
+	}, nil
 }
 
 func getVerbosity(cmd *cobra.Command) uilog.Verbosity {

--- a/ignite/cmd/plugin.go
+++ b/ignite/cmd/plugin.go
@@ -424,8 +424,7 @@ If no path is specified all declared apps are updated.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				// update all plugins
-				err := plugin.Update(plugins...)
-				if err != nil {
+				if err := plugin.Update(plugins...); err != nil {
 					return err
 				}
 				return nil
@@ -433,8 +432,7 @@ If no path is specified all declared apps are updated.`,
 			// find the plugin to update
 			for _, p := range plugins {
 				if p.HasPath(args[0]) {
-					err := plugin.Update(p)
-					if err != nil {
+					if err := plugin.Update(p); err != nil {
 						return err
 					}
 					return nil
@@ -502,7 +500,6 @@ Respects key value pairs declared after the app path to be added to the generate
 				p.With[kv[0]] = kv[1]
 			}
 
-			session.StartSpinner("Loading app")
 			plugins, err := plugin.Load(cmd.Context(), []pluginsconfig.Plugin{p}, pluginsOptions...)
 			if err != nil {
 				return err

--- a/ignite/cmd/plugin.go
+++ b/ignite/cmd/plugin.go
@@ -31,7 +31,7 @@ var plugins []*plugin.Plugin
 
 // LoadPlugins tries to load all the plugins found in configurations.
 // If no configurations found, it returns w/o error.
-func LoadPlugins(ctx context.Context, cmd *cobra.Command) error {
+func LoadPlugins(ctx context.Context, cmd *cobra.Command, session *cliui.Session) error {
 	var (
 		rootCmd        = cmd.Root()
 		pluginsConfigs []pluginsconfig.Plugin
@@ -52,9 +52,6 @@ func LoadPlugins(ctx context.Context, cmd *cobra.Command) error {
 	if len(pluginsConfigs) == 0 {
 		return nil
 	}
-
-	session := cliui.New(cliui.WithStdout(os.Stdout))
-	defer session.End()
 
 	uniquePlugins := pluginsconfig.RemoveDuplicates(pluginsConfigs)
 	plugins, err = plugin.Load(ctx, uniquePlugins, plugin.CollectEvents(session.EventBus()))

--- a/ignite/cmd/plugin.go
+++ b/ignite/cmd/plugin.go
@@ -431,17 +431,15 @@ If no path is specified all declared apps are updated.`,
 				if err != nil {
 					return err
 				}
-				cmd.Println("All apps updated.")
 				return nil
 			}
 			// find the plugin to update
 			for _, p := range plugins {
-				if p.Path == args[0] {
+				if p.HasPath(args[0]) {
 					err := plugin.Update(p)
 					if err != nil {
 						return err
 					}
-					cmd.Printf("App %q updated.\n", p.Path)
 					return nil
 				}
 			}
@@ -479,7 +477,7 @@ Respects key value pairs declared after the app path to be added to the generate
 			}
 
 			for _, p := range conf.Apps {
-				if p.Path == args[0] {
+				if p.HasPath(args[0]) {
 					return errors.Errorf("app %s is already installed", args[0])
 				}
 			}
@@ -562,7 +560,7 @@ func NewAppUninstall() *cobra.Command {
 
 			removed := false
 			for i, cp := range conf.Apps {
-				if cp.Path == args[0] {
+				if cp.HasPath(args[0]) {
 					conf.Apps = append(conf.Apps[:i], conf.Apps[i+1:]...)
 					removed = true
 					break
@@ -648,7 +646,7 @@ func NewAppDescribe() *cobra.Command {
 			ctx := cmd.Context()
 
 			for _, p := range plugins {
-				if p.Path == args[0] {
+				if p.HasPath(args[0]) {
 					manifest, err := p.Interface.Manifest(ctx)
 					if err != nil {
 						return errors.Errorf("error while loading app manifest: %w", err)

--- a/ignite/services/plugin/scaffold_test.go
+++ b/ignite/services/plugin/scaffold_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ignite/cli/v28/ignite/pkg/gocmd"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	"github.com/ignite/cli/v28/ignite/pkg/gocmd"
 )
 
 func TestScaffold(t *testing.T) {


### PR DESCRIPTION
close #3373

## Description

- Fix panic from `app update` command;
- Use the GitHub namespace to find the plugin without the target;

