### PR TITLE
refactor(services): add suggestions for logging on `serve` failure

### DIFF
--- a/ignite/services/chain/serve.go
+++ b/ignite/services/chain/serve.go
@@ -245,10 +245,10 @@ func (c *Chain) Serve(ctx context.Context, cacheStorage cache.Storage, options .
 						info := colors.Info(
 							"Blockchain failed to start.\n",
 							"If the new code is no longer compatible with the saved\n",
-							"state, you can reset the database by launching:",
+							"state, you can reset the database by launching:\n",
+							"For more verbose logging, add -v to the command.",
 						)
-						command := colors.SprintFunc(colors.White)("ignite chain serve --reset-once")
-
+						command := colors.SprintFunc(colors.White)("ignite chain serve --reset-once -v")
 						return errors.Errorf("cannot run %s\n\n%s\n%s", startErr.AppName, info, command)
 					}
 


### PR DESCRIPTION
Currently when `serve` fails, it shows
```
Blockchain failed to start.                           
If the new code is no longer compatible with the saved
state, you can reset the database by launching:       
ignite chain serve --reset-once         
```

Considering this will the entry point for many folks new to Ignite, probably adding a suggestion for verbose logging is a trivial, but helpful addition.

Cheers.