### PR TITLE
style: fix searchbar border color in docs

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -72,7 +72,7 @@ html[data-theme='dark'] {
   ) !important;
   --docsearch-key-shadow: inset 0 -2px 0 0 #353535, inset 0 0 1px 1px #7a7a7b,
     0 2px 2px 0 rgba(45, 45, 45, 0.3) !important;
-    --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, inset -1px 1px 0 0 #2c2e40, 0 3px 8px 0 theme(colors.gray.1000) !important
+  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, inset -1px 1px 0 0 #2c2e40, 0 3px 8px 0 theme(colors.gray.1000) !important
 }
 
 html {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,8 +1,8 @@
-@import "tailwindcss/base";
-@import "./fonts.css";
-@import "./base.css";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@import 'tailwindcss/base';
+@import './fonts.css';
+@import './base.css';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
 
 .code-block-removed-line {
   background-color: #ff000020;
@@ -31,7 +31,7 @@
   --ifm-menu-link-padding-vertical: 0.6rem;
   --ifm-background-color: theme(colors.gray.0);
   --ifm-footer-link-color: var(--ifm-font-color-base);
-  --ifm-menu-link-sublist-icon: url("~/img/ico-chevron.svg");
+  --ifm-menu-link-sublist-icon: url('~/img/ico-chevron.svg');
   --docsearch-searchbox-background: #f7f7f7;
   --docsearch-modal-background: theme(colors.card) !important;
   --ifm-navbar-height: 5.563rem;
@@ -51,7 +51,7 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-html[data-theme="dark"] {
+html[data-theme='dark'] {
   --ifm-color-primary: theme(colors.gray.0);
   --ifm-color-primary-dark: #e6e6e6;
   --ifm-color-primary-darker: #d9d9d9;
@@ -65,9 +65,14 @@ html[data-theme="dark"] {
   --docsearch-highlight-color: theme(colors.inactiveLight) !important;
   --docsearch-hit-background: theme(colors.lightfg) !important;
   --docsearch-searchbox-shadow: inset 0 0 0 1px var(--docsearch-primary-color);
-  --docsearch-key-gradient: linear-gradient(-26.5deg, #5d5d5d, #3c3c3c) !important;
-  --docsearch-key-shadow: inset 0 -2px 0 0 #353535, inset 0 0 1px 1px #7a7a7b, 0 2px 2px 0 rgba(45, 45, 45, 0.3) !important;
-  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, inset -1px 1px 0 0 #2c2e40, 0 3px 8px 0 theme(colors.gray.1000) !important;
+  --docsearch-key-gradient: linear-gradient(
+    -26.5deg,
+    #5d5d5d,
+    #3c3c3c
+  ) !important;
+  --docsearch-key-shadow: inset 0 -2px 0 0 #353535, inset 0 0 1px 1px #7a7a7b,
+    0 2px 2px 0 rgba(45, 45, 45, 0.3) !important;
+    --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, inset -1px 1px 0 0 #2c2e40, 0 3px 8px 0 theme(colors.gray.1000) !important
 }
 
 html {
@@ -89,7 +94,7 @@ html {
 
   /* Banner */
 
-  #__docusaurus > div[role="banner"] {
+  #__docusaurus > div[role='banner'] {
     @apply bg-gray-30 text-gray-1000 font-normal;
     & > div {
       @apply flex py-3;
@@ -101,7 +106,7 @@ html {
       @apply hidden;
     }
   }
-  &[data-theme="dark"] #__docusaurus > div[role="banner"] {
+  &[data-theme='dark'] #__docusaurus > div[role='banner'] {
     @apply bg-fg text-mutedLight font-normal;
   }
 
@@ -138,10 +143,10 @@ html {
       @apply right-8.5;
     }
   }
-  &[data-theme="dark"] .navbar__item {
+  &[data-theme='dark'] .navbar__item {
     @apply text-mutedLight;
   }
-  &[data-theme="dark"] .navbar__toggle {
+  &[data-theme='dark'] .navbar__toggle {
     @apply bg-fg;
   }
 
@@ -210,12 +215,12 @@ html {
       }
     }
   }
-  &[data-theme="dark"] .navbar-sidebar {
+  &[data-theme='dark'] .navbar-sidebar {
     @apply bg-gray-1000;
     &__brand {
       @apply shadow-none relative;
       &::after {
-        content: "";
+        content: '';
         @apply absolute block h-px  bg-linkHover bottom-0 right-3 left-0 mx-6;
       }
     }
@@ -226,16 +231,16 @@ html {
       }
     }
   }
-  &[data-theme="dark"] .DocSearch-Modal {
+  &[data-theme='dark'] .DocSearch-Modal {
     @apply bg-gray-1000;
   }
-  &[data-theme="dark"] .DocSearch-Footer {
+  &[data-theme='dark'] .DocSearch-Footer {
     @apply bg-gray-1000;
   }
-  &[data-theme="dark"] .DocSearch-Button {
+  &[data-theme='dark'] .DocSearch-Button {
     @apply bg-fg text-inactiveLight;
   }
-  &[data-theme="dark"] .DocSearch-Button-Key {
+  &[data-theme='dark'] .DocSearch-Button-Key {
     @apply text-inactiveLight border-inactiveLight;
   }
 
@@ -244,7 +249,7 @@ html {
     &:first-child {
       & > a {
         &::after {
-          content: "Docs";
+          content: 'Docs';
         }
         & > svg {
           @apply hidden;
@@ -252,7 +257,7 @@ html {
       }
     }
     &:not(:last-child)::after {
-      content: ">";
+      content: '>';
       @apply bg-none;
     }
   }
@@ -275,7 +280,7 @@ html {
       @apply my-5 mx-0;
     }
   }
-  &[data-theme="dark"] .theme-doc-toc-mobile {
+  &[data-theme='dark'] .theme-doc-toc-mobile {
     @apply bg-fg;
   }
 
@@ -294,7 +299,7 @@ html {
     }
   }
 
-  &[data-theme="dark"] .theme-doc-sidebar-menu .menu__list::before {
+  &[data-theme='dark'] .theme-doc-sidebar-menu .menu__list::before {
     @apply bg-inactiveLight;
   }
   .theme-doc-sidebar-menu {
@@ -303,7 +308,7 @@ html {
     .menu__list {
       @apply relative pl-0;
       &::before {
-        content: "";
+        content: '';
         @apply absolute block left-3 top-0 h-full w-[2px] bg-border;
       }
       ul::before {
@@ -323,7 +328,7 @@ html {
       .menu__link--active:not(.menu__link--sublist) {
         @apply relative text-docusaurusColorBase font-medium;
         &::before {
-          content: "";
+          content: '';
           @apply absolute block left-0 top-0 h-full w-[2px] bg-docusaurusColorBase;
           @apply -left-[calc(theme(space.7)-theme(space.3))];
         }
@@ -349,20 +354,26 @@ html {
     }
   }
 
-  &[data-theme="dark"] .menu__link {
+  &[data-theme='dark'] .menu__link {
     @apply text-mutedLight;
   }
-  .theme-doc-sidebar-item-link .menu__link[target="_blank"] {
+  .theme-doc-sidebar-item-link .menu__link[target='_blank'] {
     &::after {
-      content: "\2197";
+      content: '\2197';
       @apply ml-1;
     }
   }
   .menu__link {
     @apply text-muted;
     &:hover {
-      text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base), -0.1px -0.1px 0 var(--ifm-font-color-base), 0.1px -0.1px 0 var(--ifm-font-color-base), -0.1px 0.1px 0 var(--ifm-font-color-base),
-        -0.1px 0 0 var(--ifm-font-color-base), 0.1px 0 0 var(--ifm-font-color-base), 0 0.1px 0 var(--ifm-font-color-base), 0 -0.1px 0 var(--ifm-font-color-base);
+      text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base),
+        -0.1px -0.1px 0 var(--ifm-font-color-base),
+        0.1px -0.1px 0 var(--ifm-font-color-base),
+        -0.1px 0.1px 0 var(--ifm-font-color-base),
+        -0.1px 0 0 var(--ifm-font-color-base),
+        0.1px 0 0 var(--ifm-font-color-base),
+        0 0.1px 0 var(--ifm-font-color-base),
+        0 -0.1px 0 var(--ifm-font-color-base);
       @apply text-docusaurusColorBase;
     }
 
@@ -391,12 +402,17 @@ html {
   /* TOC */
   .table-of-contents__link:hover,
   .table-of-contents__link--active {
-    text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base), -0.1px -0.1px 0 var(--ifm-font-color-base), 0.1px -0.1px 0 var(--ifm-font-color-base), -0.1px 0.1px 0 var(--ifm-font-color-base),
-      -0.1px 0 0 var(--ifm-font-color-base), 0.1px 0 0 var(--ifm-font-color-base), 0 0.1px 0 var(--ifm-font-color-base), 0 -0.1px 0 var(--ifm-font-color-base);
+    text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base),
+      -0.1px -0.1px 0 var(--ifm-font-color-base),
+      0.1px -0.1px 0 var(--ifm-font-color-base),
+      -0.1px 0.1px 0 var(--ifm-font-color-base),
+      -0.1px 0 0 var(--ifm-font-color-base),
+      0.1px 0 0 var(--ifm-font-color-base), 0 0.1px 0 var(--ifm-font-color-base),
+      0 -0.1px 0 var(--ifm-font-color-base);
   }
 
   /* RELATED ARTICLES */
-  &[data-theme="dark"] .pagination-nav > a {
+  &[data-theme='dark'] .pagination-nav > a {
     @apply bg-fg;
   }
   .pagination-nav {
@@ -530,7 +546,7 @@ html {
         @apply relative pl-8 mb-5.5;
         &::before {
           counter-increment: item;
-          content: counters(item, ".", decimal-leading-zero) ".";
+          content: counters(item, '.', decimal-leading-zero) '.';
           @apply absolute flex left-0 top-[.2rem] text-3 font-semibold tracking-tight;
         }
       }
@@ -540,7 +556,7 @@ html {
       & > li {
         &::before {
           counter-increment: subitem;
-          content: counters(subitem, ".", decimal-leading-zero) ".";
+          content: counters(subitem, '.', decimal-leading-zero) '.';
         }
       }
     }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,8 +1,8 @@
-@import 'tailwindcss/base';
-@import './fonts.css';
-@import './base.css';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@import "tailwindcss/base";
+@import "./fonts.css";
+@import "./base.css";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 .code-block-removed-line {
   background-color: #ff000020;
@@ -31,7 +31,7 @@
   --ifm-menu-link-padding-vertical: 0.6rem;
   --ifm-background-color: theme(colors.gray.0);
   --ifm-footer-link-color: var(--ifm-font-color-base);
-  --ifm-menu-link-sublist-icon: url('~/img/ico-chevron.svg');
+  --ifm-menu-link-sublist-icon: url("~/img/ico-chevron.svg");
   --docsearch-searchbox-background: #f7f7f7;
   --docsearch-modal-background: theme(colors.card) !important;
   --ifm-navbar-height: 5.563rem;
@@ -51,7 +51,7 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-html[data-theme='dark'] {
+html[data-theme="dark"] {
   --ifm-color-primary: theme(colors.gray.0);
   --ifm-color-primary-dark: #e6e6e6;
   --ifm-color-primary-darker: #d9d9d9;
@@ -65,13 +65,9 @@ html[data-theme='dark'] {
   --docsearch-highlight-color: theme(colors.inactiveLight) !important;
   --docsearch-hit-background: theme(colors.lightfg) !important;
   --docsearch-searchbox-shadow: inset 0 0 0 1px var(--docsearch-primary-color);
-  --docsearch-key-gradient: linear-gradient(
-    -26.5deg,
-    #5d5d5d,
-    #3c3c3c
-  ) !important;
-  --docsearch-key-shadow: inset 0 -2px 0 0 #353535, inset 0 0 1px 1px #7a7a7b,
-    0 2px 2px 0 rgba(45, 45, 45, 0.3) !important;
+  --docsearch-key-gradient: linear-gradient(-26.5deg, #5d5d5d, #3c3c3c) !important;
+  --docsearch-key-shadow: inset 0 -2px 0 0 #353535, inset 0 0 1px 1px #7a7a7b, 0 2px 2px 0 rgba(45, 45, 45, 0.3) !important;
+  --docsearch-modal-shadow: inset 1px 1px 0 0 #2c2e40, inset -1px 1px 0 0 #2c2e40, 0 3px 8px 0 theme(colors.gray.1000) !important;
 }
 
 html {
@@ -93,7 +89,7 @@ html {
 
   /* Banner */
 
-  #__docusaurus > div[role='banner'] {
+  #__docusaurus > div[role="banner"] {
     @apply bg-gray-30 text-gray-1000 font-normal;
     & > div {
       @apply flex py-3;
@@ -105,7 +101,7 @@ html {
       @apply hidden;
     }
   }
-  &[data-theme='dark'] #__docusaurus > div[role='banner'] {
+  &[data-theme="dark"] #__docusaurus > div[role="banner"] {
     @apply bg-fg text-mutedLight font-normal;
   }
 
@@ -142,10 +138,10 @@ html {
       @apply right-8.5;
     }
   }
-  &[data-theme='dark'] .navbar__item {
+  &[data-theme="dark"] .navbar__item {
     @apply text-mutedLight;
   }
-  &[data-theme='dark'] .navbar__toggle {
+  &[data-theme="dark"] .navbar__toggle {
     @apply bg-fg;
   }
 
@@ -214,12 +210,12 @@ html {
       }
     }
   }
-  &[data-theme='dark'] .navbar-sidebar {
+  &[data-theme="dark"] .navbar-sidebar {
     @apply bg-gray-1000;
     &__brand {
       @apply shadow-none relative;
       &::after {
-        content: '';
+        content: "";
         @apply absolute block h-px  bg-linkHover bottom-0 right-3 left-0 mx-6;
       }
     }
@@ -230,16 +226,16 @@ html {
       }
     }
   }
-  &[data-theme='dark'] .DocSearch-Modal {
+  &[data-theme="dark"] .DocSearch-Modal {
     @apply bg-gray-1000;
   }
-  &[data-theme='dark'] .DocSearch-Footer {
+  &[data-theme="dark"] .DocSearch-Footer {
     @apply bg-gray-1000;
   }
-  &[data-theme='dark'] .DocSearch-Button {
+  &[data-theme="dark"] .DocSearch-Button {
     @apply bg-fg text-inactiveLight;
   }
-  &[data-theme='dark'] .DocSearch-Button-Key {
+  &[data-theme="dark"] .DocSearch-Button-Key {
     @apply text-inactiveLight border-inactiveLight;
   }
 
@@ -248,7 +244,7 @@ html {
     &:first-child {
       & > a {
         &::after {
-          content: 'Docs';
+          content: "Docs";
         }
         & > svg {
           @apply hidden;
@@ -256,7 +252,7 @@ html {
       }
     }
     &:not(:last-child)::after {
-      content: '>';
+      content: ">";
       @apply bg-none;
     }
   }
@@ -279,7 +275,7 @@ html {
       @apply my-5 mx-0;
     }
   }
-  &[data-theme='dark'] .theme-doc-toc-mobile {
+  &[data-theme="dark"] .theme-doc-toc-mobile {
     @apply bg-fg;
   }
 
@@ -298,7 +294,7 @@ html {
     }
   }
 
-  &[data-theme='dark'] .theme-doc-sidebar-menu .menu__list::before {
+  &[data-theme="dark"] .theme-doc-sidebar-menu .menu__list::before {
     @apply bg-inactiveLight;
   }
   .theme-doc-sidebar-menu {
@@ -307,7 +303,7 @@ html {
     .menu__list {
       @apply relative pl-0;
       &::before {
-        content: '';
+        content: "";
         @apply absolute block left-3 top-0 h-full w-[2px] bg-border;
       }
       ul::before {
@@ -327,7 +323,7 @@ html {
       .menu__link--active:not(.menu__link--sublist) {
         @apply relative text-docusaurusColorBase font-medium;
         &::before {
-          content: '';
+          content: "";
           @apply absolute block left-0 top-0 h-full w-[2px] bg-docusaurusColorBase;
           @apply -left-[calc(theme(space.7)-theme(space.3))];
         }
@@ -353,26 +349,20 @@ html {
     }
   }
 
-  &[data-theme='dark'] .menu__link {
+  &[data-theme="dark"] .menu__link {
     @apply text-mutedLight;
   }
-  .theme-doc-sidebar-item-link .menu__link[target='_blank'] {
+  .theme-doc-sidebar-item-link .menu__link[target="_blank"] {
     &::after {
-      content: '\2197';
+      content: "\2197";
       @apply ml-1;
     }
   }
   .menu__link {
     @apply text-muted;
     &:hover {
-      text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base),
-        -0.1px -0.1px 0 var(--ifm-font-color-base),
-        0.1px -0.1px 0 var(--ifm-font-color-base),
-        -0.1px 0.1px 0 var(--ifm-font-color-base),
-        -0.1px 0 0 var(--ifm-font-color-base),
-        0.1px 0 0 var(--ifm-font-color-base),
-        0 0.1px 0 var(--ifm-font-color-base),
-        0 -0.1px 0 var(--ifm-font-color-base);
+      text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base), -0.1px -0.1px 0 var(--ifm-font-color-base), 0.1px -0.1px 0 var(--ifm-font-color-base), -0.1px 0.1px 0 var(--ifm-font-color-base),
+        -0.1px 0 0 var(--ifm-font-color-base), 0.1px 0 0 var(--ifm-font-color-base), 0 0.1px 0 var(--ifm-font-color-base), 0 -0.1px 0 var(--ifm-font-color-base);
       @apply text-docusaurusColorBase;
     }
 
@@ -401,17 +391,12 @@ html {
   /* TOC */
   .table-of-contents__link:hover,
   .table-of-contents__link--active {
-    text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base),
-      -0.1px -0.1px 0 var(--ifm-font-color-base),
-      0.1px -0.1px 0 var(--ifm-font-color-base),
-      -0.1px 0.1px 0 var(--ifm-font-color-base),
-      -0.1px 0 0 var(--ifm-font-color-base),
-      0.1px 0 0 var(--ifm-font-color-base), 0 0.1px 0 var(--ifm-font-color-base),
-      0 -0.1px 0 var(--ifm-font-color-base);
+    text-shadow: 0.1px 0.1px 0 var(--ifm-font-color-base), -0.1px -0.1px 0 var(--ifm-font-color-base), 0.1px -0.1px 0 var(--ifm-font-color-base), -0.1px 0.1px 0 var(--ifm-font-color-base),
+      -0.1px 0 0 var(--ifm-font-color-base), 0.1px 0 0 var(--ifm-font-color-base), 0 0.1px 0 var(--ifm-font-color-base), 0 -0.1px 0 var(--ifm-font-color-base);
   }
 
   /* RELATED ARTICLES */
-  &[data-theme='dark'] .pagination-nav > a {
+  &[data-theme="dark"] .pagination-nav > a {
     @apply bg-fg;
   }
   .pagination-nav {
@@ -545,7 +530,7 @@ html {
         @apply relative pl-8 mb-5.5;
         &::before {
           counter-increment: item;
-          content: counters(item, '.', decimal-leading-zero) '.';
+          content: counters(item, ".", decimal-leading-zero) ".";
           @apply absolute flex left-0 top-[.2rem] text-3 font-semibold tracking-tight;
         }
       }
@@ -555,7 +540,7 @@ html {
       & > li {
         &::before {
           counter-increment: subitem;
-          content: counters(subitem, '.', decimal-leading-zero) '.';
+          content: counters(subitem, ".", decimal-leading-zero) ".";
         }
       }
     }


### PR DESCRIPTION
Fix Searchbar border color in Docusaurus by completing the drop-shadow var style.

Close: #3245

<img width="662" alt="Capture d’écran 2024-02-03 à 17 02 18" src="https://github.com/ignite/cli/assets/7622257/ba8a267f-c2ec-4c47-917c-e3db8bdb56fa">
