### PR TITLE
docs: Improve ignite installation prerequisite documentation

### DIFF
--- a/docs/docs/01-welcome/02-install.md
+++ b/docs/docs/01-welcome/02-install.md
@@ -25,7 +25,10 @@ Ignite CLI is supported for the following operating systems:
 Ignite CLI is written in the Go programming language. To use Ignite CLI on a local system:
 
 - Install [Go](https://golang.org/doc/install) (**version 1.21.1** or higher)
-- Ensure the Go environment variables are [set properly](https://golang.org/doc/gopath_code#GOPATH) on your system
+- Ensure the Go environment variables are [set properly](https://golang.org/doc/gopath_code#GOPATH) on your system.
+
+#### Troubleshooting Go Environment Setup: 
+  If you encounter any issues while setting up your Go environment variables, please refer to our detailed guide: [Configure Go Environment Variables.](03-set-go-env-var.md)
 
 ## Verify your Ignite CLI version
 

--- a/docs/docs/01-welcome/03-set-go-env-var.md
+++ b/docs/docs/01-welcome/03-set-go-env-var.md
@@ -1,0 +1,75 @@
+# Go Path Environment Setup
+
+This guide provides instructions on how to properly configure your Go PATH environment variables. This is especially useful if you encounter issues like the one described in [GitHub Issue #2291](https://github.com/ignite/cli/issues/2291).
+
+## Prerequisites
+
+Ensure you have Go installed on your system. You can download it from [golang.org](https://golang.org/dl/).
+
+## Steps to Configure Go PATH Environment Variables
+
+1. **Open your shell configuration file**:
+
+   Depending on the shell you are using, open the appropriate configuration file. You might need to use `sudo` to update the file.
+
+   - For `zsh` (Z shell):
+     ```sh
+     sudo nano ~/.zshrc
+     ```
+
+   - For `bash`:
+     ```sh
+     sudo nano ~/.bashrc
+     ```
+
+   - For `profile`:
+     ```sh
+     sudo nano ~/.profile
+     ```
+
+2. **Add the following code snippet**:
+
+   Append the following lines to the end of the opened configuration file to set up your Go PATH environment variables:
+
+   ```sh
+   export GOPATH=$HOME/go
+   export PATH=$PATH:$GOPATH/bin
+
+   
+3. **Apply the changes**:
+   
+   After saving the changes to your configuration file, you need to source it to apply the changes:
+
+   - For `zsh` (Z shell):
+  
+        ```sh
+        source ~/.zshrc 
+        ```
+    - For `bash`:
+        ```sh
+        source ~/.bashrc
+        ```
+    - For `profile`:
+        ```sh
+        source ~/.profile
+        ```
+4. **Verify the configuration**:
+
+    To ensure that the environment variables are set correctly, run the following commands:
+
+    ```sh
+        echo $GOPATH
+        echo $PATH
+    ```
+
+
+
+## Troubleshooting
+
+**If you encounter any issues**:
+
+- Double-check that you have correctly edited and sourced the appropriate configuration file.
+
+- Ensure that there are no typos in the environment variable names or paths.
+
+- Restart your terminal session or computer if the changes do not seem to take effect.


### PR DESCRIPTION
I ran into the issue described in GitHub Issue #2291 while working on the blog tutorial. This prompted me to improve the documentation to help others avoid similar problems.

The changes aim to provide clearer, step-by-step instructions for new and existing users to configure their Go environment correctly.

Since this is a common problem outside the project, this PR could be turned into a blog post to drive awareness and traffic to the Ignite CLI.

# Changes Made
Updated Prerequisites Section:

- Added a numbered list format for better readability.
- Clearly specified the required Go version (1.21.1 or higher) and provided a direct link to the Go installation page.
- Ensured the statement about setting Go environment variables is clear and direct.
- Included a troubleshooting step with a link to a detailed guide on configuring Go environment variables.

**Added Troubleshooting Section:**

Included troubleshooting tips to assist users in resolving issues related to setting up Go environment variables.