### PR TITLE
chore: remove temporary hardcoded commit

### DIFF
--- a/ignite/services/plugin/template/go.mod.plush
+++ b/ignite/services/plugin/template/go.mod.plush
@@ -8,5 +8,4 @@ require (
 	github.com/stretchr/testify v1.8.4
 )
 
-// replace github.com/ignite/cli/v29 => github.com/ignite/cli/v29 main
-replace github.com/ignite/cli/v29 => github.com/ignite/cli/v29 f4ce3f1acd08a1e5e789e983caa1eeb658a3c130
+replace github.com/ignite/cli/v29 => github.com/ignite/cli/v29 main


### PR DESCRIPTION
Removes this temporary commit https://github.com/ignite/cli/pull/3945/commits/2e2cea46f40ebb15f250bd34e892c75aad720a45 now that https://github.com/ignite/cli/pull/3945 has been merged