### PR TITLE
chore: clean-up crisis from main

### DIFF
--- a/ignite/pkg/cosmosanalysis/app/app_test.go
+++ b/ignite/pkg/cosmosanalysis/app/app_test.go
@@ -120,7 +120,6 @@ func TestFindRegisteredModules(t *testing.T) {
 				"cosmossdk.io/x/authz/module",
 				"cosmossdk.io/x/bank",
 				"cosmossdk.io/x/consensus",
-				"cosmossdk.io/x/crisis",
 				"cosmossdk.io/x/distribution",
 				"cosmossdk.io/x/group/module",
 				"cosmossdk.io/x/mint",

--- a/ignite/pkg/cosmosanalysis/app/testdata/app_di.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/app_di.go
@@ -18,8 +18,6 @@ import (
 	bankkeeper "cosmossdk.io/x/bank/keeper"
 	consensus "cosmossdk.io/x/consensus"
 	consensuskeeper "cosmossdk.io/x/consensus/keeper"
-	"cosmossdk.io/x/crisis"
-	crisiskeeper "cosmossdk.io/x/crisis/keeper"
 	distr "cosmossdk.io/x/distribution"
 	distrkeeper "cosmossdk.io/x/distribution/keeper"
 	"cosmossdk.io/x/evidence"
@@ -88,7 +86,6 @@ var (
 			},
 		),
 		params.AppModuleBasic{},
-		crisis.AppModuleBasic{},
 		slashing.AppModuleBasic{},
 		feegrantmodule.AppModuleBasic{},
 		upgrade.AppModuleBasic{},
@@ -125,7 +122,6 @@ type SimApp struct {
 	MintKeeper            mintkeeper.Keeper
 	DistrKeeper           distrkeeper.Keeper
 	GovKeeper             *govkeeper.Keeper
-	CrisisKeeper          *crisiskeeper.Keeper
 	UpgradeKeeper         *upgradekeeper.Keeper
 	ParamsKeeper          paramskeeper.Keeper
 	AuthzKeeper           authzkeeper.Keeper
@@ -209,7 +205,6 @@ func NewSimApp(
 		&app.MintKeeper,
 		&app.DistrKeeper,
 		&app.GovKeeper,
-		&app.CrisisKeeper,
 		&app.UpgradeKeeper,
 		&app.ParamsKeeper,
 		&app.AuthzKeeper,
@@ -256,8 +251,6 @@ func NewSimApp(
 	}
 
 	/****  Module Options ****/
-
-	app.ModuleManager.RegisterInvariants(app.CrisisKeeper)
 
 	// RegisterUpgradeHandlers is used for registering any on-chain upgrades.
 	app.RegisterUpgradeHandlers()

--- a/ignite/pkg/cosmosanalysis/app/testdata/modules/app_config/app_config.go
+++ b/ignite/pkg/cosmosanalysis/app/testdata/modules/app_config/app_config.go
@@ -10,7 +10,6 @@ import (
 	bankmodulev1 "cosmossdk.io/api/cosmos/bank/module/v1"
 	circuitmodulev1 "cosmossdk.io/api/cosmos/circuit/module/v1"
 	consensusmodulev1 "cosmossdk.io/api/cosmos/consensus/module/v1"
-	crisismodulev1 "cosmossdk.io/api/cosmos/crisis/module/v1"
 	distrmodulev1 "cosmossdk.io/api/cosmos/distribution/module/v1"
 	evidencemodulev1 "cosmossdk.io/api/cosmos/evidence/module/v1"
 	feegrantmodulev1 "cosmossdk.io/api/cosmos/feegrant/module/v1"
@@ -34,8 +33,6 @@ import (
 	circuittypes "cosmossdk.io/x/circuit/types"
 	_ "cosmossdk.io/x/consensus" // import for side-effects
 	consensustypes "cosmossdk.io/x/consensus/types"
-	_ "cosmossdk.io/x/crisis" // import for side-effects
-	crisistypes "cosmossdk.io/x/crisis/types"
 	_ "cosmossdk.io/x/distribution" // import for side-effects
 	distrtypes "cosmossdk.io/x/distribution/types"
 	_ "cosmossdk.io/x/evidence" // import for side-effects
@@ -91,7 +88,6 @@ var (
 		slashingtypes.ModuleName,
 		govtypes.ModuleName,
 		minttypes.ModuleName,
-		crisistypes.ModuleName,
 		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
 		authz.ModuleName,
@@ -138,7 +134,6 @@ var (
 
 	endBlockers = []string{
 		// cosmos sdk modules
-		crisistypes.ModuleName,
 		govtypes.ModuleName,
 		stakingtypes.ModuleName,
 		feegrant.ModuleName,
@@ -281,10 +276,6 @@ var (
 			{
 				Name:   govtypes.ModuleName,
 				Config: appconfig.WrapAny(&govmodulev1.Module{}),
-			},
-			{
-				Name:   crisistypes.ModuleName,
-				Config: appconfig.WrapAny(&crisismodulev1.Module{}),
 			},
 			{
 				Name:   consensustypes.ModuleName,

--- a/ignite/pkg/cosmosanalysis/module/testdata/earth/app/app_config.go
+++ b/ignite/pkg/cosmosanalysis/module/testdata/earth/app/app_config.go
@@ -10,7 +10,6 @@ import (
 	bankmodulev1 "cosmossdk.io/api/cosmos/bank/module/v1"
 	circuitmodulev1 "cosmossdk.io/api/cosmos/circuit/module/v1"
 	consensusmodulev1 "cosmossdk.io/api/cosmos/consensus/module/v1"
-	crisismodulev1 "cosmossdk.io/api/cosmos/crisis/module/v1"
 	distrmodulev1 "cosmossdk.io/api/cosmos/distribution/module/v1"
 	evidencemodulev1 "cosmossdk.io/api/cosmos/evidence/module/v1"
 	feegrantmodulev1 "cosmossdk.io/api/cosmos/feegrant/module/v1"
@@ -34,8 +33,6 @@ import (
 	circuittypes "cosmossdk.io/x/circuit/types"
 	_ "cosmossdk.io/x/consensus" // import for side-effects
 	consensustypes "cosmossdk.io/x/consensus/types"
-	_ "cosmossdk.io/x/crisis" // import for side-effects
-	crisistypes "cosmossdk.io/x/crisis/types"
 	_ "cosmossdk.io/x/distribution" // import for side-effects
 	distrtypes "cosmossdk.io/x/distribution/types"
 	_ "cosmossdk.io/x/evidence" // import for side-effects
@@ -94,7 +91,6 @@ var (
 		slashingtypes.ModuleName,
 		govtypes.ModuleName,
 		minttypes.ModuleName,
-		crisistypes.ModuleName,
 		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
 		authz.ModuleName,
@@ -140,7 +136,6 @@ var (
 
 	endBlockers = []string{
 		// cosmos sdk modules
-		crisistypes.ModuleName,
 		govtypes.ModuleName,
 		stakingtypes.ModuleName,
 		feegrant.ModuleName,
@@ -289,10 +284,6 @@ var (
 			{
 				Name:   govtypes.ModuleName,
 				Config: appconfig.WrapAny(&govmodulev1.Module{}),
-			},
-			{
-				Name:   crisistypes.ModuleName,
-				Config: appconfig.WrapAny(&crisismodulev1.Module{}),
 			},
 			{
 				Name:   consensustypes.ModuleName,

--- a/ignite/services/scaffolder/module.go
+++ b/ignite/services/scaffolder/module.go
@@ -46,7 +46,6 @@ var (
 		"slashing":           {},
 		"gov":                {},
 		"mint":               {},
-		"crisis":             {},
 		"ibc":                {},
 		"genutil":            {},
 		"evidence":           {},
@@ -77,7 +76,6 @@ var (
 		"slashing",
 		"gov",
 		"mint",
-		"crisis",
 		"ibc",
 		"transfer", // IBC transfer
 		"feeibc",


### PR DESCRIPTION
Small PR that cleans up `x/crisis` from main.
That module isn't scaffolded anymore with a chain from v29, so no need to keep it around in tests.
Additionally, I'll make another PR to unwire it from v28 as it doesn't work anyway (https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-qfc5-6r3j-jj22)