### PR TITLE
feat(services): set default chain-id in client.toml

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 - [#4113](https://github.com/ignite/cli/pull/4113) Generate chain config documentation automatically
 - [#4131](https://github.com/ignite/cli/pull/4131) Support `bytes` as data type in the `scaffold` commands
 - [#4095](https://github.com/ignite/cli/pull/4095) Migrate to matomo analytics
+- [#4183](https://github.com/ignite/cli/pull/4183) Set `chain-id` in the client.toml
 
 ### Changes
 

--- a/ignite/services/chain/init.go
+++ b/ignite/services/chain/init.go
@@ -101,7 +101,7 @@ func (c *Chain) InitChain(ctx context.Context, initConfiguration, initGenesis bo
 
 	// ovewrite app config files with the values defined in Ignite's config file
 	if initConfiguration {
-		if err := c.Configure(home, conf); err != nil {
+		if err := c.Configure(home, chainID, conf); err != nil {
 			return err
 		}
 	}

--- a/ignite/services/chain/runtime.go
+++ b/ignite/services/chain/runtime.go
@@ -55,17 +55,17 @@ func (c Chain) Start(ctx context.Context, runner chaincmdrunner.Runner, cfg *cha
 }
 
 // Configure sets the runtime configurations files for a chain (app.toml, client.toml, config.toml).
-func (c Chain) Configure(homePath string, cfg *chainconfig.Config) error {
-	if err := c.appTOML(homePath, cfg); err != nil {
+func (c Chain) Configure(homePath, chainID string, cfg *chainconfig.Config) error {
+	if err := appTOML(homePath, cfg); err != nil {
 		return err
 	}
-	if err := c.clientTOML(homePath, cfg); err != nil {
+	if err := clientTOML(homePath, chainID, cfg); err != nil {
 		return err
 	}
-	return c.configTOML(homePath, cfg)
+	return configTOML(homePath, cfg)
 }
 
-func (c Chain) appTOML(homePath string, cfg *chainconfig.Config) error {
+func appTOML(homePath string, cfg *chainconfig.Config) error {
 	validator, err := chainconfig.FirstValidator(cfg)
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func (c Chain) appTOML(homePath string, cfg *chainconfig.Config) error {
 	return err
 }
 
-func (c Chain) configTOML(homePath string, cfg *chainconfig.Config) error {
+func configTOML(homePath string, cfg *chainconfig.Config) error {
 	validator, err := chainconfig.FirstValidator(cfg)
 	if err != nil {
 		return err
@@ -171,14 +171,14 @@ func (c Chain) configTOML(homePath string, cfg *chainconfig.Config) error {
 	return err
 }
 
-func (c Chain) clientTOML(homePath string, cfg *chainconfig.Config) error {
+func clientTOML(homePath, chainID string, cfg *chainconfig.Config) error {
 	validator, err := chainconfig.FirstValidator(cfg)
 	if err != nil {
 		return err
 	}
 
 	path := filepath.Join(homePath, "config/client.toml")
-	tmConfig, err := toml.LoadFile(path)
+	clientConfig, err := toml.LoadFile(path)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -188,11 +188,12 @@ func (c Chain) clientTOML(homePath string, cfg *chainconfig.Config) error {
 	}
 
 	// Set default config values
-	tmConfig.Set("keyring-backend", "test")
-	tmConfig.Set("broadcast-mode", "sync")
+	clientConfig.Set("chain-id", chainID)
+	clientConfig.Set("keyring-backend", "test")
+	clientConfig.Set("broadcast-mode", "sync")
 
 	// Update config values with the validator's client config
-	if err := updateTomlTreeValues(tmConfig, validator.Client); err != nil {
+	if err := updateTomlTreeValues(clientConfig, validator.Client); err != nil {
 		return err
 	}
 
@@ -202,7 +203,7 @@ func (c Chain) clientTOML(homePath string, cfg *chainconfig.Config) error {
 	}
 	defer file.Close()
 
-	_, err = tmConfig.WriteTo(file)
+	_, err = clientConfig.WriteTo(file)
 	return err
 }
 


### PR DESCRIPTION
The default `client.toml` doesn't have `chain-id` specified, which requires a user to always use the `--chain-id` flag when using directly the binary instead of ignite (that does autodetection by querying the node status)