### PR TITLE
feat: by default generate the migration docs from a major version to another

### DIFF
--- a/ignite/internal/tools/gen-mig-diffs/cmd/root.go
+++ b/ignite/internal/tools/gen-mig-diffs/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
@@ -93,7 +94,7 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			// Scaffold the default commands for each version.
-			scaffoldOptions := make([]scaffold.Options, 0)
+			scaffoldOptions := []scaffold.Option{scaffold.WithStderr(os.Stderr)}
 			if scaffoldOutput != "" {
 				scaffoldOptions = append(scaffoldOptions, scaffold.WithOutput(scaffoldOutput))
 			}

--- a/ignite/internal/tools/gen-mig-diffs/cmd/root.go
+++ b/ignite/internal/tools/gen-mig-diffs/cmd/root.go
@@ -94,7 +94,11 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			// Scaffold the default commands for each version.
-			scaffoldOptions := []scaffold.Option{scaffold.WithStderr(os.Stderr)}
+			scaffoldOptions := []scaffold.Option{
+				scaffold.WithStderr(os.Stderr),
+				scaffold.WithStdout(os.Stdout),
+				scaffold.WithStdin(os.Stdin),
+			}
 			if scaffoldOutput != "" {
 				scaffoldOptions = append(scaffoldOptions, scaffold.WithOutput(scaffoldOutput))
 			}

--- a/ignite/internal/tools/gen-mig-diffs/go.mod
+++ b/ignite/internal/tools/gen-mig-diffs/go.mod
@@ -80,7 +80,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
-	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/ignite/internal/tools/gen-mig-diffs/go.sum
+++ b/ignite/internal/tools/gen-mig-diffs/go.sum
@@ -226,8 +226,6 @@ golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2Uz
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
-golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 h1:985EYyeCOxTpcgOTJpflJUwOeEz0CQOdPt73OzpE9F8=
-golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=


### PR DESCRIPTION
## Description

If the user doesn't specify the `from` version, we get the last major release instead of the last patch release. This way, we can better generate migration docs with significant migration content