### PR TITLE
feat(config): add HD wallet parameters `address index` and `account number` to the chain account config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - [#3977](https://github.com/ignite/cli/pull/3977) Add `chain lint` command to lint the chain's codebase using `golangci-lint`
 - [#3770](https://github.com/ignite/cli/pull/3770) Add `scaffold configs` and `scaffold params` commands
 - [#3985](https://github.com/ignite/cli/pull/3985) Make some `cmd` pkg functions public
+- [#3967](https://github.com/ignite/cli/issues/3967) Add HD wallet parameters `address index` and `account number` to the chain account config
 
 ### Changes
 

--- a/ignite/config/chain/base/config.go
+++ b/ignite/config/chain/base/config.go
@@ -29,11 +29,13 @@ var (
 
 // Account holds the options related to setting up Cosmos wallets.
 type Account struct {
-	Name     string   `yaml:"name"`
-	Coins    []string `yaml:"coins,omitempty"`
-	Mnemonic string   `yaml:"mnemonic,omitempty"`
-	Address  string   `yaml:"address,omitempty"`
-	CoinType string   `yaml:"cointype,omitempty"`
+	Name          string   `yaml:"name"`
+	Coins         []string `yaml:"coins,omitempty"`
+	Mnemonic      string   `yaml:"mnemonic,omitempty"`
+	Address       string   `yaml:"address,omitempty"`
+	CoinType      string   `yaml:"cointype,omitempty"`
+	AccountNumber string   `yaml:"account_number,omitempty"`
+	AddressIndex  string   `yaml:"address_index,omitempty"`
 }
 
 // Build holds build configs.

--- a/ignite/pkg/chaincmd/chaincmd.go
+++ b/ignite/pkg/chaincmd/chaincmd.go
@@ -53,6 +53,8 @@ const (
 	optionVestingAmount                    = "--vesting-amount"
 	optionVestingEndTime                   = "--vesting-end-time"
 	optionBroadcastMode                    = "--broadcast-mode"
+	optionAccount                          = "--account"
+	optionIndex                            = "--index"
 
 	constTendermint = "tendermint"
 	constJSON       = "json"
@@ -185,7 +187,7 @@ func (c ChainCmd) InitCommand(moniker string) step.Option {
 }
 
 // AddKeyCommand returns the command to add a new key in the chain keyring.
-func (c ChainCmd) AddKeyCommand(accountName, coinType string) step.Option {
+func (c ChainCmd) AddKeyCommand(accountName, coinType, accountNumber, addressIndex string) step.Option {
 	command := []string{
 		commandKeys,
 		"add",
@@ -196,13 +198,19 @@ func (c ChainCmd) AddKeyCommand(accountName, coinType string) step.Option {
 	if coinType != "" {
 		command = append(command, optionCoinType, coinType)
 	}
+	if accountNumber != "" {
+		command = append(command, optionAccount, accountNumber)
+	}
+	if addressIndex != "" {
+		command = append(command, optionIndex, addressIndex)
+	}
 	command = c.attachKeyringBackend(command)
 
 	return c.cliCommand(command)
 }
 
 // RecoverKeyCommand returns the command to recover a key into the chain keyring from a mnemonic.
-func (c ChainCmd) RecoverKeyCommand(accountName, coinType string) step.Option {
+func (c ChainCmd) RecoverKeyCommand(accountName, coinType, accountNumber, addressIndex string) step.Option {
 	command := []string{
 		commandKeys,
 		"add",
@@ -211,6 +219,12 @@ func (c ChainCmd) RecoverKeyCommand(accountName, coinType string) step.Option {
 	}
 	if coinType != "" {
 		command = append(command, optionCoinType, coinType)
+	}
+	if accountNumber != "" {
+		command = append(command, optionAccount, accountNumber)
+	}
+	if addressIndex != "" {
+		command = append(command, optionIndex, addressIndex)
 	}
 	command = c.attachKeyringBackend(command)
 

--- a/ignite/pkg/chaincmd/runner/account.go
+++ b/ignite/pkg/chaincmd/runner/account.go
@@ -31,7 +31,14 @@ type Account struct {
 // AddAccount creates a new account or imports an account when mnemonic is provided.
 // returns with an error if the operation went unsuccessful or an account with the provided name
 // already exists.
-func (r Runner) AddAccount(ctx context.Context, name, mnemonic, coinType string) (Account, error) {
+func (r Runner) AddAccount(
+	ctx context.Context,
+	name,
+	mnemonic,
+	coinType,
+	accountNumber,
+	addressIndex string,
+) (Account, error) {
 	if err := r.CheckAccountExist(ctx, name); err != nil {
 		return Account{}, err
 	}
@@ -66,7 +73,7 @@ func (r Runner) AddAccount(ctx context.Context, name, mnemonic, coinType string)
 		if err := r.run(
 			ctx,
 			runOptions{},
-			r.chainCmd.RecoverKeyCommand(name, coinType),
+			r.chainCmd.RecoverKeyCommand(name, coinType, accountNumber, addressIndex),
 			step.Write(input.Bytes()),
 		); err != nil {
 			return Account{}, err
@@ -76,7 +83,7 @@ func (r Runner) AddAccount(ctx context.Context, name, mnemonic, coinType string)
 			stdout: b,
 			stderr: b,
 			stdin:  os.Stdin,
-		}, r.chainCmd.AddKeyCommand(name, coinType)); err != nil {
+		}, r.chainCmd.AddKeyCommand(name, coinType, accountNumber, addressIndex)); err != nil {
 			return Account{}, err
 		}
 

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -50,6 +50,12 @@ type Faucet struct {
 	// coinType registered coin type number for HD derivation (BIP-0044).
 	coinType string
 
+	// accountNumber registered account number for HD derivation (BIP-0044).
+	accountNumber string
+
+	// addressIndex registered address index for HD derivation (BIP-0044).
+	addressIndex string
+
 	// coins keeps a list of coins that can be distributed by the faucet.
 	coins sdk.Coins
 
@@ -74,11 +80,13 @@ type Option func(*Faucet)
 
 // Account provides the account information to transfer tokens from.
 // when mnemonic isn't provided, account assumed to be exists in the keyring.
-func Account(name, mnemonic string, coinType string) Option {
+func Account(name, mnemonic, coinType, accountNumber, addressIndex string) Option {
 	return func(f *Faucet) {
 		f.accountName = name
 		f.accountMnemonic = mnemonic
 		f.coinType = coinType
+		f.accountNumber = accountNumber
+		f.addressIndex = addressIndex
 	}
 }
 
@@ -153,7 +161,14 @@ func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Fau
 
 	// import the account if mnemonic is provided.
 	if f.accountMnemonic != "" {
-		_, err := f.runner.AddAccount(ctx, f.accountName, f.accountMnemonic, f.coinType)
+		_, err := f.runner.AddAccount(
+			ctx,
+			f.accountName,
+			f.accountMnemonic,
+			f.coinType,
+			f.accountNumber,
+			f.addressIndex,
+		)
 		if err != nil && !errors.Is(err, chaincmdrunner.ErrAccountAlreadyExists) {
 			return Faucet{}, err
 		}

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -77,7 +77,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 	}
 
 	faucetOptions := []cosmosfaucet.Option{
-		cosmosfaucet.Account(*conf.Faucet.Name, "", ""),
+		cosmosfaucet.Account(*conf.Faucet.Name, "", "", "", ""),
 		cosmosfaucet.ChainID(id),
 		cosmosfaucet.OpenAPI(apiAddress),
 		cosmosfaucet.Version(c.Version),

--- a/ignite/services/chain/init.go
+++ b/ignite/services/chain/init.go
@@ -138,7 +138,14 @@ func (c *Chain) InitAccounts(ctx context.Context, cfg *chainconfig.Config) error
 
 		// If the account doesn't provide an address, we create one
 		if accountAddress == "" {
-			generatedAccount, err = commands.AddAccount(ctx, account.Name, account.Mnemonic, account.CoinType)
+			generatedAccount, err = commands.AddAccount(
+				ctx,
+				account.Name,
+				account.Mnemonic,
+				account.CoinType,
+				account.AccountNumber,
+				account.AddressIndex,
+			)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
close #3967

## Description

Add address index and account number to the chain config to be added into the key add command flag.

### How to test

Scaffold a mars chain (`ignite s chain mars`) and use this test `config.yml` file:

```yaml
version: 1
accounts:
  - name: alice
    mnemonic: apple pony round crazy boil solid inch beef equal attract soul accuse nice thumb shadow egg drum valley grace wish elbow hat salute pair
    cointype: 118
    account_number: 1
    address_index: 2
    coins:
      - 20000token
      - 200000000stake
  - name: bob
    coins:
      - 10000token
      - 100000000stake
client:
  openapi:
    path: docs/static/openapi.yml
faucet:
  name: bob
  coins:
    - 5token
    - 100000stake
validators:
  - name: alice
    bonded: 100000000stake
```

- run the chain with ignite: `ignite c serve --clear-cache --reset-once`, and you can see the Alice address will be `cosmos19jn5wrfgd0tgrh083u0qe54tj03esg68kyu6tz`:
```shell
  Blockchain is running
  
  ✔ Added account alice with address cosmos19jn5wrfgd0tgrh083u0qe54tj03esg68kyu6tz and mnemonic:
  apple pony round crazy boil solid inch beef equal attract soul accuse nice thumb shadow egg drum valley grace wish elbow hat salute pair
  
  ✔ Added account bob with address cosmos1ns5jkh9hqpxnpqkz34yt0wlzwvnfu8nfej0fd7 and mnemonic:
  birth various position huge derive sugar endorse cliff group muscle report festival there trash fluid morning trend bargain razor sister aunt melody injur
  
  🌍 Tendermint node: http://0.0.0.0:26657
  🌍 Blockchain API: http://0.0.0.0:1317
  🌍 Token faucet: http://0.0.0.0:4500
  
  ⋆ Data directory: /Users/danilopantani/.mars
  ⋆ App binary: /Users/danilopantani/Desktop/go/bin/marsd
  
  Press the 'q' key to stop serve
```

You can check the wallet generation using the [Ian Coleman tool](https://iancoleman.io/bip39/)