### PR TITLE
ci: remove consecutiveness step

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -5,17 +5,13 @@ on:
     branches:
       - main
 
-jobs:
-  consecutiveness:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ignite/consecutive-workflow-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+concurrency:
+  group: ci-${{ github.ref }}-docs-deploy
+  cancel-in-progress: true
 
+jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    needs: [ consecutiveness ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -2,7 +2,7 @@ name: Release Docker Image
 
 on:
   release:
-    types: [ published ]
+    types: [published]
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 
@@ -11,13 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  consecutiveness:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ignite/consecutive-workflow-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   check-latest-run:
     runs-on: "ubuntu-latest"
     steps:
@@ -34,7 +27,7 @@ jobs:
     name: Push Docker image to Docker Hub
     if: needs.check-latest-run.outputs.last_sha != github.sha
     runs-on: ubuntu-latest
-    needs: [ consecutiveness, check-latest-run ]
+    needs: [check-latest-run]
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -58,7 +58,7 @@ jobs:
   releases-binaries:
     if: needs.check-latest-run.outputs.last_sha != github.sha
     name: Release Go Binary
-    needs: [consecutiveness, check-latest-run]
+    needs: [check-latest-run]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -10,13 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  consecutiveness:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ignite/consecutive-workflow-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   check-latest-run:
     runs-on: "ubuntu-latest"
     steps:
@@ -32,7 +25,7 @@ jobs:
   release-nightly:
     if: needs.check-latest-run.outputs.last_sha != github.sha
     runs-on: ubuntu-latest
-    needs: [ consecutiveness, check-latest-run ]
+    needs: [check-latest-run]
     env:
       working-directory: go/src/github.com/ignite/cli
 
@@ -65,12 +58,12 @@ jobs:
   releases-binaries:
     if: needs.check-latest-run.outputs.last_sha != github.sha
     name: Release Go Binary
-    needs: [ consecutiveness, check-latest-run ]
+    needs: [consecutiveness, check-latest-run]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [ linux, darwin ]
-        goarch: [ amd64, arm64 ]
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1.43


### PR DESCRIPTION
This job has been timing out, and we don't need it anyway: https://github.com/ignite/cli/actions/runs/10032367974/job/27723961043 / https://github.com/ignite/consecutive-workflow-action as we use `cancel-in-process`.