### PR TITLE
feat: integrate ibc x 0.52 (part 2/2)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@
 - [#4436](https://github.com/ignite/cli/pull/4436) Return tx hash to the faucet API
 - [#4437](https://github.com/ignite/cli/pull/4437) Remove module placeholders
 - [#4289](https://github.com/ignite/cli/pull/4289), [#4423](https://github.com/ignite/cli/pull/4423), [#4432](https://github.com/ignite/cli/pull/4432) Cosmos SDK v0.52 support
-- [#4477](https://github.com/ignite/cli/pull/4477) IBC v10 support
+- [#4477](https://github.com/ignite/cli/pull/4477), [#4492](https://github.com/ignite/cli/pull/4492) IBC v10 support
 - [#4166](https://github.com/ignite/cli/issues/4166) Migrate buf config files to v2
 
 ### Changes

--- a/ignite/cmd/plugin_test.go
+++ b/ignite/cmd/plugin_test.go
@@ -73,8 +73,6 @@ func assertFlags(t *testing.T, expectedFlags plugin.Flags, execCmd *plugin.Execu
 }
 
 func TestLinkPluginCmds(t *testing.T) {
-	t.Skip("passes locally and with act, but fails in CI")
-
 	var (
 		args         = []string{"arg1", "arg2"}
 		pluginParams = map[string]string{"key": "val"}
@@ -419,8 +417,6 @@ func dumpCmd(c *cobra.Command, w io.Writer, ntabs int) {
 }
 
 func TestLinkPluginHooks(t *testing.T) {
-	t.Skip("passes locally and with act, but fails in CI")
-
 	var (
 		args         = []string{"arg1", "arg2"}
 		pluginParams = map[string]string{"key": "val"}

--- a/ignite/pkg/cosmosclient/cosmosclient_test.go
+++ b/ignite/pkg/cosmosclient/cosmosclient_test.go
@@ -397,8 +397,6 @@ func TestClientStatus(t *testing.T) {
 }
 
 func TestClientCreateTx(t *testing.T) {
-	t.Skip() // TODO(@julienrbrt): Investigate timeout_timestamp fix need to by extended -> https://github.com/cosmos/cosmos-sdk/pull/22723. This will be done in a follow-up PR.
-
 	var (
 		ctx         = context.Background()
 		accountName = "bob"

--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -55,7 +55,7 @@ func (app *App) registerIBCModules(appOpts servertypes.AppOptions) error {
 	app.ParamsKeeper.Subspace(icacontrollertypes.SubModuleName).WithKeyTable(icacontrollertypes.ParamKeyTable())
 	app.ParamsKeeper.Subspace(icahosttypes.SubModuleName).WithKeyTable(icahosttypes.ParamKeyTable())
 
-	govModuleAddr := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+	govModuleAddr, _ := app.AuthKeeper.AddressCodec().BytesToString(authtypes.NewModuleAddress(govtypes.ModuleName))
 
 	// Create IBC keeper
 	app.IBCKeeper = ibckeeper.NewKeeper(


### PR DESCRIPTION
Follow-up of https://github.com/ignite/cli/pull/4477

- [ ] Bump dependencies to fix cosmosclient
- [ ] Fix relayer tests
- [ ] Fix double CLI flags (due to upstream bug as well)
- [ ] Rename IBC imports to /v10/ (pending IBC renaming in their main branch)