### PR TITLE
fix: scaffold an `uint64 type crashs Ignite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,7 @@
 - [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
 - [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
 - [#4474](https://github.com/ignite/cli/pull/4474) Fix issue in `build --release` command
+- [#4479](https://github.com/ignite/cli/pull/4479) Scaffold an `uint64 type crashs Ignite
 
 ## [`v28.7.0`](https://github.com/ignite/cli/releases/tag/v28.7.0)
 

--- a/ignite/templates/field/datatype/types.go
+++ b/ignite/templates/field/datatype/types.go
@@ -18,10 +18,14 @@ const (
 	Bool Name = "bool"
 	// Int represents the int type name.
 	Int Name = "int"
+	// Int64 represents the int64 type name.
+	Int64 Name = "int64"
 	// IntSlice represents the int array type name.
 	IntSlice Name = "array.int"
 	// Uint represents the uint type name.
 	Uint Name = "uint"
+	// Uint64 represents the uint64 type name.
+	Uint64 Name = "uint64"
 	// UintSlice represents the uint array type name.
 	UintSlice Name = "array.uint"
 	// Coin represents the coin type name.
@@ -56,9 +60,11 @@ var supportedTypes = map[Name]DataType{
 	StringSliceAlias: DataStringSlice,
 	Bool:             DataBool,
 	Int:              DataInt,
+	Int64:            DataInt,
 	IntSlice:         DataIntSlice,
 	IntSliceAlias:    DataIntSlice,
 	Uint:             DataUint,
+	Uint64:           DataUint,
 	UintSlice:        DataUintSlice,
 	UintSliceAlias:   DataUintSlice,
 	Coin:             DataCoin,


### PR DESCRIPTION
close #4284

### Description

When we Scaffold a `uint64` type, Ignite understands it as a custom type because it is in the code but is not a valid default type. This PR adds `uint64` and `int64` as default types.

##### How to test

```shell
ignite scaffold params blocksPerYear:uint64 -y
```