### PR TITLE
feat: prepare for wasm app

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - [#3839](https://github.com/ignite/cli/pull/3839) New structure for app scaffolding
 - [#3835](https://github.com/ignite/cli/pull/3835) Add `--minimal` flag to `scaffold chain` to scaffold a chain with the least amount of sdk modules
 - [#3820](https://github.com/ignite/cli/pull/3820) Add integration tests for IBC chains
+- [#3956](https://github.com/ignite/cli/pull/3956) Prepare for wasm app
 
 ### Changes
 

--- a/ignite/templates/app/files/app/app.go.plush
+++ b/ignite/templates/app/files/app/app.go.plush
@@ -318,7 +318,9 @@ func New(
 	app.App = appBuilder.Build(db, traceStore, baseAppOptions...)
 
 	// Register legacy modules
-	app.registerIBCModules()
+	if err := app.registerIBCModules(appOpts); err != nil {
+		return nil, err
+	}
 
 	// register streaming services
 	if err := app.RegisterStreamingServices(appOpts, app.kvStoreKeys()); err != nil {

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -38,7 +38,7 @@ import (
 )
 
 // registerIBCModules register IBC keepers and non dependency inject modules.
-func (app *App) registerIBCModules() {
+func (app *App) registerIBCModules(appOpts servertypes.AppOptions) error {
 	// set up non depinject support modules store keys
 	if err := app.RegisterStores(
 		storetypes.NewKVStoreKey(capabilitytypes.StoreKey),
@@ -50,7 +50,7 @@ func (app *App) registerIBCModules() {
 		storetypes.NewMemoryStoreKey(capabilitytypes.MemStoreKey),
 		storetypes.NewTransientStoreKey(paramstypes.TStoreKey),
 	); err != nil {
-		panic(err)
+		return err
 	}
 
 	// register the key tables for legacy param subspaces
@@ -176,12 +176,14 @@ func (app *App) registerIBCModules() {
 		ibctm.AppModule{},
 		solomachine.AppModule{},
 	); err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
-// Since the IBC modules don't support dependency injection, we need to
-// manually register the modules on the client side.
+// RegisterIBC Since the IBC modules don't support dependency injection,
+// we need to manually register the modules on the client side.
 // This needs to be removed after IBC supports App Wiring.
 func RegisterIBC(registry cdctypes.InterfaceRegistry) map[string]appmodule.AppModule {
 	modules := map[string]appmodule.AppModule{


### PR DESCRIPTION
### Description

- Pass the `servertypes.AppOptions` to the `registerIBCModules` function so we can use it in the wasm integration app;
- Return an error for `registerIBCModules` instead panic;