### PR TITLE
feat(template): only panics the module in the most top function level

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 - [#4111](https://github.com/ignite/cli/pull/4111) Remove vuex generation
 - [#4113](https://github.com/ignite/cli/pull/4113) Generate chain config documentation automatically
 - [#4131](https://github.com/ignite/cli/pull/4131) Support `bytes` as data type in the `scaffold` commands
+- [#4300](https://github.com/ignite/cli/pull/4300) Only panics the module in the most top function level
 
 ### Changes
 

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/module/genesis.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/module/genesis.go.plush
@@ -8,24 +8,22 @@ import (
 )
 
 // InitGenesis initializes the module's state from a provided genesis state.
-func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) error {
     // this line is used by starport scaffolding # genesis/module/init
-	if err := k.Params.Set(ctx, genState.Params); err != nil {
-		panic(err)
-	}
+	return k.Params.Set(ctx, genState.Params)
 }
 
 // ExportGenesis returns the module's exported genesis.
-func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
+func ExportGenesis(ctx sdk.Context, k keeper.Keeper) (*types.GenesisState, error) {
 	var err error
 
 	genesis := types.DefaultGenesis()
 	genesis.Params, err = k.Params.Get(ctx)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
     // this line is used by starport scaffolding # genesis/module/export
 
-    return genesis
+    return genesis, nil
 }

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/module/genesis_test.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/module/genesis_test.go.plush
@@ -18,8 +18,10 @@ func TestGenesis(t *testing.T) {
 	}
 
 	k, ctx, _ := keepertest.<%= title(moduleName) %>Keeper(t)
-	<%= moduleName %>.InitGenesis(ctx, k, genesisState)
-	got := <%= moduleName %>.ExportGenesis(ctx, k)
+	err := <%= moduleName %>.InitGenesis(ctx, k, genesisState)
+	require.NoError(t, err)
+	got, err := <%= moduleName %>.ExportGenesis(ctx, k)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 
 	nullify.Fill(&genesisState)

--- a/ignite/templates/module/create/files/base/x/{{moduleName}}/module/module.go.plush
+++ b/ignite/templates/module/create/files/base/x/{{moduleName}}/module/module.go.plush
@@ -144,12 +144,17 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 	// Initialize global index to index in genesis state
 	cdc.MustUnmarshalJSON(gs, &genState)
 
-	InitGenesis(ctx, am.keeper, genState)
+	if err := InitGenesis(ctx, am.keeper, genState); err != nil {
+        panic(err)
+	}
 }
 
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
-	genState := ExportGenesis(ctx, am.keeper)
+	genState, err := ExportGenesis(ctx, am.keeper)
+	if err != nil {
+	    panic(err)
+	}
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/ignite/templates/module/create/ibc.go
+++ b/ignite/templates/module/create/ibc.go
@@ -64,6 +64,15 @@ func genesisModify(replacer placeholder.Replacer, opts *CreateOptions) genny.Run
 			return err
 		}
 
+		// Import
+		content, err := xast.AppendImports(
+			f.String(),
+			xast.WithLastImport("cosmossdk.io/errors"),
+		)
+		if err != nil {
+			return err
+		}
+
 		// Genesis init
 		templateInit := `%s
 k.SetPort(ctx, genState.PortId)
@@ -74,11 +83,11 @@ if k.ShouldBound(ctx, genState.PortId) {
 	// and claims the returned capability
 	err := k.BindPort(ctx, genState.PortId)
 	if err != nil {
-		panic("could not claim port capability: " + err.Error())
+		return errors.Wrap(err, "could not claim port capability")
 	}
 }`
 		replacementInit := fmt.Sprintf(templateInit, typed.PlaceholderGenesisModuleInit)
-		content := replacer.Replace(f.String(), typed.PlaceholderGenesisModuleInit, replacementInit)
+		content = replacer.Replace(content, typed.PlaceholderGenesisModuleInit, replacementInit)
 
 		// Genesis export
 		templateExport := `genesis.PortId = k.GetPort(ctx)

--- a/ignite/templates/typed/list/genesis.go
+++ b/ignite/templates/typed/list/genesis.go
@@ -126,13 +126,13 @@ func genesisModuleModify(replacer placeholder.Replacer, opts *typed.Options) gen
 		templateModuleInit := `// Set all the %[2]v
 for _, elem := range genState.%[3]vList {
 	if err := k.%[3]v.Set(ctx, elem.Id, elem); err != nil {
-		panic(err)
+		return err
 	}
 }
 
 // Set %[2]v count
 if err := k.%[3]vSeq.Set(ctx, genState.%[3]vCount); err != nil {
-	panic(err)
+	return err
 }
 %[1]v`
 		replacementModuleInit := fmt.Sprintf(
@@ -149,12 +149,12 @@ err = k.%[2]v.Walk(ctx, nil, func(key uint64, elem types.%[2]v) (bool, error) {
 		return false, nil
 })
 if err != nil {
-	panic(err)
+	return err
 }
 
 genesis.%[2]vCount, err = k.%[2]vSeq.Peek(ctx)
 if err != nil {
-	panic(err)
+	return err
 }
 
 %[1]v`

--- a/ignite/templates/typed/list/genesis.go
+++ b/ignite/templates/typed/list/genesis.go
@@ -149,12 +149,12 @@ err = k.%[2]v.Walk(ctx, nil, func(key uint64, elem types.%[2]v) (bool, error) {
 		return false, nil
 })
 if err != nil {
-	return err
+	return nil, err
 }
 
 genesis.%[2]vCount, err = k.%[2]vSeq.Peek(ctx)
 if err != nil {
-	return err
+	return nil, err
 }
 
 %[1]v`

--- a/ignite/templates/typed/map/map.go
+++ b/ignite/templates/typed/map/map.go
@@ -420,7 +420,7 @@ for _, elem := range genState.%[3]vList {
 		genesis.%[2]vList = append(genesis.%[2]vList, val)
 		return false, nil
 	}); err != nil {
-		return err
+		return nil, err
 	}
 %[1]v`
 		replacementModuleExport := fmt.Sprintf(

--- a/ignite/templates/typed/map/map.go
+++ b/ignite/templates/typed/map/map.go
@@ -403,7 +403,7 @@ func genesisModuleModify(replacer placeholder.Replacer, opts *typed.Options) gen
 		templateModuleInit := `// Set all the %[2]v
 for _, elem := range genState.%[3]vList {
 	if err := k.%[3]v.Set(ctx, elem.%[4]v, elem); err != nil {
-		panic(err)
+		return err
 	}
 }
 %[1]v`
@@ -420,7 +420,7 @@ for _, elem := range genState.%[3]vList {
 		genesis.%[2]vList = append(genesis.%[2]vList, val)
 		return false, nil
 	}); err != nil {
-		panic(err)
+		return err
 	}
 %[1]v`
 		replacementModuleExport := fmt.Sprintf(

--- a/ignite/templates/typed/singleton/singleton.go
+++ b/ignite/templates/typed/singleton/singleton.go
@@ -390,7 +390,7 @@ if genState.%[3]v != nil {
 		templateModuleExport := `// Get all %[2]v
 %[2]v, err := k.%[3]v.Get(ctx)
 if err != nil {
-	return err
+	return nil, err
 }
 genesis.%[3]v = &%[2]v
 %[1]v`

--- a/ignite/templates/typed/singleton/singleton.go
+++ b/ignite/templates/typed/singleton/singleton.go
@@ -375,7 +375,7 @@ func genesisModuleModify(replacer placeholder.Replacer, opts *typed.Options) gen
 		templateModuleInit := `// Set if defined
 if genState.%[3]v != nil {
 	if err := k.%[3]v.Set(ctx, *genState.%[3]v); err != nil {
-		panic(err)
+		return err
 	}
 }
 %[1]v`
@@ -389,9 +389,10 @@ if genState.%[3]v != nil {
 
 		templateModuleExport := `// Get all %[2]v
 %[2]v, err := k.%[3]v.Get(ctx)
-if err == nil {
-	genesis.%[3]v = &%[2]v
+if err != nil {
+	return err
 }
+genesis.%[3]v = &%[2]v
 %[1]v`
 		replacementModuleExport := fmt.Sprintf(
 			templateModuleExport,


### PR DESCRIPTION
## Description

Avoid using a lot of panic calls into the `InitGenesis` and `ExportGenesis` methods and panic in the parent function. This also make the code more testable.