### PR TITLE
refactor!: sync with latest simulation changes + make it extensible

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,7 @@
 - [#4317](https://github.com/ignite/cli/pull/4317) Remove xchisel dependency
 - [#4361](https://github.com/ignite/cli/pull/4361) Remove unused `KeyPrefix` method
 - [#4384](https://github.com/ignite/cli/pull/4384) Compare genesis params into chain genesis tests
+- [#4463](https://github.com/ignite/cli/pull/4463) Run `chain simulation` with any simulation test case
 
 ### Fixes
 

--- a/ignite/cmd/chain_simulate.go
+++ b/ignite/cmd/chain_simulate.go
@@ -22,8 +22,8 @@ const (
 	flagSimappNumBlocks          = "numBlocks"
 	flagSimappBlockSize          = "blockSize"
 	flagSimappLean               = "lean"
-	flagSimappPeriod             = "period"
 	flagSimappGenesisTime        = "genesisTime"
+	flagSimName                  = "simName"
 )
 
 // NewChainSimulate creates a new simulation command to run the blockchain simulation.
@@ -31,7 +31,7 @@ func NewChainSimulate() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "simulate",
 		Short: "Run simulation testing for the blockchain",
-		Long:  "Run simulation testing for the blockchain. It sends many randomized-input messages of each module to a simulated node and checks if invariants break",
+		Long:  "Run simulation testing for the blockchain. It sends many randomized-input messages of each module to a simulated node.",
 		Args:  cobra.NoArgs,
 		RunE:  chainSimulationHandler,
 	}
@@ -41,8 +41,8 @@ func NewChainSimulate() *cobra.Command {
 
 func chainSimulationHandler(cmd *cobra.Command, _ []string) error {
 	var (
-		period, _      = cmd.Flags().GetUint(flagSimappPeriod)
 		genesisTime, _ = cmd.Flags().GetInt64(flagSimappGenesisTime)
+		simName, _     = cmd.Flags().GetString(flagSimName)
 		config         = newConfigFromFlags(cmd)
 		appPath        = flagGetPath(cmd)
 	)
@@ -62,7 +62,7 @@ func chainSimulationHandler(cmd *cobra.Command, _ []string) error {
 	}
 
 	return c.Simulate(cmd.Context(),
-		chain.SimappWithPeriod(period),
+		chain.SimappWithSimulationTestName(simName),
 		chain.SimappWithGenesisTime(genesisTime),
 		chain.SimappWithConfig(config),
 	)
@@ -114,6 +114,6 @@ func simappFlags(c *cobra.Command) {
 	c.Flags().Bool(flagSimappLean, false, "lean simulation log output")
 
 	// simulation flags
-	c.Flags().Uint(flagSimappPeriod, 0, "run slow invariants only once every period assertions")
+	c.Flags().String(flagSimName, "TestFullAppSimulation", "name of the simulation to run")
 	c.Flags().Int64(flagSimappGenesisTime, 0, "override genesis UNIX time instead of using a random UNIX time")
 }

--- a/ignite/pkg/chaincmd/runner/simulate.go
+++ b/ignite/pkg/chaincmd/runner/simulate.go
@@ -12,15 +12,15 @@ import (
 // Simulation run the chain simulation.
 func (r Runner) Simulation(
 	ctx context.Context,
-	appPath string,
+	appPath, simName string,
 	enabled bool,
 	config simulation.Config,
-	period uint,
 	genesisTime int64,
 ) error {
 	return r.run(ctx, runOptions{stdout: os.Stdout},
 		chaincmd.SimulationCommand(
 			appPath,
+			simName,
 			chaincmd.SimappWithGenesis(config.GenesisFile),
 			chaincmd.SimappWithParams(config.ParamsFile),
 			chaincmd.SimappWithExportParamsPath(config.ExportParamsPath),
@@ -34,7 +34,6 @@ func (r Runner) Simulation(
 			chaincmd.SimappWithLean(config.Lean),
 			chaincmd.SimappWithCommit(config.Commit),
 			chaincmd.SimappWithEnable(enabled),
-			chaincmd.SimappWithPeriod(period),
 			chaincmd.SimappWithGenesisTime(genesisTime),
 		))
 }

--- a/ignite/pkg/chaincmd/simulate.go
+++ b/ignite/pkg/chaincmd/simulate.go
@@ -1,12 +1,12 @@
 package chaincmd
 
 import (
+	"fmt"
 	"path/filepath"
 	"strconv"
 
 	"github.com/ignite/cli/v29/ignite/pkg/cmdrunner/step"
 	"github.com/ignite/cli/v29/ignite/pkg/gocmd"
-	"github.com/ignite/cli/v29/ignite/pkg/safeconverter"
 )
 
 const (
@@ -23,13 +23,11 @@ const (
 	optionSimappLean               = "-Lean"
 	optionSimappCommit             = "-Commit"
 	optionSimappEnabled            = "-Enabled"
-	optionSimappPeriod             = "-Period"
 	optionSimappGenesisTime        = "-GenesisTime"
 
-	commandGoTest     = "test"
-	optionGoBenchmem  = "-benchmem"
-	optionGoSimappRun = "-run=^TestFullAppSimulation$"
-	optionGoSimsTags  = "-tags='sims'"
+	commandGoTest    = "test"
+	optionGoBenchmem = "-benchmem"
+	optionGoSimsTags = "-tags='sims'"
 )
 
 // SimappOption for the SimulateCommand.
@@ -157,13 +155,6 @@ func SimappWithEnable(enable bool) SimappOption {
 	}
 }
 
-// SimappWithPeriod provides period option for the simapp command.
-func SimappWithPeriod(period uint) SimappOption {
-	return func(command []string) []string {
-		return append(command, optionSimappPeriod, strconv.Itoa(safeconverter.ToInt[uint](period)))
-	}
-}
-
 // SimappWithGenesisTime provides genesisTime option for the simapp command.
 func SimappWithGenesisTime(genesisTime int64) SimappOption {
 	return func(command []string) []string {
@@ -172,11 +163,16 @@ func SimappWithGenesisTime(genesisTime int64) SimappOption {
 }
 
 // SimulationCommand returns the cli command for simapp tests.
-func SimulationCommand(appPath string, options ...SimappOption) step.Option {
+// simName must be a test defined within the application (defaults to TestFullAppSimulation).
+func SimulationCommand(appPath string, simName string, options ...SimappOption) step.Option {
+	if simName == "" {
+		simName = "TestFullAppSimulation"
+	}
+
 	command := []string{
 		commandGoTest,
 		optionGoBenchmem,
-		optionGoSimappRun,
+		fmt.Sprintf("-run=^%s$", simName),
 		optionGoSimsTags,
 		filepath.Join(appPath, "app"),
 	}

--- a/ignite/services/chain/simulate.go
+++ b/ignite/services/chain/simulate.go
@@ -7,10 +7,10 @@ import (
 )
 
 type simappOptions struct {
-	enabled     bool
-	config      simulation.Config
-	period      uint
-	genesisTime int64
+	simulationTestName string
+	enabled            bool
+	config             simulation.Config
+	genesisTime        int64
 }
 
 func newSimappOptions() simappOptions {
@@ -19,20 +19,12 @@ func newSimappOptions() simappOptions {
 			Commit: true,
 		},
 		enabled:     true,
-		period:      0,
 		genesisTime: 0,
 	}
 }
 
 // SimappOption provides options for the simapp command.
 type SimappOption func(*simappOptions)
-
-// SimappWithPeriod allows running slow invariants only once every period assertions.
-func SimappWithPeriod(period uint) SimappOption {
-	return func(c *simappOptions) {
-		c.period = period
-	}
-}
 
 // SimappWithGenesisTime allows overriding genesis UNIX time instead of using a random UNIX time.
 func SimappWithGenesisTime(genesisTime int64) SimappOption {
@@ -45,6 +37,13 @@ func SimappWithGenesisTime(genesisTime int64) SimappOption {
 func SimappWithConfig(config simulation.Config) SimappOption {
 	return func(c *simappOptions) {
 		c.config = config
+	}
+}
+
+// SimappWithSimulationTestName allows to set the simulation test name.
+func SimappWithSimulationTestName(name string) SimappOption {
+	return func(c *simappOptions) {
+		c.simulationTestName = name
 	}
 }
 
@@ -62,9 +61,9 @@ func (c *Chain) Simulate(ctx context.Context, options ...SimappOption) error {
 	}
 	return commands.Simulation(ctx,
 		c.app.Path,
+		simappOptions.simulationTestName,
 		simappOptions.enabled,
 		simappOptions.config,
-		simappOptions.period,
 		simappOptions.genesisTime,
 	)
 }

--- a/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/commands.go.plush
+++ b/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/commands.go.plush
@@ -142,10 +142,6 @@ func appExport(
 		return servertypes.ExportedApp{}, errors.New("appOpts is not viper.Viper")
 	}
 
-	// overwrite the FlagInvCheckPeriod
-	viperAppOpts.Set(server.FlagInvCheckPeriod, 1)
-	appOpts = viperAppOpts
-
 	var bApp *app.App
 	if height != -1 {
 		bApp = app.New(logger, db, traceStore, false, appOpts)

--- a/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/commands.go.plush
+++ b/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/commands.go.plush
@@ -137,11 +137,6 @@ func appExport(
 	appOpts servertypes.AppOptions,
 	modulesToExport []string,
 ) (servertypes.ExportedApp, error) {
-	viperAppOpts, ok := appOpts.(*viper.Viper)
-	if !ok {
-		return servertypes.ExportedApp{}, errors.New("appOpts is not viper.Viper")
-	}
-
 	var bApp *app.App
 	if height != -1 {
 		bApp = app.New(logger, db, traceStore, false, appOpts)


### PR DESCRIPTION
Updates simulation with latest 0.52.
`-Period` got removed in https://github.com/cosmos/cosmos-sdk/pull/23341 as invariant isn't a thing in 0.52 anymore.

Additionally, this closes https://github.com/ignite/cli/issues/4308, by letting the user pass any sim test directly (default to the whole app simulation)