### PR TITLE
chore: do not proxy sentry dsn

### DIFF
--- a/ignite/cmd/ignite/main.go
+++ b/ignite/cmd/ignite/main.go
@@ -42,7 +42,7 @@ func run() int {
 	}
 	var wg sync.WaitGroup
 	analytics.SendMetric(&wg, subCmd)
-	analytics.EnableSentry(&wg, ctx)
+	analytics.EnableSentry(ctx, &wg)
 
 	err = cmd.ExecuteContext(ctx)
 	if err != nil {

--- a/ignite/cmd/testnet_inplace.go
+++ b/ignite/cmd/testnet_inplace.go
@@ -1,9 +1,9 @@
 package ignitecmd
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/spf13/cobra"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/ignite/cli/v29/ignite/pkg/cliui"
 	"github.com/ignite/cli/v29/ignite/pkg/cosmosaccount"

--- a/ignite/internal/analytics/analytics.go
+++ b/ignite/internal/analytics/analytics.go
@@ -101,7 +101,7 @@ func SendMetric(wg *sync.WaitGroup, cmd *cobra.Command) {
 }
 
 // EnableSentry enable errors reporting to Sentry.
-func EnableSentry(wg *sync.WaitGroup, ctx context.Context) {
+func EnableSentry(ctx context.Context, wg *sync.WaitGroup) {
 	dntInfo, err := checkDNT()
 	if err != nil || dntInfo.DoNotTrack {
 		return

--- a/ignite/pkg/announcements/announcement.go
+++ b/ignite/pkg/announcements/announcement.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ignite/cli/v29/ignite/pkg/cliui/icons"
 )
 
-var (
+const (
 	SurveyLink      = "https://bit.ly/3WZS2uS"
 	AnnouncementAPI = "http://api.ignite.com/announcements"
 )

--- a/ignite/pkg/announcements/announcement.go
+++ b/ignite/pkg/announcements/announcement.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ignite/cli/v29/ignite/pkg/cliui/icons"
 )
 
-const (
+var (
 	SurveyLink      = "https://bit.ly/3WZS2uS"
 	AnnouncementAPI = "http://api.ignite.com/announcements"
 )
@@ -19,7 +19,7 @@ type announcement struct {
 }
 
 func GetAnnouncements() string {
-	resp, err := http.Get(AnnouncementAPI)
+	resp, err := http.Get(AnnouncementAPI) //nolint:gosec
 	if err != nil || resp.StatusCode != 200 {
 		return fallbackData()
 	}

--- a/ignite/pkg/sentry/sentry.go
+++ b/ignite/pkg/sentry/sentry.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ignite/cli/v29/ignite/version"
 )
 
-const IgniteDNS = "https://bugs.ignite.com"
+const IgniteDNS = "https://1d862300ead01c5814d8ead3732fd41f@o1152630.ingest.us.sentry.io/4507891348930560"
 
 func InitSentry(ctx context.Context) (deferMe func(), err error) {
 	sentrySyncTransport := sentry.NewHTTPSyncTransport()


### PR DESCRIPTION
Due to the way the Sentry client parses the DSN, it isn't possible to use a proxy.
Otherwise, the request will all fail due to a wrong DSN.
We should just hardcode it in ignite, which is fine IMHO as sentry doesn't deprecate the DSN.
I have seen other open source Go project do the same.

Opened https://github.com/ignite/infraconfig/pull/6 to delete the proxy from infra.