### PR TITLE
chore: get correct `cosmosver.Latest` version

### DIFF
--- a/ignite/pkg/cosmosver/cosmosver.go
+++ b/ignite/pkg/cosmosver/cosmosver.go
@@ -32,6 +32,7 @@ var (
 		StargateFortyFourVersion,
 		StargateFortyFiveThreeVersion,
 		StargateFortySevenTwoVersion,
+		StargateFiftyVersion,
 	}
 
 	// Latest is the latest known version of the Cosmos-SDK.

--- a/integration/readme.md
+++ b/integration/readme.md
@@ -34,7 +34,7 @@ env.Must(env.Exec("create a list with bool",
         step.Workdir(path),
     )),
 ))
-env.EnsureAppIsSteady(path)
+env.EnsureSteady()
 ```
 
 - To check if the command returns an error, you can add the `envtest.ExecShouldError()` step:
@@ -47,5 +47,5 @@ env.Must(env.Exec("should prevent creating a list with duplicated fields",
     )),
     envtest.ExecShouldError(),
 ))
-env.EnsureAppIsSteady(path)
+env.EnsureSteady()
 ```


### PR DESCRIPTION
Found this while doing the rollkit app, docs for integration doesn't match the new api and latest version doesn't return the actual latest version.