### PR TITLE
fix: remove app name prefix from the `.gitignore` file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- [#3959](https://github.com/ignite/cli/pull/3959) Remove app name prefix from the `.gitignore` file
+
 ### Fixes
 
 - [#3953](https://github.com/ignite/cli/pull/3953) Fix apps `Stdout` is redirected to `Stderr`

--- a/ignite/services/plugin/template/.gitignore.plush
+++ b/ignite/services/plugin/template/.gitignore.plush
@@ -18,6 +18,3 @@
 # Go workspace file
 go.work
 go.work.sum
-
-# App
-<%= Name %>*


### PR DESCRIPTION
### Description

Remove the app name prefix from the `.gitignore` file. All files with the same name are being ignored. For instance, if I have an app name `wasm` and a file with the name `wasm.go` will be ignored