### PR TITLE
fix: avoid create duplicated scopedKeppers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,7 +55,8 @@
 - [#4184](https://github.com/ignite/cli/pull/4184) Set custom `InitChainer` because of manually registered modules
 - [#4198](https://github.com/ignite/cli/pull/4198) Set correct prefix overwriting in `buf.gen.pulsar.yaml`
 - [#4199](https://github.com/ignite/cli/pull/4199) Set and seal SDK global config in `app/config.go`
-- [#4212](https://github.com/ignite/cli/pull/4212) set default values for extension flag to dont crash ignite
+- [#4212](https://github.com/ignite/cli/pull/4212) Set default values for extension flag to dont crash ignite
+- [#4216](https://github.com/ignite/cli/pull/4216) Avoid create duplicated scopedKeppers
 
 ## [`v28.4.0`](https://github.com/ignite/cli/releases/tag/v28.4.0)
 

--- a/ignite/templates/app/files-consumer/app/app.go.plush
+++ b/ignite/templates/app/files-consumer/app/app.go.plush
@@ -125,6 +125,7 @@ type App struct {
 	ScopedIBCTransferKeeper   capabilitykeeper.ScopedKeeper
 	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
 	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
+	ScopedKeepers             map[string]capabilitykeeper.ScopedKeeper
 
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
 
@@ -166,7 +167,7 @@ func New(
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) (*App, error) {
 	var (
-		app        = &App{}
+		app        = &App{ScopedKeepers: make(map[string]capabilitykeeper.ScopedKeeper)}
 		appBuilder *runtime.AppBuilder
 
 		// merge the AppConfig and other configuration in one config
@@ -345,7 +346,12 @@ func (app *App) GetIBCKeeper() *ibckeeper.Keeper {
 
 // GetCapabilityScopedKeeper returns the capability scoped keeper.
 func (app *App) GetCapabilityScopedKeeper(moduleName string) capabilitykeeper.ScopedKeeper {
-	return app.CapabilityKeeper.ScopeToModule(moduleName)
+	sk, ok := app.ScopedKeepers[moduleName]
+	if !ok {
+		sk = app.CapabilityKeeper.ScopeToModule(moduleName)
+		app.ScopedKeepers[moduleName] = sk
+	}
+	return sk
 }
 
 // SimulationManager implements the SimulationApp interface.

--- a/ignite/templates/app/files/app/app.go.plush
+++ b/ignite/templates/app/files/app/app.go.plush
@@ -136,6 +136,7 @@ type App struct {
 	ScopedIBCTransferKeeper   capabilitykeeper.ScopedKeeper
 	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
 	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
+	ScopedKeepers             map[string]capabilitykeeper.ScopedKeeper
 
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
 
@@ -191,7 +192,7 @@ func New(
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) (*App, error) {
 	var (
-		app        = &App{}
+		app        = &App{ScopedKeepers: make(map[string]capabilitykeeper.ScopedKeeper)}
 		appBuilder *runtime.AppBuilder
 
 		// merge the AppConfig and other configuration in one config
@@ -350,7 +351,12 @@ func (app *App) GetIBCKeeper() *ibckeeper.Keeper {
 
 // GetCapabilityScopedKeeper returns the capability scoped keeper.
 func (app *App) GetCapabilityScopedKeeper(moduleName string) capabilitykeeper.ScopedKeeper {
-	return app.CapabilityKeeper.ScopeToModule(moduleName)
+	sk, ok := app.ScopedKeepers[moduleName]
+	if !ok {
+		sk = app.CapabilityKeeper.ScopeToModule(moduleName)
+		app.ScopedKeepers[moduleName] = sk
+	}
+	return sk
 }
 
 // SimulationManager implements the SimulationApp interface.

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/keeper/keeper.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/keeper/keeper.go.plush
@@ -39,8 +39,7 @@ type (
 
         <%= if (isIBC) { %>
 		ibcKeeperFn        func() *ibckeeper.Keeper
-		capabilityScopedFn func(string) capabilitykeeper.ScopedKeeper
-		scopedKeeper       exported.ScopedKeeper<% } %>
+		capabilityScopedFn func(string) capabilitykeeper.ScopedKeeper<% } %>
 		<%= for (dependency) in dependencies { %>
         <%= toVariableName(dependency.KeeperName()) %> types.<%= dependency.KeeperName() %><% } %>
 	}
@@ -101,7 +100,7 @@ func (k Keeper) Logger() log.Logger {
 // ----------------------------------------------------------------------------
 
 // ChanCloseInit defines a wrapper function for the channel Keeper's function.
-func (k *Keeper) ChanCloseInit(ctx sdk.Context, portID, channelID string) error {
+func (k Keeper) ChanCloseInit(ctx sdk.Context, portID, channelID string) error {
 	capName := host.ChannelCapabilityPath(portID, channelID)
 	chanCap, ok := k.ScopedKeeper().GetCapability(ctx, capName)
 	if !ok {
@@ -111,7 +110,7 @@ func (k *Keeper) ChanCloseInit(ctx sdk.Context, portID, channelID string) error 
 }
 
 // ShouldBound checks if the IBC app module can be bound to the desired port
-func (k *Keeper) ShouldBound(ctx sdk.Context, portID string) bool {
+func (k Keeper) ShouldBound(ctx sdk.Context, portID string) bool {
 	scopedKeeper := k.ScopedKeeper()
 	if scopedKeeper == nil {
 		return false
@@ -122,40 +121,37 @@ func (k *Keeper) ShouldBound(ctx sdk.Context, portID string) bool {
 
 // BindPort defines a wrapper function for the port Keeper's function in
 // order to expose it to module's InitGenesis function
-func (k *Keeper) BindPort(ctx sdk.Context, portID string) error {
+func (k Keeper) BindPort(ctx sdk.Context, portID string) error {
 	cap := k.ibcKeeperFn().PortKeeper.BindPort(ctx, portID)
 	return k.ClaimCapability(ctx, cap, host.PortPath(portID))
 }
 
 // GetPort returns the portID for the IBC app module. Used in ExportGenesis
-func (k *Keeper) GetPort(ctx sdk.Context) string {
+func (k Keeper) GetPort(ctx sdk.Context) string {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, []byte{})
 	return string(store.Get(types.PortKey))
 }
 
 // SetPort sets the portID for the IBC app module. Used in InitGenesis
-func (k *Keeper) SetPort(ctx sdk.Context, portID string) {
+func (k Keeper) SetPort(ctx sdk.Context, portID string) {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, []byte{})
 	store.Set(types.PortKey, []byte(portID))
 }
 
 // AuthenticateCapability wraps the scopedKeeper's AuthenticateCapability function
-func (k *Keeper) AuthenticateCapability(ctx sdk.Context, cap *capabilitytypes.Capability, name string) bool {
+func (k Keeper) AuthenticateCapability(ctx sdk.Context, cap *capabilitytypes.Capability, name string) bool {
 	return k.ScopedKeeper().AuthenticateCapability(ctx, cap, name)
 }
 
 // ClaimCapability allows the IBC app module to claim a capability that core IBC
 // passes to it
-func (k *Keeper) ClaimCapability(ctx sdk.Context, cap *capabilitytypes.Capability, name string) error {
+func (k Keeper) ClaimCapability(ctx sdk.Context, cap *capabilitytypes.Capability, name string) error {
 	return k.ScopedKeeper().ClaimCapability(ctx, cap, name)
 }
 
 // ScopedKeeper returns the ScopedKeeper
-func (k *Keeper) ScopedKeeper() exported.ScopedKeeper {
-	if k.scopedKeeper == nil && k.capabilityScopedFn != nil {
-		k.scopedKeeper = k.capabilityScopedFn(types.ModuleName)
-	}
-	return k.scopedKeeper
+func (k Keeper) ScopedKeeper() exported.ScopedKeeper {
+	return k.capabilityScopedFn(types.ModuleName)
 }<% } %>


### PR DESCRIPTION
close #4066

## Description

Since we are not using the module keeper as a pointer, the scoped keeper can't be saved inside the keeper structure, causing chain crashes. This PR makes the App handle the scoped keeper logic.