### PR TITLE
fix: set default values for extension flag to dont crash ignite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,7 @@
 - [#4184](https://github.com/ignite/cli/pull/4184) Set custom `InitChainer` because of manually registered modules
 - [#4198](https://github.com/ignite/cli/pull/4198) Set correct prefix overwriting in `buf.gen.pulsar.yaml`
 - [#4199](https://github.com/ignite/cli/pull/4199) Set and seal SDK global config in `app/config.go`
+- [#4212](https://github.com/ignite/cli/pull/4212) set default values for extension flag to dont crash ignite
 
 ## [`v28.4.0`](https://github.com/ignite/cli/releases/tag/v28.4.0)
 

--- a/ignite/services/plugin/grpc/v1/interface_flag.go
+++ b/ignite/services/plugin/grpc/v1/interface_flag.go
@@ -34,7 +34,7 @@ func newDefaultFlagValueError(typeName, value string) error {
 }
 
 func (f *Flag) exportToFlagSet(fs *pflag.FlagSet) error {
-	switch f.Type {
+	switch f.Type { //nolint:exhaustive
 	case Flag_TYPE_FLAG_BOOL,
 		Flag_TYPE_FLAG_INT,
 		Flag_TYPE_FLAG_INT64,

--- a/ignite/services/plugin/grpc/v1/interface_flag.go
+++ b/ignite/services/plugin/grpc/v1/interface_flag.go
@@ -35,6 +35,20 @@ func newDefaultFlagValueError(typeName, value string) error {
 
 func (f *Flag) exportToFlagSet(fs *pflag.FlagSet) error {
 	switch f.Type {
+	case Flag_TYPE_FLAG_BOOL,
+		Flag_TYPE_FLAG_INT,
+		Flag_TYPE_FLAG_INT64,
+		Flag_TYPE_FLAG_UINT,
+		Flag_TYPE_FLAG_UINT64:
+		if f.DefaultValue == "" {
+			f.DefaultValue = "0"
+		}
+		if f.Value == "" {
+			f.Value = "0"
+		}
+	}
+
+	switch f.Type {
 	case Flag_TYPE_FLAG_BOOL:
 		v, err := strconv.ParseBool(f.DefaultValue)
 		if err != nil {


### PR DESCRIPTION
## Description

Add any flag to the extension, and don't use the flag or don't set a default value to this flag crashes the extension