### PR TITLE
ci: fix linter in release/v28.x.y

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -3,8 +3,6 @@ name: Lint
 on:
   pull_request:
   push:
-    paths-ignore:
-      - "**.md"
     branches:
       - main
       - release/*
@@ -26,9 +24,10 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54.2
+          version: v1.60.3
           install-mode: goinstall
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
+          skip-save-cache: true

--- a/ignite/cmd/cmd.go
+++ b/ignite/cmd/cmd.go
@@ -60,7 +60,7 @@ To get started, create a blockchain:
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Args:          cobra.MinimumNArgs(0), // note(@julienrbrt): without this, ignite __complete(noDesc) hidden commands are not working.
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// Check for new versions only when shell completion scripts are not being
 			// generated to avoid invalid output to stdout when a new version is available
 			if cmd.Use != "completion" || !strings.HasPrefix(cmd.Use, cobra.ShellCompRequestCmd) {

--- a/ignite/cmd/doctor.go
+++ b/ignite/cmd/doctor.go
@@ -12,7 +12,7 @@ func NewDoctor() *cobra.Command {
 		Use:    "doctor",
 		Short:  "Fix chain configuration",
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			session := cliui.New()
 			defer session.End()
 

--- a/ignite/cmd/plugin.go
+++ b/ignite/cmd/plugin.go
@@ -416,7 +416,7 @@ func NewAppList() *cobra.Command {
 		Use:   "list",
 		Short: "List installed apps",
 		Long:  "Prints status and information of all installed Ignite Apps.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			s := cliui.New(cliui.WithStdout(os.Stdout))
 			return printPlugins(cmd.Context(), s)
 		},
@@ -433,7 +433,7 @@ func NewAppUpdate() *cobra.Command {
 If no path is specified all declared apps are updated.`,
 		Example: "ignite app update github.com/org/my-app/",
 		Args:    cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				// update all plugins
 				return plugin.Update(plugins...)

--- a/ignite/config/plugins/parse.go
+++ b/ignite/config/plugins/parse.go
@@ -17,20 +17,20 @@ import (
 // given names above are found, then an empty config is returned, w/o errors.
 func ParseDir(dir string) (*Config, error) {
 	// handy function that wraps and prefix err with a common label
-	errf := func(err error) (*Config, error) {
-		return nil, errors.Errorf("plugin config parse: %w", err)
+	errf := func(err error) error {
+		return errors.Errorf("plugin config parse: %w", err)
 	}
 	fi, err := os.Stat(dir)
 	if err != nil {
-		return errf(err)
+		return nil, errf(err)
 	}
 	if !fi.IsDir() {
-		return errf(errors.Errorf("path %s is not a dir", dir))
+		return nil, errf(errors.Errorf("path %s is not a dir", dir))
 	}
 
 	filename, err := locateFile(dir)
 	if err != nil {
-		return errf(err)
+		return nil, errf(err)
 	}
 	c := Config{
 		path: filename,
@@ -41,13 +41,13 @@ func ParseDir(dir string) (*Config, error) {
 		if os.IsNotExist(err) {
 			return &c, nil
 		}
-		return errf(err)
+		return nil, errf(err)
 	}
 	defer f.Close()
 
 	// if the error is end of file meaning an empty file on read return nil
 	if err := yaml.NewDecoder(f).Decode(&c); err != nil && !errors.Is(err, io.EOF) {
-		return errf(err)
+		return nil, errf(err)
 	}
 	return &c, nil
 }

--- a/ignite/pkg/cliui/entrywriter/entrywriter.go
+++ b/ignite/pkg/cliui/entrywriter/entrywriter.go
@@ -53,7 +53,7 @@ func Write(out io.Writer, header []string, entries ...[]string) error {
 		if len(entry) != len(header) {
 			return errors.Wrapf(ErrInvalidFormat, "entry %d doesn't match header length", i)
 		}
-		if _, err := fmt.Fprintf(w, formatLine(entry, false)+"\n"); err != nil {
+		if _, err := fmt.Fprint(w, formatLine(entry, false)+"\n"); err != nil {
 			return err
 		}
 	}

--- a/ignite/pkg/cosmostxcollector/adapter/postgres/schemas.go
+++ b/ignite/pkg/cosmostxcollector/adapter/postgres/schemas.go
@@ -82,7 +82,7 @@ func (s Schemas) WalkFrom(fromVersion uint64, fn SchemasWalkFunc) error {
 	paths := map[uint64]string{}
 
 	// Index the paths to the schemas with the matching versions
-	err := fs.WalkDir(s.fs, SchemasDir, func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(s.fs, SchemasDir, func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return errors.Errorf("failed to read schema %s: %w", path, err)
 		}

--- a/ignite/pkg/openapiconsole/console.go
+++ b/ignite/pkg/openapiconsole/console.go
@@ -13,7 +13,7 @@ var index embed.FS
 func Handler(title, specURL string) http.HandlerFunc {
 	t, _ := template.ParseFS(index, "index.tpl")
 
-	return func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		_ = t.Execute(w, struct {
 			Title string
 			URL   string

--- a/ignite/pkg/protoanalysis/protoutil/helpers.go
+++ b/ignite/pkg/protoanalysis/protoutil/helpers.go
@@ -179,7 +179,7 @@ func GetMessageByName(f *proto.Proto, name string) (node *proto.Message, err err
 			return ok
 		},
 		// return immediately iff found.
-		func(c *Cursor) bool { return !found })
+		func(*Cursor) bool { return !found })
 	if found {
 		return
 	}
@@ -210,7 +210,7 @@ func GetServiceByName(f *proto.Proto, name string) (node *proto.Service, err err
 			return ok
 		},
 		// return immediately iff found.
-		func(c *Cursor) bool { return !found })
+		func(*Cursor) bool { return !found })
 	if found {
 		return
 	}
@@ -241,7 +241,7 @@ func GetImportByPath(f *proto.Proto, path string) (node *proto.Import, err error
 			return ok
 		},
 		// return immediately iff found.
-		func(c *Cursor) bool { return !found })
+		func(*Cursor) bool { return !found })
 	if found {
 		return
 	}

--- a/ignite/services/scaffolder/type.go
+++ b/ignite/services/scaffolder/type.go
@@ -75,7 +75,7 @@ func SingletonType() AddTypeKind {
 
 // DryType only creates a type with a basic definition.
 func DryType() AddTypeKind {
-	return func(o *addTypeOptions) {}
+	return func(*addTypeOptions) {}
 }
 
 // TypeWithModule module to scaffold type into.

--- a/ignite/templates/field/datatype/custom.go
+++ b/ignite/templates/field/datatype/custom.go
@@ -16,7 +16,7 @@ var DataCustom = DataType{
 	ProtoType: func(datatype, name string, index int) string {
 		return fmt.Sprintf("%s %s = %d", datatype, name, index)
 	},
-	GenesisArgs: func(name multiformatname.Name, value int) string {
+	GenesisArgs: func(name multiformatname.Name, _ int) string {
 		return fmt.Sprintf("%s: new(types.%s),\n", name.UpperCamel, name.UpperCamel)
 	},
 	CLIArgs: func(name multiformatname.Name, datatype, prefix string, argIndex int) string {


### PR DESCRIPTION
Linter job is broken in release/v28.y.x (https://github.com/ignite/cli/actions/runs/12686175460/job/35358078508)
This brings the job from main to this branch