### PR TITLE
refactor(templates): use go context instead of sdk.Context

### DIFF
--- a/ignite/templates/app/files/app/export.go.plush
+++ b/ignite/templates/app/files/app/export.go.plush
@@ -54,7 +54,7 @@ func (app *App) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAddrs
 // NOTE zero height genesis is a temporary feature which will be deprecated
 //
 //	in favor of export at a block height
-func (app *App) prepForZeroHeightGenesis(ctx context.Context, jailAllowedAddrs []string) {
+func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 
 	// check if there is a allowed address list

--- a/ignite/templates/app/files/app/export.go.plush
+++ b/ignite/templates/app/files/app/export.go.plush
@@ -54,7 +54,7 @@ func (app *App) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAddrs
 // NOTE zero height genesis is a temporary feature which will be deprecated
 //
 //	in favor of export at a block height
-func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
+func (app *App) prepForZeroHeightGenesis(ctx context.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 
 	// check if there is a allowed address list

--- a/ignite/templates/ibc/files/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
+++ b/ignite/templates/ibc/files/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
@@ -1,10 +1,10 @@
 package keeper
 
 import (
+	"context"
     "errors"
 
 	errorsmod "cosmossdk.io/errors"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"<%= ModulePath %>/x/<%= moduleName %>/types"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
@@ -14,7 +14,7 @@ import (
 
 // Transmit<%= packetName.UpperCamel %>Packet transmits the packet over IBC with the specified source port and source channel
 func (k Keeper) Transmit<%= packetName.UpperCamel %>Packet(
-    ctx sdk.Context,
+    ctx context.Context,
     packetData types.<%= packetName.UpperCamel %>PacketData,
 	sourcePort,
 	sourceChannel string,
@@ -35,7 +35,7 @@ func (k Keeper) Transmit<%= packetName.UpperCamel %>Packet(
 }
 
 // OnRecv<%= packetName.UpperCamel %>Packet processes packet reception
-func (k Keeper) OnRecv<%= packetName.UpperCamel %>Packet(ctx sdk.Context, packet channeltypes.Packet, data types.<%= packetName.UpperCamel %>PacketData) (packetAck types.<%= packetName.UpperCamel %>PacketAck, err error) {
+func (k Keeper) OnRecv<%= packetName.UpperCamel %>Packet(ctx context.Context, packet channeltypes.Packet, data types.<%= packetName.UpperCamel %>PacketData) (packetAck types.<%= packetName.UpperCamel %>PacketAck, err error) {
 	// validate packet data upon receiving
 
 	// TODO: packet reception logic
@@ -45,7 +45,7 @@ func (k Keeper) OnRecv<%= packetName.UpperCamel %>Packet(ctx sdk.Context, packet
 
 // OnAcknowledgement<%= packetName.UpperCamel %>Packet responds to the success or failure of a packet
 // acknowledgement written on the receiving chain.
-func (k Keeper) OnAcknowledgement<%= packetName.UpperCamel %>Packet(ctx sdk.Context, packet channeltypes.Packet, data types.<%= packetName.UpperCamel %>PacketData, ack channeltypes.Acknowledgement) error {
+func (k Keeper) OnAcknowledgement<%= packetName.UpperCamel %>Packet(ctx context.Context, packet channeltypes.Packet, data types.<%= packetName.UpperCamel %>PacketData, ack channeltypes.Acknowledgement) error {
 	switch dispatchedAck := ack.Response.(type) {
 	case *channeltypes.Acknowledgement_Error:
 
@@ -72,7 +72,7 @@ func (k Keeper) OnAcknowledgement<%= packetName.UpperCamel %>Packet(ctx sdk.Cont
 }
 
 // OnTimeout<%= packetName.UpperCamel %>Packet responds to the case where a packet has not been transmitted because of a timeout
-func (k Keeper) OnTimeout<%= packetName.UpperCamel %>Packet(ctx sdk.Context, packet channeltypes.Packet, data types.<%= packetName.UpperCamel %>PacketData) error {
+func (k Keeper) OnTimeout<%= packetName.UpperCamel %>Packet(ctx context.Context, packet channeltypes.Packet, data types.<%= packetName.UpperCamel %>PacketData) error {
 
     // TODO: packet timeout logic
 

--- a/ignite/templates/ibc/files/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
+++ b/ignite/templates/ibc/files/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	"context"
-    "errors"
+	"errors"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/ignite/templates/module/create/files/ibc/x/{{moduleName}}/module/module_ibc.go.plush
+++ b/ignite/templates/module/create/files/ibc/x/{{moduleName}}/module/module_ibc.go.plush
@@ -3,7 +3,9 @@ package <%= moduleName %>
 import (
 	"fmt"
 
+	"cosmossdk.io/core/event"
 	errorsmod "cosmossdk.io/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
@@ -193,28 +195,21 @@ func (im IBCModule) OnAcknowledgementPacket(
 		return errorsmod.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
 	}
 
-    ctx.EventManager().EmitEvent(
-        sdk.NewEvent(
-            eventType,
-            sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-            sdk.NewAttribute(types.AttributeKeyAck, fmt.Sprintf("%v", ack)),
-        ),
-    )
+	_ = im.EventService.EventManager(ctx).EmitKV(
+		eventType,
+		event.NewAttribute(types.AttributeKeyAck, fmt.Sprintf("%v", ack)),
+	)
 
 	switch resp := ack.Response.(type) {
 	case *channeltypes.Acknowledgement_Result:
-		ctx.EventManager().EmitEvent(
-			sdk.NewEvent(
-				eventType,
-				sdk.NewAttribute(types.AttributeKeyAckSuccess, string(resp.Result)),
-			),
+		_ = im.EventService.EventManager(ctx).EmitKV(
+			eventType,
+			event.NewAttribute(types.AttributeKeyAckSuccess, string(resp.Result)),
 		)
 	case *channeltypes.Acknowledgement_Error:
-		ctx.EventManager().EmitEvent(
-			sdk.NewEvent(
-				eventType,
-				sdk.NewAttribute(types.AttributeKeyAckError, resp.Error),
-			),
+		_ = im.EventService.EventManager(ctx).EmitKV(
+			eventType,
+			event.NewAttribute(types.AttributeKeyAckError, resp.Error),
 		)
 	}
 

--- a/ignite/templates/module/create/files/ibc/x/{{moduleName}}/module/module_ibc.go.plush
+++ b/ignite/templates/module/create/files/ibc/x/{{moduleName}}/module/module_ibc.go.plush
@@ -29,7 +29,7 @@ func NewIBCModule(k keeper.Keeper) IBCModule {
 
 // OnChanOpenInit implements the IBCModule interface
 func (im IBCModule) OnChanOpenInit(
-	ctx sdk.Context,
+	ctx context.Context,
 	order channeltypes.Order,
 	connectionHops []string,
 	portID string,
@@ -62,7 +62,7 @@ func (im IBCModule) OnChanOpenInit(
 
 // OnChanOpenTry implements the IBCModule interface
 func (im IBCModule) OnChanOpenTry(
-	ctx sdk.Context,
+	ctx context.Context,
 	order channeltypes.Order,
 	connectionHops []string,
 	portID,
@@ -101,7 +101,7 @@ func (im IBCModule) OnChanOpenTry(
 
 // OnChanOpenAck implements the IBCModule interface
 func (im IBCModule) OnChanOpenAck(
-	ctx sdk.Context,
+	ctx context.Context,
 	portID,
 	channelID string,
 	_,
@@ -115,7 +115,7 @@ func (im IBCModule) OnChanOpenAck(
 
 // OnChanOpenConfirm implements the IBCModule interface
 func (im IBCModule) OnChanOpenConfirm(
-	ctx sdk.Context,
+	ctx context.Context,
 	portID,
 	channelID string,
 ) error {
@@ -124,7 +124,7 @@ func (im IBCModule) OnChanOpenConfirm(
 
 // OnChanCloseInit implements the IBCModule interface
 func (im IBCModule) OnChanCloseInit(
-	ctx sdk.Context,
+	ctx context.Context,
 	portID,
 	channelID string,
 ) error {
@@ -134,7 +134,7 @@ func (im IBCModule) OnChanCloseInit(
 
 // OnChanCloseConfirm implements the IBCModule interface
 func (im IBCModule) OnChanCloseConfirm(
-	ctx sdk.Context,
+	ctx context.Context,
 	portID,
 	channelID string,
 ) error {
@@ -143,7 +143,7 @@ func (im IBCModule) OnChanCloseConfirm(
 
 // OnRecvPacket implements the IBCModule interface
 func (im IBCModule) OnRecvPacket(
-	ctx sdk.Context,
+	ctx context.Context,
 	modulePacket channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) ibcexported.Acknowledgement {
@@ -168,7 +168,7 @@ func (im IBCModule) OnRecvPacket(
 
 // OnAcknowledgementPacket implements the IBCModule interface
 func (im IBCModule) OnAcknowledgementPacket(
-	ctx sdk.Context,
+	ctx context.Context,
 	modulePacket channeltypes.Packet,
 	acknowledgement []byte,
 	relayer sdk.AccAddress,
@@ -223,7 +223,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 
 // OnTimeoutPacket implements the IBCModule interface
 func (im IBCModule) OnTimeoutPacket(
-	ctx sdk.Context,
+	ctx context.Context,
 	modulePacket channeltypes.Packet,
     relayer sdk.AccAddress,
 ) error {

--- a/integration/relayer/cmd_relayer_test.go
+++ b/integration/relayer/cmd_relayer_test.go
@@ -129,7 +129,7 @@ var (
 
 	nameOnRecvIbcPostPacket = "OnRecvIbcPostPacket"
 	funcOnRecvIbcPostPacket = `package keeper
-func (k Keeper) OnRecvIbcPostPacket(ctx sdk.Context, packet channeltypes.Packet, data types.IbcPostPacketData) (packetAck types.IbcPostPacketAck, err error) {
+func (k Keeper) OnRecvIbcPostPacket(ctx context.Context, packet channeltypes.Packet, data types.IbcPostPacketData) (packetAck types.IbcPostPacketAck, err error) {
 	packetAck.PostId, err = k.PostSeq.Next(ctx)
 	if err != nil {
 		return packetAck, err
@@ -139,7 +139,7 @@ func (k Keeper) OnRecvIbcPostPacket(ctx sdk.Context, packet channeltypes.Packet,
 
 	nameOnAcknowledgementIbcPostPacket = "OnAcknowledgementIbcPostPacket"
 	funcOnAcknowledgementIbcPostPacket = `package keeper
-func (k Keeper) OnAcknowledgementIbcPostPacket(ctx sdk.Context, packet channeltypes.Packet, data types.IbcPostPacketData, ack channeltypes.Acknowledgement) error {
+func (k Keeper) OnAcknowledgementIbcPostPacket(ctx context.Context, packet channeltypes.Packet, data types.IbcPostPacketData, ack channeltypes.Acknowledgement) error {
     switch dispatchedAck := ack.Response.(type) {
 	case *channeltypes.Acknowledgement_Error:
 		// We will not treat acknowledgment error in this tutorial
@@ -171,7 +171,7 @@ func (k Keeper) OnAcknowledgementIbcPostPacket(ctx sdk.Context, packet channelty
 
 	nameOnTimeoutIbcPostPacket = "OnTimeoutIbcPostPacket"
 	funcOnTimeoutIbcPostPacket = `package keeper
-func (k Keeper) OnTimeoutIbcPostPacket(ctx sdk.Context, packet channeltypes.Packet, data types.IbcPostPacketData) error {
+func (k Keeper) OnTimeoutIbcPostPacket(ctx context.Context, packet channeltypes.Packet, data types.IbcPostPacketData) error {
 	seq, err := k.TimeoutPostSeq.Next(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Follow-up of https://github.com/ignite/cli/pull/4432

Removal of sdk.Context in modules. The app (v1) should still have sdk.Context while in sdk v2 not.
Next PR is integrating SDK v2.