### PR TITLE
fix: set address prefix with sdk v0.52

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 - [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
 - [#4474](https://github.com/ignite/cli/pull/4474) Fix issue in `build --release` command
 - [#4479](https://github.com/ignite/cli/pull/4479) Scaffold an `uint64 type crashs Ignite
+- [#4486](https://github.com/ignite/cli/pull/4486) Fix issue when set account prefix with sdk v0.52
 
 ## [`v28.7.0`](https://github.com/ignite/cli/releases/tag/v28.7.0)
 

--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,7 @@
 - [#4361](https://github.com/ignite/cli/pull/4361) Remove unused `KeyPrefix` method
 - [#4384](https://github.com/ignite/cli/pull/4384) Compare genesis params into chain genesis tests
 - [#4463](https://github.com/ignite/cli/pull/4463) Run `chain simulation` with any simulation test case
+- [#4486](https://github.com/ignite/cli/pull/4486) Fix issue when set account prefix with sdk v0.52
 
 ### Fixes
 
@@ -56,7 +57,6 @@
 - [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
 - [#4474](https://github.com/ignite/cli/pull/4474) Fix issue in `build --release` command
 - [#4479](https://github.com/ignite/cli/pull/4479) Scaffold an `uint64 type crashs Ignite
-- [#4486](https://github.com/ignite/cli/pull/4486) Fix issue when set account prefix with sdk v0.52
 
 ## [`v28.7.0`](https://github.com/ignite/cli/releases/tag/v28.7.0)
 

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -837,7 +837,8 @@ func (c Client) newContext() client.Context {
 		WithGenerateOnly(c.generateOnly).
 		WithAddressCodec(addressCodec).
 		WithValidatorAddressCodec(validatorAddressCodec).
-		WithConsensusAddressCodec(consensusAddressCodec)
+		WithConsensusAddressCodec(consensusAddressCodec).
+		WithAddressPrefix(c.addressPrefix)
 }
 
 func newFactory(clientCtx client.Context) tx.Factory {

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -364,8 +364,6 @@ func New(ctx context.Context, options ...Option) (Client, error) {
 	if c.signer == nil {
 		c.signer = signer{}
 	}
-	// set address prefix in SDK global config
-	c.SetConfigAddressPrefix()
 
 	return c, nil
 }
@@ -466,16 +464,6 @@ func (c Client) Address(accountName string) (string, error) {
 // Context returns client context.
 func (c Client) Context() client.Context {
 	return c.context
-}
-
-// SetConfigAddressPrefix sets the account prefix in the SDK global config.
-func (c Client) SetConfigAddressPrefix() {
-	// TODO find a better way if possible.
-	// https://github.com/ignite/cli/issues/2744
-	mconf.Lock()
-	defer mconf.Unlock()
-	config := sdktypes.GetConfig()
-	config.SetBech32PrefixForAccount(c.addressPrefix, c.addressPrefix+"pub")
 }
 
 // Response of your broadcasted transaction.


### PR DESCRIPTION
Cosmos SDK v0.52 does not allow configuration changes when the Config is sealed.
`SetConfigAddressPrefix` function cannot be excuted after the Config is set, but instead must be used `WithAddressPrefix` in  client.Context.

Closes: https://github.com/ignite/cli/issues/2744