### PR TITLE
fix: add missing verbose mode flags

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 - [#4000](https://github.com/ignite/cli/pull/4000) Run all dry runners before the wet run in the `xgenny` pkg
 - [#4091](https://github.com/ignite/cli/pull/4091) Fix race conditions in the plugin logic
 - [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
+- [#4286](https://github.com/ignite/cli/pull/4286) Add missing verbose mode flags
 
 ## [`v28.5.0`](https://github.com/ignite/cli/releases/tag/v28.5.0)
 

--- a/ignite/cmd/chain_build.go
+++ b/ignite/cmd/chain_build.go
@@ -88,12 +88,12 @@ for your current environment.
 	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	c.Flags().AddFlagSet(flagSetSkipProto())
 	c.Flags().AddFlagSet(flagSetDebug())
+	c.Flags().AddFlagSet(flagSetVerbose())
 	c.Flags().Bool(flagRelease, false, "build for a release")
 	c.Flags().StringSliceP(flagReleaseTargets, "t", []string{}, "release targets. Available only with --release flag")
 	c.Flags().StringSlice(flagBuildTags, []string{}, "parameters to build the chain binary")
 	c.Flags().String(flagReleasePrefix, "", "tarball prefix for each release target. Available only with --release flag")
 	c.Flags().StringP(flagOutput, "o", "", "binary output path")
-	c.Flags().BoolP("verbose", "v", false, "verbose output")
 
 	return c
 }

--- a/ignite/cmd/chain_debug.go
+++ b/ignite/cmd/chain_debug.go
@@ -57,7 +57,6 @@ The debug server stops automatically when the client connection is closed.
 	}
 
 	flagSetPath(c)
-	c.Flags().AddFlagSet(flagSetVerbose())
 	c.Flags().Bool(flagServer, false, "start a debug server")
 	c.Flags().String(flagServerAddress, debugger.DefaultAddress, "debug server address")
 
@@ -67,10 +66,7 @@ The debug server stops automatically when the client connection is closed.
 func chainDebugHandler(cmd *cobra.Command, _ []string) error {
 	// Prepare session options.
 	// Events are ignored by the session when the debug server UI is used.
-	options := []cliui.Option{
-		cliui.StartSpinnerWithText("Initializing..."),
-		cliui.WithVerbosity(getVerbosity(cmd)),
-	}
+	options := []cliui.Option{cliui.StartSpinnerWithText("Initializing...")}
 	server, _ := cmd.Flags().GetBool(flagServer)
 	if server {
 		options = append(options, cliui.IgnoreEvents())

--- a/ignite/cmd/chain_debug.go
+++ b/ignite/cmd/chain_debug.go
@@ -57,6 +57,7 @@ The debug server stops automatically when the client connection is closed.
 	}
 
 	flagSetPath(c)
+	c.Flags().AddFlagSet(flagSetVerbose())
 	c.Flags().Bool(flagServer, false, "start a debug server")
 	c.Flags().String(flagServerAddress, debugger.DefaultAddress, "debug server address")
 
@@ -66,7 +67,10 @@ The debug server stops automatically when the client connection is closed.
 func chainDebugHandler(cmd *cobra.Command, _ []string) error {
 	// Prepare session options.
 	// Events are ignored by the session when the debug server UI is used.
-	options := []cliui.Option{cliui.StartSpinnerWithText("Initializing...")}
+	options := []cliui.Option{
+		cliui.StartSpinnerWithText("Initializing..."),
+		cliui.WithVerbosity(getVerbosity(cmd)),
+	}
 	server, _ := cmd.Flags().GetBool(flagServer)
 	if server {
 		options = append(options, cliui.IgnoreEvents())

--- a/ignite/cmd/chain_faucet.go
+++ b/ignite/cmd/chain_faucet.go
@@ -21,6 +21,7 @@ func NewChainFaucet() *cobra.Command {
 
 	flagSetPath(c)
 	c.Flags().AddFlagSet(flagSetHome())
+	c.Flags().AddFlagSet(flagSetVerbose())
 	c.Flags().BoolP("verbose", "v", false, "verbose output")
 
 	return c

--- a/ignite/cmd/chain_faucet.go
+++ b/ignite/cmd/chain_faucet.go
@@ -21,7 +21,6 @@ func NewChainFaucet() *cobra.Command {
 
 	flagSetPath(c)
 	c.Flags().AddFlagSet(flagSetHome())
-	c.Flags().AddFlagSet(flagSetVerbose())
 	c.Flags().BoolP("verbose", "v", false, "verbose output")
 
 	return c
@@ -31,10 +30,7 @@ func chainFaucetHandler(cmd *cobra.Command, args []string) error {
 	var (
 		toAddress = args[0]
 		coins     = args[1]
-		session   = cliui.New(
-			cliui.WithVerbosity(getVerbosity(cmd)),
-			cliui.StartSpinner(),
-		)
+		session   = cliui.New(cliui.StartSpinner())
 	)
 	defer session.End()
 

--- a/ignite/cmd/chain_init.go
+++ b/ignite/cmd/chain_init.go
@@ -88,6 +88,7 @@ commands manually to ensure a production-level node initialization.
 	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	c.Flags().AddFlagSet(flagSetSkipProto())
 	c.Flags().AddFlagSet(flagSetDebug())
+	c.Flags().AddFlagSet(flagSetVerbose())
 	c.Flags().StringSlice(flagBuildTags, []string{}, "parameters to build the chain binary")
 
 	return c

--- a/ignite/cmd/chain_lint.go
+++ b/ignite/cmd/chain_lint.go
@@ -15,10 +15,7 @@ func NewChainLint() *cobra.Command {
 		Long:  "The lint command runs the golangci-lint tool to lint the codebase.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			session := cliui.New(
-				cliui.StartSpinnerWithText("Linting..."),
-				cliui.WithVerbosity(getVerbosity(cmd)),
-			)
+			session := cliui.New(cliui.StartSpinnerWithText("Linting..."))
 			defer session.End()
 
 			chainOption := []chain.Option{
@@ -34,8 +31,6 @@ func NewChainLint() *cobra.Command {
 			return c.Lint(cmd.Context())
 		},
 	}
-
-	c.Flags().AddFlagSet(flagSetVerbose())
 
 	return c
 }

--- a/ignite/cmd/chain_lint.go
+++ b/ignite/cmd/chain_lint.go
@@ -17,6 +17,7 @@ func NewChainLint() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			session := cliui.New(
 				cliui.StartSpinnerWithText("Linting..."),
+				cliui.WithVerbosity(getVerbosity(cmd)),
 			)
 			defer session.End()
 
@@ -33,6 +34,8 @@ func NewChainLint() *cobra.Command {
 			return c.Lint(cmd.Context())
 		},
 	}
+
+	c.Flags().AddFlagSet(flagSetVerbose())
 
 	return c
 }

--- a/ignite/cmd/chain_serve.go
+++ b/ignite/cmd/chain_serve.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	flagVerbose         = "verbose"
 	flagConfig          = "config"
 	flagForceReset      = "force-reset"
 	flagGenerateClients = "generate-clients"
@@ -70,7 +71,7 @@ production, you may want to run "appd start" manually.
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().AddFlagSet(flagSetCheckDependencies())
 	c.Flags().AddFlagSet(flagSetSkipProto())
-	c.Flags().BoolP("verbose", "v", false, "verbose output")
+	c.Flags().AddFlagSet(flagSetVerbose())
 	c.Flags().BoolP(flagForceReset, "f", false, "force reset of the app state on start and every source change")
 	c.Flags().BoolP(flagResetOnce, "r", false, "reset the app state once on init")
 	c.Flags().Bool(flagGenerateClients, false, "generate code for the configured clients on reset or source code change")

--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -109,8 +109,14 @@ To get started, create a blockchain:
 	}, nil
 }
 
+func flagSetVerbose() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.BoolP(flagVerbose, "v", false, "verbose output")
+	return fs
+}
+
 func getVerbosity(cmd *cobra.Command) uilog.Verbosity {
-	if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+	if verbose, _ := cmd.Flags().GetBool(flagVerbose); verbose {
 		return uilog.VerbosityVerbose
 	}
 


### PR DESCRIPTION
We are using the verbose flag in some parts of the code, but the flag is no set