### PR TITLE
chore: bring back default extensions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [`v28.5.1`](https://github.com/ignite/cli/releases/tag/v28.5.1)
+
+### Changes
+
+- [#4262](https://github.com/ignite/cli/pull/4262) Bring back relayer command
+
 ## [`v28.5.0`](https://github.com/ignite/cli/releases/tag/v28.5.0)
 
 ### Features

--- a/ignite/cmd/plugin_default.go
+++ b/ignite/cmd/plugin_default.go
@@ -26,20 +26,18 @@ const (
 // a command will added if the plugin is not already installed.
 // When the user executes that command, the plugin is automatically installed.
 var defaultPlugins = []defaultPlugin{
-	// TODO uncomment after fix SPN. Don't forget to un-skip TestEnsureDefaultPlugins.
-	// {
-	//	use:     "network",
-	//	short:   "Launch a blockchain in production",
-	//	aliases: []string{"n"},
-	//	path:    PluginNetworkPath,
-	// },
-	// TODO uncomment after launch the `hermes/v0.2.4`. Don't forget to un-skip TestEnsureDefaultPlugins.
-	// {
-	// 	use:     "relayer",
-	// 	short:   "Connect blockchains with an IBC relayer",
-	// 	aliases: []string{"r"},
-	// 	path:    PluginRelayerPath,
-	// },
+	{
+		use:     "network",
+		short:   "Launch a blockchain in production",
+		aliases: []string{"n"},
+		path:    PluginNetworkPath,
+	},
+	{
+		use:     "relayer",
+		short:   "Connect blockchains with an IBC relayer",
+		aliases: []string{"r"},
+		path:    PluginRelayerPath,
+	},
 }
 
 // ensureDefaultPlugins ensures that all defaultPlugins are whether registered

--- a/ignite/cmd/plugin_default_test.go
+++ b/ignite/cmd/plugin_default_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestEnsureDefaultPlugins(t *testing.T) {
-	t.Skip("skip till we have default plugins again")
-
 	tests := []struct {
 		name                 string
 		cfg                  *pluginsconfig.Config


### PR DESCRIPTION
hermes/v0.2.4 has been tagged so we can re-enable it on ignite