### PR TITLE
docs(blog): fix pointer type and add build steps

### DIFF
--- a/docs/versioned_docs/version-v28/02-guide/04-blog.md
+++ b/docs/versioned_docs/version-v28/02-guide/04-blog.md
@@ -220,7 +220,7 @@ ignite scaffold message delete-post id:uint
 This command enables the deletion of posts by their ID.
 
 2. **Delete Logic:**
- 
+
 Implement RemovePost in `x/blog/keeper/post.go` to delete posts from the store.
 
 ```go title="x/blog/keeper/post.go"
@@ -301,7 +301,7 @@ func (k Keeper) ShowPost(goCtx context.Context, req *types.QueryShowPostRequest)
 		return nil, sdkerrors.ErrKeyNotFound
 	}
 
-	return &types.QueryShowPostResponse{Post: post}, nil
+	return &types.QueryShowPostResponse{Post: &post}, nil
 }
 ```
 
@@ -364,6 +364,12 @@ message QueryListPostResponse {
   repeated Post post = 1 [(gogoproto.nullable) = false];
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
+```
+
+Build the blockchain:
+
+```
+ignite chain build
 ```
 
 **Interacting with the Blog**

--- a/docs/versioned_docs/version-v28/02-guide/04-blog.md
+++ b/docs/versioned_docs/version-v28/02-guide/04-blog.md
@@ -111,7 +111,7 @@ Add the `PostKey` and `PostCountKey` functions to the `x/blog/types/keys.go` fil
 
 ```go title="x/blog/types/keys.go"
 	// PostKey is used to uniquely identify posts within the system.
-	// It will be used as the beginning of the key for each post, followed bei their unique ID
+	// It will be used as the beginning of the key for each post, followed by their unique ID
 	PostKey = "Post/value/"
 
 	// This key will be used to keep track of the ID of the latest post added to the store.

--- a/docs/versioned_docs/version-v28/02-guide/04-blog.md
+++ b/docs/versioned_docs/version-v28/02-guide/04-blog.md
@@ -372,6 +372,12 @@ Build the blockchain:
 ignite chain build
 ```
 
+Start the blockchain:
+
+```
+ignite chain serve
+```
+
 **Interacting with the Blog**
 
 1. **Create a Post:**


### PR DESCRIPTION
- Correct the error: The `Post` in `&types.QueryShowPostResponse` is a pointer type `Post *Post`
- Add a build statement before starting the blockchain; otherwise, the code will throw an error, which might confuse readers.
- fix comment: `bei` => `by`