### PR TITLE
simply add buildvcs options to prevent "error obtaining VCS status" while do the chain build

### DIFF
--- a/actions/cli/Dockerfile
+++ b/actions/cli/Dockerfile
@@ -1,3 +1,3 @@
-FROM ignitehq/cli:latest
+FROM michaell404/ignite-cli:latest
 
 USER root

--- a/ignite/services/chain/build.go
+++ b/ignite/services/chain/build.go
@@ -235,6 +235,7 @@ func (c *Chain) preBuild(
 		gocmd.FlagMod, gocmd.FlagModValueReadOnly,
 		gocmd.FlagTags, gocmd.Tags(buildTags...),
 		gocmd.FlagLdflags, gocmd.Ldflags(ldFlags...),
+		"-buildvcs=false",
 	}
 
 	c.ev.Send("Installing dependencies...", events.ProgressUpdate())


### PR DESCRIPTION
need to create image in the company docker hub