### PR TITLE
chore: remove error check after command flag get

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - [#3959](https://github.com/ignite/cli/pull/3959) Remove app name prefix from the `.gitignore` file
 - [#3962](https://github.com/ignite/cli/pull/3962) Rename all RPC endpoints and autocli commands generated for `map`/`list`/`single` types 
 - [#3972](https://github.com/ignite/cli/pull/3972) Skip Ignite app loading for some base commands that don't allow apps
+- [#3976](https://github.com/ignite/cli/pull/3976) Remove error checks for Cobra command value get calls
 
 ### Fixes
 

--- a/ignite/cmd/chain_debug.go
+++ b/ignite/cmd/chain_debug.go
@@ -100,10 +100,7 @@ func chainDebug(cmd *cobra.Command, session *cliui.Session) error {
 		chain.KeyringBackend(chaincmd.KeyringBackendTest),
 	}
 
-	config, err := cmd.Flags().GetString(flagConfig)
-	if err != nil {
-		return err
-	}
+	config, _ := cmd.Flags().GetString(flagConfig)
 	if config != "" {
 		chainOptions = append(chainOptions, chain.ConfigFile(config))
 	}

--- a/ignite/cmd/chain_serve.go
+++ b/ignite/cmd/chain_serve.go
@@ -134,10 +134,7 @@ func chainServe(cmd *cobra.Command, session *cliui.Session) error {
 	}
 
 	// check if custom config is defined
-	config, err := cmd.Flags().GetString(flagConfig)
-	if err != nil {
-		return err
-	}
+	config, _ := cmd.Flags().GetString(flagConfig)
 	if config != "" {
 		chainOption = append(chainOption, chain.ConfigFile(config))
 	}
@@ -156,47 +153,27 @@ func chainServe(cmd *cobra.Command, session *cliui.Session) error {
 	// serve the chain
 	var serveOptions []chain.ServeOption
 
-	forceUpdate, err := cmd.Flags().GetBool(flagForceReset)
-	if err != nil {
-		return err
-	}
-
+	forceUpdate, _ := cmd.Flags().GetBool(flagForceReset)
 	if forceUpdate {
 		serveOptions = append(serveOptions, chain.ServeForceReset())
 	}
 
-	resetOnce, err := cmd.Flags().GetBool(flagResetOnce)
-	if err != nil {
-		return err
-	}
-
+	resetOnce, _ := cmd.Flags().GetBool(flagResetOnce)
 	if resetOnce {
 		serveOptions = append(serveOptions, chain.ServeResetOnce())
 	}
 
-	quitOnFail, err := cmd.Flags().GetBool(flagQuitOnFail)
-	if err != nil {
-		return err
-	}
-
+	quitOnFail, _ := cmd.Flags().GetBool(flagQuitOnFail)
 	if quitOnFail {
 		serveOptions = append(serveOptions, chain.QuitOnFail())
 	}
 
-	generateClients, err := cmd.Flags().GetBool(flagGenerateClients)
-	if err != nil {
-		return err
-	}
-
+	generateClients, _ := cmd.Flags().GetBool(flagGenerateClients)
 	if generateClients {
 		serveOptions = append(serveOptions, chain.GenerateClients())
 	}
 
-	buildTags, err := cmd.Flags().GetStringSlice(flagBuildTags)
-	if err != nil {
-		return err
-	}
-
+	buildTags, _ := cmd.Flags().GetStringSlice(flagBuildTags)
 	if len(buildTags) > 0 {
 		serveOptions = append(serveOptions, chain.BuildTags(buildTags...))
 	}

--- a/ignite/cmd/generate_composables.go
+++ b/ignite/cmd/generate_composables.go
@@ -39,10 +39,7 @@ func generateComposablesHandler(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output, err := cmd.Flags().GetString(flagOutput)
-	if err != nil {
-		return err
-	}
+	output, _ := cmd.Flags().GetString(flagOutput)
 
 	var opts []chain.GenerateTarget
 	if flagGetEnableProtoVendor(cmd) {

--- a/ignite/cmd/generate_hooks.go
+++ b/ignite/cmd/generate_hooks.go
@@ -39,10 +39,7 @@ func generateHooksHandler(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output, err := cmd.Flags().GetString(flagOutput)
-	if err != nil {
-		return err
-	}
+	output, _ := cmd.Flags().GetString(flagOutput)
 
 	var opts []chain.GenerateTarget
 	if flagGetEnableProtoVendor(cmd) {

--- a/ignite/cmd/generate_typescript_client.go
+++ b/ignite/cmd/generate_typescript_client.go
@@ -63,15 +63,8 @@ func generateTSClientHandler(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output, err := cmd.Flags().GetString(flagOutput)
-	if err != nil {
-		return err
-	}
-
-	useCache, err := cmd.Flags().GetBool(flagUseCache)
-	if err != nil {
-		return err
-	}
+	output, _ := cmd.Flags().GetString(flagOutput)
+	useCache, _ := cmd.Flags().GetBool(flagUseCache)
 
 	var opts []chain.GenerateTarget
 	if flagGetEnableProtoVendor(cmd) {

--- a/ignite/cmd/generate_vuex.go
+++ b/ignite/cmd/generate_vuex.go
@@ -40,10 +40,7 @@ func generateVuexHandler(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output, err := cmd.Flags().GetString(flagOutput)
-	if err != nil {
-		return err
-	}
+	output, _ := cmd.Flags().GetString(flagOutput)
 
 	var opts []chain.GenerateTarget
 	if flagGetEnableProtoVendor(cmd) {

--- a/ignite/cmd/relayer_configure.go
+++ b/ignite/cmd/relayer_configure.go
@@ -235,79 +235,26 @@ func relayerConfigureHandler(cmd *cobra.Command, _ []string) (err error) {
 	)
 
 	// Get flags
-	advanced, err := cmd.Flags().GetBool(flagAdvanced)
-	if err != nil {
-		return err
-	}
-	sourceAccount, err = cmd.Flags().GetString(flagSourceAccount)
-	if err != nil {
-		return err
-	}
-	targetAccount, err = cmd.Flags().GetString(flagTargetAccount)
-	if err != nil {
-		return err
-	}
-	sourceRPCAddress, err = cmd.Flags().GetString(flagSourceRPC)
-	if err != nil {
-		return err
-	}
-	sourceFaucetAddress, err = cmd.Flags().GetString(flagSourceFaucet)
-	if err != nil {
-		return err
-	}
-	targetRPCAddress, err = cmd.Flags().GetString(flagTargetRPC)
-	if err != nil {
-		return err
-	}
-	targetFaucetAddress, err = cmd.Flags().GetString(flagTargetFaucet)
-	if err != nil {
-		return err
-	}
-	sourcePort, err = cmd.Flags().GetString(flagSourcePort)
-	if err != nil {
-		return err
-	}
-	sourceVersion, err = cmd.Flags().GetString(flagSourceVersion)
-	if err != nil {
-		return err
-	}
-	targetPort, err = cmd.Flags().GetString(flagTargetPort)
-	if err != nil {
-		return err
-	}
-	targetVersion, err = cmd.Flags().GetString(flagTargetVersion)
-	if err != nil {
-		return err
-	}
-	sourceGasPrice, err = cmd.Flags().GetString(flagSourceGasPrice)
-	if err != nil {
-		return err
-	}
-	targetGasPrice, err = cmd.Flags().GetString(flagTargetGasPrice)
-	if err != nil {
-		return err
-	}
-	sourceGasLimit, err = cmd.Flags().GetInt64(flagSourceGasLimit)
-	if err != nil {
-		return err
-	}
-	targetGasLimit, err = cmd.Flags().GetInt64(flagTargetGasLimit)
-	if err != nil {
-		return err
-	}
-	sourceAddressPrefix, err = cmd.Flags().GetString(flagSourceAddressPrefix)
-	if err != nil {
-		return err
-	}
-	targetAddressPrefix, err = cmd.Flags().GetString(flagTargetAddressPrefix)
-	if err != nil {
-		return err
-	}
-	ordered, err := cmd.Flags().GetBool(flagOrdered)
-	if err != nil {
-		return err
-	}
+	sourceAccount, _ = cmd.Flags().GetString(flagSourceAccount)
+	targetAccount, _ = cmd.Flags().GetString(flagTargetAccount)
+	sourceRPCAddress, _ = cmd.Flags().GetString(flagSourceRPC)
+	sourceFaucetAddress, _ = cmd.Flags().GetString(flagSourceFaucet)
+	targetRPCAddress, _ = cmd.Flags().GetString(flagTargetRPC)
+	targetFaucetAddress, _ = cmd.Flags().GetString(flagTargetFaucet)
+	sourcePort, _ = cmd.Flags().GetString(flagSourcePort)
+	sourceVersion, _ = cmd.Flags().GetString(flagSourceVersion)
+	targetPort, _ = cmd.Flags().GetString(flagTargetPort)
+	targetVersion, _ = cmd.Flags().GetString(flagTargetVersion)
+	sourceGasPrice, _ = cmd.Flags().GetString(flagSourceGasPrice)
+	targetGasPrice, _ = cmd.Flags().GetString(flagTargetGasPrice)
+	sourceGasLimit, _ = cmd.Flags().GetInt64(flagSourceGasLimit)
+	targetGasLimit, _ = cmd.Flags().GetInt64(flagTargetGasLimit)
+	sourceAddressPrefix, _ = cmd.Flags().GetString(flagSourceAddressPrefix)
+	targetAddressPrefix, _ = cmd.Flags().GetString(flagTargetAddressPrefix)
+
 	var (
+		advanced, _       = cmd.Flags().GetBool(flagAdvanced)
+		ordered, _        = cmd.Flags().GetBool(flagOrdered)
 		sourceClientID, _ = cmd.Flags().GetString(flagSourceClientID)
 		targetClientID, _ = cmd.Flags().GetString(flagTargetClientID)
 		reset, _          = cmd.Flags().GetBool(flagReset)

--- a/ignite/cmd/scaffold_band.go
+++ b/ignite/cmd/scaffold_band.go
@@ -49,10 +49,7 @@ func createBandchainHandler(cmd *cobra.Command, args []string) error {
 	session := cliui.New(cliui.StartSpinnerWithText(statusScaffolding))
 	defer session.End()
 
-	module, err := cmd.Flags().GetString(flagModule)
-	if err != nil {
-		return err
-	}
+	module, _ := cmd.Flags().GetString(flagModule)
 	if module == "" {
 		return errors.New("please specify a module to create the BandChain oracle into: --module <module_name>")
 	}

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -97,12 +97,9 @@ func scaffoldChainHandler(cmd *cobra.Command, args []string) error {
 		noDefaultModule, _ = cmd.Flags().GetBool(flagNoDefaultModule)
 		skipGit, _         = cmd.Flags().GetBool(flagSkipGit)
 		minimal, _         = cmd.Flags().GetBool(flagMinimal)
+		params, _          = cmd.Flags().GetStringSlice(flagParams)
 	)
 
-	params, err := cmd.Flags().GetStringSlice(flagParams)
-	if err != nil {
-		return err
-	}
 	if noDefaultModule && len(params) > 0 {
 		return errors.New("params flag is only supported if the default module is enabled")
 	}

--- a/ignite/cmd/scaffold_map.go
+++ b/ignite/cmd/scaffold_map.go
@@ -73,10 +73,6 @@ For detailed type information use ignite scaffold type --help
 }
 
 func scaffoldMapHandler(cmd *cobra.Command, args []string) error {
-	indexes, err := cmd.Flags().GetStringSlice(FlagIndexes)
-	if err != nil {
-		return err
-	}
-
+	indexes, _ := cmd.Flags().GetStringSlice(FlagIndexes)
 	return scaffoldType(cmd, args, scaffolder.MapType(indexes...))
 }

--- a/ignite/cmd/scaffold_module.go
+++ b/ignite/cmd/scaffold_module.go
@@ -128,24 +128,10 @@ func scaffoldModuleHandler(cmd *cobra.Command, args []string) error {
 	session := cliui.New(cliui.StartSpinnerWithText(statusScaffolding))
 	defer session.End()
 
-	ibcModule, err := cmd.Flags().GetBool(flagIBC)
-	if err != nil {
-		return err
-	}
-
-	ibcOrdering, err := cmd.Flags().GetString(flagIBCOrdering)
-	if err != nil {
-		return err
-	}
-	requireRegistration, err := cmd.Flags().GetBool(flagRequireRegistration)
-	if err != nil {
-		return err
-	}
-
-	params, err := cmd.Flags().GetStringSlice(flagParams)
-	if err != nil {
-		return err
-	}
+	ibcModule, _ := cmd.Flags().GetBool(flagIBC)
+	ibcOrdering, _ := cmd.Flags().GetString(flagIBCOrdering)
+	requireRegistration, _ := cmd.Flags().GetBool(flagRequireRegistration)
+	params, _ := cmd.Flags().GetStringSlice(flagParams)
 
 	cacheStorage, err := newCache(cmd)
 	if err != nil {
@@ -162,10 +148,7 @@ func scaffoldModuleHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get module dependencies
-	dependencies, err := cmd.Flags().GetStringSlice(flagDep)
-	if err != nil {
-		return err
-	}
+	dependencies, _ := cmd.Flags().GetStringSlice(flagDep)
 	if len(dependencies) > 0 {
 		var deps []modulecreate.Dependency
 

--- a/ignite/cmd/scaffold_package.go
+++ b/ignite/cmd/scaffold_package.go
@@ -47,23 +47,13 @@ func createPacketHandler(cmd *cobra.Command, args []string) error {
 	session := cliui.New(cliui.StartSpinnerWithText(statusScaffolding))
 	defer session.End()
 
-	module, err := cmd.Flags().GetString(flagModule)
-	if err != nil {
-		return err
-	}
+	module, _ := cmd.Flags().GetString(flagModule)
 	if module == "" {
 		return errors.New("please specify a module to create the packet into: --module <module_name>")
 	}
 
-	ackFields, err := cmd.Flags().GetStringSlice(flagAck)
-	if err != nil {
-		return err
-	}
-
-	noMessage, err := cmd.Flags().GetBool(flagNoMessage)
-	if err != nil {
-		return err
-	}
+	ackFields, _ := cmd.Flags().GetStringSlice(flagAck)
+	noMessage, _ := cmd.Flags().GetBool(flagNoMessage)
 
 	cacheStorage, err := newCache(cmd)
 	if err != nil {

--- a/ignite/cmd/scaffold_query.go
+++ b/ignite/cmd/scaffold_query.go
@@ -46,31 +46,19 @@ func queryHandler(cmd *cobra.Command, args []string) error {
 	defer session.End()
 
 	// Get the module to add the type into
-	module, err := cmd.Flags().GetString(flagModule)
-	if err != nil {
-		return err
-	}
+	module, _ := cmd.Flags().GetString(flagModule)
 
 	// Get request fields
-	resFields, err := cmd.Flags().GetStringSlice(flagResponse)
-	if err != nil {
-		return err
-	}
+	resFields, _ := cmd.Flags().GetStringSlice(flagResponse)
 
 	// Get description
-	desc, err := cmd.Flags().GetString(flagDescription)
-	if err != nil {
-		return err
-	}
+	desc, _ := cmd.Flags().GetString(flagDescription)
 	if desc == "" {
 		// Use a default description
 		desc = fmt.Sprintf("Query %s", args[0])
 	}
 
-	paginated, err := cmd.Flags().GetBool(flagPaginated)
-	if err != nil {
-		return err
-	}
+	paginated, _ := cmd.Flags().GetBool(flagPaginated)
 
 	cacheStorage, err := newCache(cmd)
 	if err != nil {


### PR DESCRIPTION
Checking errors is not required because flag values are initially validated on execution while setting the string values.

Closes #1101