### PR TITLE
ci: don't fail if codecov fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     paths-ignore:
-      - '**.md'
+      - "**.md"
     branches:
       - main
       - release/*
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: env.GIT_DIFF
         with:
-          go-version: '1.22'
+          go-version: "1.22"
           cache: true
           cache-dependency-path: go.sum
 
@@ -45,5 +45,5 @@ jobs:
         if: env.GIT_DIFF
         with:
           file: ./coverage.txt
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
codecov is blocking all prs because it is very flaky (still advocating to use sonarcloud, but that's another story)
this updates CI to not make fail the kob when codecov fails