### PR TITLE
chore: prepare v28.7.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [`v28.7.0`](https://github.com/ignite/cli/releases/tag/v28.7.0)
+
 ### Features
 
 - [#4457](https://github.com/ignite/cli/pull/4457) Add `skip-build` flag to `chain serve` command to avoid (re)building the chain


### PR DESCRIPTION
# Release Notes

## 🚀 Highlights

This release adds a command to scaffold the necessary files to publish in the [chain-registry](https://github.com/cosmos/chain-registry). Go from devnet to testnet even faster with Ignite.

## 📝 Changelog

Following an exhaustive list of changes in this release:

### Features

- [#4457](https://github.com/ignite/cli/pull/4457) Add `skip-build` flag to `chain serve` command to avoid (re)building the chain
- [#4413](https://github.com/ignite/cli/pull/4413) Add `ignite s chain-registry` command
