### PR TITLE
fix: default flag parser for apps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 - [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
 - [#4474](https://github.com/ignite/cli/pull/4474) Fix issue in `build --release` command
 - [#4479](https://github.com/ignite/cli/pull/4479) Scaffold an `uint64 type crashs Ignite
+- [#4483](https://github.com/ignite/cli/pull/4483) Fix default flag parser for apps
 
 ## [`v28.7.0`](https://github.com/ignite/cli/releases/tag/v28.7.0)
 

--- a/ignite/services/plugin/flag.go
+++ b/ignite/services/plugin/flag.go
@@ -151,12 +151,5 @@ func flagValue(flag *Flag) string {
 	if flag.DefaultValue != "" {
 		return flag.DefaultValue
 	}
-	if flag.Type == FlagTypeBool ||
-		flag.Type == FlagTypeInt ||
-		flag.Type == FlagTypeInt64 ||
-		flag.Type == FlagTypeUint ||
-		flag.Type == FlagTypeUint64 {
-		return "0"
-	}
 	return ""
 }

--- a/ignite/services/plugin/flag.go
+++ b/ignite/services/plugin/flag.go
@@ -148,8 +148,5 @@ func flagValue(flag *Flag) string {
 	if flag.Value != "" {
 		return flag.Value
 	}
-	if flag.DefaultValue != "" {
-		return flag.DefaultValue
-	}
-	return ""
+	return flag.DefaultValue
 }

--- a/ignite/services/plugin/flag_test.go
+++ b/ignite/services/plugin/flag_test.go
@@ -94,7 +94,7 @@ func TestFlags_GetBool(t *testing.T) {
 			name: "flag without value and default value",
 			key:  flagBool3,
 			f:    testFlags,
-			want: false,
+			err:  errors.New("strconv.ParseBool: parsing \"\": invalid syntax"),
 		},
 		{
 			name: "invalid flag type",
@@ -159,7 +159,7 @@ func TestFlags_GetInt(t *testing.T) {
 			name: "flag without value and default value",
 			key:  flagInt3,
 			f:    testFlags,
-			want: 0,
+			err:  errors.New("strconv.Atoi: parsing \"\": invalid syntax"),
 		},
 		{
 			name: "invalid flag type",
@@ -183,7 +183,7 @@ func TestFlags_GetInt(t *testing.T) {
 			name: "wrong flag value without default or value",
 			key:  flagWrongType3,
 			f:    testFlags,
-			want: 0,
+			err:  errors.New("strconv.Atoi: parsing \"\": invalid syntax"),
 		},
 	}
 	for _, tt := range tests {
@@ -224,7 +224,7 @@ func TestFlags_GetInt64(t *testing.T) {
 			name: "flag without value and default value",
 			key:  flagInt643,
 			f:    testFlags,
-			want: 0,
+			err:  errors.New("strconv.ParseInt: parsing \"\": invalid syntax"),
 		},
 		{
 			name: "invalid flag type",
@@ -401,7 +401,7 @@ func TestFlags_GetUint(t *testing.T) {
 			name: "flag without value and default value",
 			key:  flagUint3,
 			f:    testFlags,
-			want: 0,
+			err:  errors.New("strconv.ParseUint: parsing \"\": invalid syntax"),
 		},
 		{
 			name: "invalid flag type",
@@ -460,7 +460,7 @@ func TestFlags_GetUint64(t *testing.T) {
 			name: "flag without value and default value",
 			key:  flagUint643,
 			f:    testFlags,
-			want: 0,
+			err:  errors.New("strconv.ParseUint: parsing \"\": invalid syntax"),
 		},
 		{
 			name: "invalid flag type",
@@ -582,7 +582,7 @@ func Test_flagValue(t *testing.T) {
 		{
 			name: "number without value and default value",
 			flag: &Flag{Name: flagUint642, Type: FlagTypeUint64},
-			want: "0",
+			want: "",
 		},
 	}
 	for _, tt := range tests {

--- a/ignite/services/plugin/grpc/v1/interface_flag.go
+++ b/ignite/services/plugin/grpc/v1/interface_flag.go
@@ -43,9 +43,6 @@ func (f *Flag) ExportToFlagSet(fs *pflag.FlagSet) error {
 		if f.DefaultValue == "" {
 			f.DefaultValue = "0"
 		}
-		if f.Value == "" {
-			f.Value = "0"
-		}
 	}
 
 	switch f.Type {
@@ -56,8 +53,10 @@ func (f *Flag) ExportToFlagSet(fs *pflag.FlagSet) error {
 		}
 
 		fs.BoolP(f.Name, f.Shorthand, v, f.Usage)
-		if err := fs.Set(f.Name, f.Value); err != nil {
-			return err
+		if f.Value != "" {
+			if err := fs.Set(f.Name, f.Value); err != nil {
+				return newDefaultFlagValueError(cobraFlagTypeBool, f.Value)
+			}
 		}
 	case Flag_TYPE_FLAG_INT:
 		v, err := strconv.Atoi(f.DefaultValue)
@@ -66,8 +65,10 @@ func (f *Flag) ExportToFlagSet(fs *pflag.FlagSet) error {
 		}
 
 		fs.IntP(f.Name, f.Shorthand, v, f.Usage)
-		if err := fs.Set(f.Name, f.Value); err != nil {
-			return err
+		if f.Value != "" {
+			if err := fs.Set(f.Name, f.Value); err != nil {
+				return newDefaultFlagValueError(cobraFlagTypeInt, f.Value)
+			}
 		}
 	case Flag_TYPE_FLAG_UINT:
 		v, err := strconv.ParseUint(f.DefaultValue, 10, 64)
@@ -76,8 +77,10 @@ func (f *Flag) ExportToFlagSet(fs *pflag.FlagSet) error {
 		}
 
 		fs.UintP(f.Name, f.Shorthand, uint(v), f.Usage)
-		if err := fs.Set(f.Name, f.Value); err != nil {
-			return err
+		if f.Value != "" {
+			if err := fs.Set(f.Name, f.Value); err != nil {
+				return newDefaultFlagValueError(cobraFlagTypeUint, f.Value)
+			}
 		}
 	case Flag_TYPE_FLAG_INT64:
 		v, err := strconv.ParseInt(f.DefaultValue, 10, 64)
@@ -86,29 +89,37 @@ func (f *Flag) ExportToFlagSet(fs *pflag.FlagSet) error {
 		}
 
 		fs.Int64P(f.Name, f.Shorthand, v, f.Usage)
-		if err := fs.Set(f.Name, f.Value); err != nil {
-			return err
+		if f.Value != "" {
+			if err := fs.Set(f.Name, f.Value); err != nil {
+				return newDefaultFlagValueError(cobraFlagTypeInt64, f.Value)
+			}
 		}
 	case Flag_TYPE_FLAG_UINT64:
 		v, err := strconv.ParseUint(f.DefaultValue, 10, 64)
 		if err != nil {
-			return newDefaultFlagValueError(cobraFlagTypeInt64, f.DefaultValue)
+			return newDefaultFlagValueError(cobraFlagTypeUint64, f.DefaultValue)
 		}
 
 		fs.Uint64P(f.Name, f.Shorthand, v, f.Usage)
-		if err := fs.Set(f.Name, f.Value); err != nil {
-			return err
+		if f.Value != "" {
+			if err := fs.Set(f.Name, f.Value); err != nil {
+				return newDefaultFlagValueError(cobraFlagTypeUint64, f.Value)
+			}
 		}
 	case Flag_TYPE_FLAG_STRING_SLICE:
 		s := strings.Trim(f.DefaultValue, "[]")
 		fs.StringSliceP(f.Name, f.Shorthand, strings.Fields(s), f.Usage)
-		if err := fs.Set(f.Name, strings.Trim(f.Value, "[]")); err != nil {
-			return err
+		if f.Value != "" {
+			if err := fs.Set(f.Name, strings.Trim(f.Value, "[]")); err != nil {
+				return newDefaultFlagValueError(cobraFlagTypeStringSlice, f.Value)
+			}
 		}
 	case Flag_TYPE_FLAG_STRING_UNSPECIFIED:
 		fs.StringP(f.Name, f.Shorthand, f.DefaultValue, f.Usage)
-		if err := fs.Set(f.Name, f.Value); err != nil {
-			return err
+		if f.Value != "" {
+			if err := fs.Set(f.Name, f.Value); err != nil {
+				return newDefaultFlagValueError(cobraFlagTypeString, f.Value)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Fix default values for app flags, it always gets zero if the value is not set