### PR TITLE
fix: set gas adjustment before calc

### DIFF
--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -573,6 +573,10 @@ func (c Client) CreateTx(goCtx context.Context, account cosmosaccount.Account, m
 		return TxService{}, err
 	}
 
+	if c.gasAdjustment != 0 && c.gasAdjustment != defaultGasAdjustment {
+		txf = txf.WithGasAdjustment(c.gasAdjustment)
+	}
+
 	var gas uint64
 	if c.gas != "" && c.gas != GasAuto {
 		gas, err = strconv.ParseUint(c.gas, 10, 64)
@@ -593,10 +597,6 @@ func (c Client) CreateTx(goCtx context.Context, account cosmosaccount.Account, m
 
 	if c.gasPrices != "" {
 		txf = txf.WithGasPrices(c.gasPrices)
-	}
-
-	if c.gasAdjustment != 0 && c.gasAdjustment != defaultGasAdjustment {
-		txf = txf.WithGasAdjustment(c.gasAdjustment)
 	}
 
 	txUnsigned, err := txf.BuildUnsignedTx(msgs...)


### PR DESCRIPTION
In `CreateTx` in `pkg/cosmosclient/cosmosclient.go` if gas is set to auto the function will calculate gas using the gasometer.

The gas adjustment is used in this calculation (at least in the cosmos sdk implementation)

https://github.com/cosmos/cosmos-sdk/blob/10465a6aabdfc9119ff187ac3ef229f33c06ab45/client/tx/tx.go#L149-L166

As the `txf.WithGasAdjustment` is set after the calculation the function will use the default value.

This PR moves the assignment to before the calculation so that the gas adjustment is correctly applied in the gasometer estimation. 