### PR TITLE
fix: fix gentx parser into the cosmosutil package

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 - [#4000](https://github.com/ignite/cli/pull/4000) Run all dry runners before the wet run in the `xgenny` pkg
 - [#4091](https://github.com/ignite/cli/pull/4091) Fix race conditions in the plugin logic
 - [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
+- [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
 
 ## [`v28.5.3`](https://github.com/ignite/cli/releases/tag/v28.5.3)
 

--- a/ignite/pkg/cosmosutil/gentx.go
+++ b/ignite/pkg/cosmosutil/gentx.go
@@ -7,9 +7,8 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cometbft/cometbft/crypto/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/ignite/cli/v29/ignite/pkg/errors"
 )
@@ -17,7 +16,11 @@ import (
 type (
 	// GentxInfo represents the basic info about gentx file.
 	GentxInfo struct {
+		// Deprecated: Use of Delegator Address in MsgCreateValidator is deprecated.
+		// The validator address bytes and delegator address bytes refer to the same account while creating validator (defer
+		// only in bech32 notation).
 		DelegatorAddress string
+		ValidatorAddress string
 		PubKey           ed25519.PubKey
 		SelfDelegation   sdk.Coin
 		Memo             string
@@ -75,6 +78,7 @@ func ParseGentx(gentxBz []byte) (info GentxInfo, err error) {
 
 	info.Memo = gentx.Body.Memo
 	info.DelegatorAddress = gentx.Body.Messages[0].DelegatorAddress
+	info.ValidatorAddress = gentx.Body.Messages[0].ValidatorAddress
 
 	pb := gentx.Body.Messages[0].PubKey.Key
 	info.PubKey, err = base64.StdEncoding.DecodeString(pb)

--- a/ignite/pkg/cosmosutil/gentx_test.go
+++ b/ignite/pkg/cosmosutil/gentx_test.go
@@ -29,6 +29,7 @@ func TestParseGentx(t *testing.T) {
 			gentxPath: "testdata/gentx1.json",
 			wantInfo: cosmosutil.GentxInfo{
 				DelegatorAddress: "cosmos1dd246yq6z5vzjz9gh8cff46pll75yyl8ygndsj",
+				ValidatorAddress: "cosmosvaloper1dd246yq6z5vzjz9gh8cff46pll75yyl8pu8cup",
 				PubKey:           ed25519.PubKey(pk1),
 				SelfDelegation: sdk.Coin{
 					Denom:  "stake",
@@ -40,7 +41,8 @@ func TestParseGentx(t *testing.T) {
 			name:      "parse gentx file 2",
 			gentxPath: "testdata/gentx2.json",
 			wantInfo: cosmosutil.GentxInfo{
-				DelegatorAddress: "cosmos1mmlqwyqk7neqegffp99q86eckpm4pjah3ytlpa",
+				DelegatorAddress: "",
+				ValidatorAddress: "cosmosvaloper1mmlqwyqk7neqegffp99q86eckpm4pjah5sl2dw",
 				PubKey:           ed25519.PubKey(pk2),
 				SelfDelegation: sdk.Coin{
 					Denom:  "stake",

--- a/ignite/pkg/cosmosutil/testdata/gentx2.json
+++ b/ignite/pkg/cosmosutil/testdata/gentx2.json
@@ -37,7 +37,7 @@
           "max_rate": "0.200000000000000000",
           "rate": "0.100000000000000000"
         },
-        "delegator_address": "cosmos1mmlqwyqk7neqegffp99q86eckpm4pjah3ytlpa",
+        "delegator_address": "",
         "description": {
           "details": "",
           "identity": "",


### PR DESCRIPTION
Fix gentx parser into the cosmosutil package because the use of Delegator Address in MsgCreateValidator is deprecated

https://github.com/cosmos/cosmos-sdk/blob/8bfcf554275c1efbb42666cc8510d2da139b67fa/proto/cosmos/staking/v1beta1/tx.proto#L66-L69