### PR TITLE
refactor: remove deprecated `sdk.MustSortJSON`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -79,6 +79,7 @@
 - [#4086](https://github.com/ignite/cli/pull/4086) Retry to get the IBC balance if it fails the first time
 - [#4096](https://github.com/ignite/cli/pull/4096) Add new reserved names module and remove duplicated genesis order
 - [#4112](https://github.com/ignite/cli/pull/4112) Remove duplicate SetCmdClientContextHandler
+- [#4219](https://github.com/ignite/cli/pull/4219) Remove deprecated `sdk.MustSortJSON`
 
 ## [`v28.3.0`](https://github.com/ignite/cli/releases/tag/v28.3.0)
 

--- a/ignite/templates/ibc/packet.go
+++ b/ignite/templates/ibc/packet.go
@@ -130,7 +130,7 @@ func moduleModify(replacer placeholder.Replacer, opts *PacketOptions) genny.RunF
 		if err != nil {
 			return channeltypes.NewErrorAcknowledgement(errorsmod.Wrap(sdkerrors.ErrJSONMarshal, err.Error()))
 		}
-		ack = channeltypes.NewResultAcknowledgement(sdk.MustSortJSON(packetAckBytes))
+		ack = channeltypes.NewResultAcknowledgement(packetAckBytes)
 	}
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/module/module.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/module/module.go.plush
@@ -41,7 +41,7 @@ var (
 	_ appmodule.AppModule       = (*AppModule)(nil)
 	_ appmodule.HasBeginBlocker = (*AppModule)(nil)
 	_ appmodule.HasEndBlocker   = (*AppModule)(nil)
-	<%= if (isIBC) { %>_ porttypes.IBCModule   = IBCModule{}<% } %>
+	<%= if (isIBC) { %>_ porttypes.IBCModule   = (*IBCModule)(nil)<% } %>
 )
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

remove deprecated `sdk.MustSortJSON` used for GetSignbytes, this is now automatic with amino signing.

