### PR TITLE
FIX: Fixes violations of the linter rules on an empty scaffolded chain

### DIFF
--- a/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/testnet.go.plush
+++ b/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/testnet.go.plush
@@ -158,27 +158,37 @@ func initAppForTestnet(app *app.App, args valArgs) *app.App {
 	iterator.Close()
 
 	// Add our validator to power and last validators store
-	app.StakingKeeper.SetValidator(ctx, newVal)
-	err = app.StakingKeeper.SetValidatorByConsAddr(ctx, newVal)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-	app.StakingKeeper.SetValidatorByPowerIndex(ctx, newVal)
-	app.StakingKeeper.SetLastValidatorPower(ctx, validator, 0)
-	if err := app.StakingKeeper.Hooks().AfterValidatorCreated(ctx, validator); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
+	handleErr(app.StakingKeeper.SetValidator(ctx, newVal))
+	handleErr(app.StakingKeeper.SetValidatorByConsAddr(ctx, newVal))
+	handleErr(app.StakingKeeper.SetValidatorByPowerIndex(ctx, newVal))
+	handleErr(app.StakingKeeper.SetLastValidatorPower(ctx, validator, 0))
+	handleErr(app.StakingKeeper.Hooks().AfterValidatorCreated(ctx, validator))
+	
 	// DISTRIBUTION
 	//
 
 	// Initialize records for this validator across all distribution stores
-	app.DistrKeeper.ValidatorHistoricalRewards.Set(ctx, collections.Join(sdk.ValAddress(validator), uint64(0)), distrtypes.NewValidatorHistoricalRewards(sdk.DecCoins{}, 1))
-	app.DistrKeeper.ValidatorCurrentRewards.Set(ctx, validator, distrtypes.NewValidatorCurrentRewards(sdk.DecCoins{}, 1))
-	app.DistrKeeper.ValidatorsAccumulatedCommission.Set(ctx, validator, distrtypes.InitialValidatorAccumulatedCommission())
-	app.DistrKeeper.ValidatorOutstandingRewards.Set(ctx, validator, distrtypes.ValidatorOutstandingRewards{Rewards: sdk.DecCoins{}})
+	handleErr(app.DistrKeeper.ValidatorHistoricalRewards.Set(
+		ctx,
+		collections.Join(sdk.ValAddress(validator), uint64(0)),
+		distrtypes.NewValidatorHistoricalRewards(sdk.DecCoins{}, 1),
+	))
+
+	handleErr(app.DistrKeeper.ValidatorCurrentRewards.Set(
+		ctx,
+		validator,
+		distrtypes.NewValidatorCurrentRewards(sdk.DecCoins{}, 1),
+	))
+
+	handleErr(app.DistrKeeper.ValidatorsAccumulatedCommission.Set(
+		ctx, validator, distrtypes.InitialValidatorAccumulatedCommission(),
+	))
+
+	handleErr(app.DistrKeeper.ValidatorOutstandingRewards.Set(
+		ctx,
+		validator,
+		distrtypes.ValidatorOutstandingRewards{Rewards: sdk.DecCoins{}},
+	))
 	
 <%= if (!IsChainMinimal) { %>
 	// SLASHING
@@ -204,7 +214,6 @@ func initAppForTestnet(app *app.App, args valArgs) *app.App {
 
 	defaultCoins := sdk.NewCoins(sdk.NewInt64Coin(bondDenom, 1000000000))
 
-	// Fund local accounts
 	// Fund local accounts
 	for _, accountStr := range args.accountsToFund {
 		err := app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, defaultCoins)
@@ -266,4 +275,12 @@ func getCommandArgs(appOpts servertypes.AppOptions) (valArgs, error) {
 	args.homeDir = homeDir
 
 	return args, nil
+}
+
+// handleErr prints the error and exits the program if the error is not nil
+func handleErr(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
I noticed that when running the linter on an empty scaffolded chain, problems arise related to violating the rules of the ignite linter. Added a simple error handling function so as not to duplicate the same type of error handling only in places where it did not exist.

