### PR TITLE
feat(cli): add `skip-proto` flag to `s chain` command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#4019](https://github.com/ignite/cli/pull/4019) Add `skip-proto` flag to `s chain` command
 - [#3977](https://github.com/ignite/cli/pull/3977) Add `chain lint` command to lint the chain's codebase using `golangci-lint`
 - [#3770](https://github.com/ignite/cli/pull/3770) Add `scaffold configs` and `scaffold params` commands
 - [#3985](https://github.com/ignite/cli/pull/3985) Make some `cmd` pkg functions public

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -84,6 +84,7 @@ about Cosmos SDK on https://docs.cosmos.network
 	c.Flags().StringSlice(flagParams, []string{}, "add default module parameters")
 	c.Flags().StringSlice(flagModuleConfigs, []string{}, "add module configs")
 	c.Flags().Bool(flagSkipGit, false, "skip Git repository initialization")
+	c.Flags().Bool(flagSkipProto, false, "skip proto generation")
 	c.Flags().Bool(flagMinimal, false, "create a minimal blockchain (with the minimum required Cosmos SDK modules)")
 	c.Flags().Bool(flagIsConsumer, false, "scafffold an ICS consumer chain")
 	// Cannot have both minimal and consumer flag
@@ -106,6 +107,7 @@ func scaffoldChainHandler(cmd *cobra.Command, args []string) error {
 		isConsumer, _      = cmd.Flags().GetBool(flagIsConsumer)
 		params, _          = cmd.Flags().GetStringSlice(flagParams)
 		moduleConfigs, _   = cmd.Flags().GetStringSlice(flagModuleConfigs)
+		skipProto, _       = cmd.Flags().GetBool(flagSkipProto)
 	)
 
 	if noDefaultModule {
@@ -130,6 +132,7 @@ func scaffoldChainHandler(cmd *cobra.Command, args []string) error {
 		addressPrefix,
 		noDefaultModule,
 		skipGit,
+		skipProto,
 		minimal,
 		isConsumer,
 		params,

--- a/ignite/services/scaffolder/configs.go
+++ b/ignite/services/scaffolder/configs.go
@@ -73,7 +73,7 @@ func (s Scaffolder) CreateConfigs(
 		return sm, err
 	}
 
-	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath)
+	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath, false)
 }
 
 // checkConfigCreated checks if the config has been already created.

--- a/ignite/services/scaffolder/init.go
+++ b/ignite/services/scaffolder/init.go
@@ -25,7 +25,7 @@ func Init(
 	cacheStorage cache.Storage,
 	tracer *placeholder.Tracer,
 	root, name, addressPrefix string,
-	noDefaultModule, skipGit, minimal, isConsumerChain bool,
+	noDefaultModule, skipGit, skipProto, minimal, isConsumerChain bool,
 	params, moduleConfigs []string,
 ) (path string, err error) {
 	pathInfo, err := gomodulepath.Parse(name)
@@ -61,8 +61,7 @@ func Init(
 		return "", err
 	}
 
-	err = finish(ctx, cacheStorage, path, pathInfo.RawPath)
-	if err != nil {
+	if err = finish(ctx, cacheStorage, path, pathInfo.RawPath, skipProto); err != nil {
 		return "", err
 	}
 

--- a/ignite/services/scaffolder/message.go
+++ b/ignite/services/scaffolder/message.go
@@ -158,7 +158,7 @@ func (s Scaffolder) AddMessage(
 	if err != nil {
 		return sm, err
 	}
-	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath)
+	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath, false)
 }
 
 // checkForbiddenMessageField returns true if the name is forbidden as a message name.

--- a/ignite/services/scaffolder/module.go
+++ b/ignite/services/scaffolder/module.go
@@ -257,7 +257,7 @@ func (s Scaffolder) CreateModule(
 		return sm, runErr
 	}
 
-	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath)
+	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath, false)
 }
 
 // moduleExists checks if the module exists in the app.

--- a/ignite/services/scaffolder/packet.go
+++ b/ignite/services/scaffolder/packet.go
@@ -143,7 +143,7 @@ func (s Scaffolder) AddPacket(
 	if err != nil {
 		return sm, err
 	}
-	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath)
+	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath, false)
 }
 
 // isIBCModule returns true if the provided module implements the IBC module interface

--- a/ignite/services/scaffolder/params.go
+++ b/ignite/services/scaffolder/params.go
@@ -72,7 +72,7 @@ func (s Scaffolder) CreateParams(
 		return sm, err
 	}
 
-	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath)
+	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath, false)
 }
 
 // checkParamCreated checks if the parameter has been already created.

--- a/ignite/services/scaffolder/query.go
+++ b/ignite/services/scaffolder/query.go
@@ -87,5 +87,5 @@ func (s Scaffolder) AddQuery(
 	if err != nil {
 		return sm, err
 	}
-	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath)
+	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath, false)
 }

--- a/ignite/services/scaffolder/scaffolder.go
+++ b/ignite/services/scaffolder/scaffolder.go
@@ -63,10 +63,11 @@ func New(appPath string) (Scaffolder, error) {
 	return s, nil
 }
 
-func finish(ctx context.Context, cacheStorage cache.Storage, path, gomodPath string) error {
-	err := protoc(ctx, cacheStorage, path, gomodPath)
-	if err != nil {
-		return err
+func finish(ctx context.Context, cacheStorage cache.Storage, path, gomodPath string, skipProto bool) error {
+	if !skipProto {
+		if err := protoc(ctx, cacheStorage, path, gomodPath); err != nil {
+			return err
+		}
 	}
 
 	if err := gocmd.Fmt(ctx, path); err != nil {

--- a/ignite/services/scaffolder/type.go
+++ b/ignite/services/scaffolder/type.go
@@ -219,7 +219,7 @@ func (s Scaffolder) AddType(
 		return sm, err
 	}
 
-	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath)
+	return sm, finish(ctx, cacheStorage, opts.AppPath, s.modpath.RawPath, false)
 }
 
 // checkForbiddenTypeIndex returns true if the name is forbidden as a index name.

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -4,6 +4,7 @@ import (
 	"cosmossdk.io/core/appmodule"
 	storetypes "cosmossdk.io/store/types"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"


### PR DESCRIPTION
Adds a `--skip-proto` flag to `s chain` to speed up scaffolding.
Advanced user can enjoy faster scaffolding time but still need to run `ignite chain serve` or `ignite chain build` afterwards.