### PR TITLE
chore: add scaffolding branding

### DIFF
--- a/ignite/services/plugin/template/.gitignore.plush
+++ b/ignite/services/plugin/template/.gitignore.plush
@@ -1,3 +1,4 @@
+# Built with https://github.com/ignite/cli
 # Binaries for programs and plugins
 *.exe
 *.exe~


### PR DESCRIPTION
Idea taken from Spawn: https://github.com/rollchains/spawn/blob/v0.50.2/simapp/.gitignore#L1
In cosmosregistry/example, I did it with the mean of a `THANKS.md`: https://github.com/cosmosregistry/example/blob/754905a/scripts/rename.sh#L45-L47 but having it not cluttering the root  directory is better.

This will be useful as we are removing the branded placeholders for AST only.