### PR TITLE
docs: add invite link to chat shield

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@
   </a>
     <img alt="Test Status" src="https://github.com/ignite/cli/workflows/Test/badge.svg" />
     <img alt="Lint Status" src="https://github.com/ignite/cli/workflows/Lint/badge.svg" />
-    <img alt="Discord" src="https://img.shields.io/discord/893126937067802685">
+    <a href="https://discord.gg/STGn7vqT" target="_blank"><img alt="Discord" src="https://img.shields.io/discord/893126937067802685"></a>
 </div>
 
 ![Ignite CLI](./assets/ignite-cli.png)


### PR DESCRIPTION
Shield button just linked to an image but should have the Discord invite as link.