### PR TITLE
fix: use getter to read first config validator

### DIFF
--- a/ignite/cmd/chain_debug.go
+++ b/ignite/cmd/chain_debug.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdmodel "github.com/ignite/cli/v28/ignite/cmd/model"
+	chainconfig "github.com/ignite/cli/v28/ignite/config/chain"
 	"github.com/ignite/cli/v28/ignite/pkg/chaincmd"
 	"github.com/ignite/cli/v28/ignite/pkg/cliui"
 	"github.com/ignite/cli/v28/ignite/pkg/cliui/icons"
@@ -117,8 +118,11 @@ func chainDebug(cmd *cobra.Command, session *cliui.Session) error {
 		return err
 	}
 
-	// TODO: Replace by config.FirstValidator when PR #3199 is merged
-	validator := cfg.Validators[0]
+	validator, err := chainconfig.FirstValidator(cfg)
+	if err != nil {
+		return err
+	}
+
 	servers, err := validator.GetServers()
 	if err != nil {
 		return err

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -206,7 +206,12 @@ func (c *Chain) RPCPublicAddress() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		validator := conf.Validators[0]
+
+		validator, err := chainconfig.FirstValidator(conf)
+		if err != nil {
+			return "", err
+		}
+
 		servers, err := validator.GetServers()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Getter checks that there is at least a validator configured and otherwise returns a proper error.

Fixed #3968 