### PR TITLE
Comment out optimistic execution

### DIFF
--- a/ignite/templates/app/files-minimal/app/app.go.plush
+++ b/ignite/templates/app/files-minimal/app/app.go.plush
@@ -147,8 +147,8 @@ func New(
 	}
 
 	// add to default baseapp options
-	// enable optimistic execution
-	baseAppOptions = append(baseAppOptions, baseapp.SetOptimisticExecution())
+	// uncomment to enable Optimistic Execution
+	// baseAppOptions = append(baseAppOptions, baseapp.SetOptimisticExecution())
 
 	// build app
 	app.App = appBuilder.Build(db, traceStore, baseAppOptions...)


### PR DESCRIPTION
While I do think it makes sense to have OE as an easy to access option, I also have learned recently that OE can cause problems when using VE.

So my proposed solution is to comment it out in the template so that it can be easily re-enabled.