### PR TITLE
docs: Add Discord widget to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@
   </a>
     <img alt="Test Status" src="https://github.com/ignite/cli/workflows/Test/badge.svg" />
     <img alt="Lint Status" src="https://github.com/ignite/cli/workflows/Lint/badge.svg" />
+    <img alt="Discord" src="https://img.shields.io/discord/893126937067802685">
 </div>
 
 ![Ignite CLI](./assets/ignite-cli.png)


### PR DESCRIPTION
Adds a Widget to the README that displays Discord and users online.