### PR TITLE
refactor(templates): do not use proto-builder

### DIFF
--- a/ignite/templates/app/files/Makefile.plush
+++ b/ignite/templates/app/files/Makefile.plush
@@ -63,16 +63,26 @@ install:
 ###  Protobuf  ###
 ##################
 
-# Use this proto-image if you do not want to use Ignite for generating proto files
-protoVer=0.15.1
-protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
-protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(protoImageName)
+# Use this target if you do not want to use Ignite for generating proto files
+GOLANG_PROTOBUF_VERSION=1.28.1
+GRPC_GATEWAY_VERSION=1.16.0
+GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION=2.20.0
+
+proto-deps:
+	@echo "Installing proto deps"
+	@go install github.com/bufbuild/buf/cmd/buf@v1.50.0
+	@go install github.com/cosmos/gogoproto/protoc-gen-gogo@latest
+	@go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest
+	@go install google.golang.org/protobuf/cmd/protoc-gen-go@v$(GOLANG_PROTOBUF_VERSION)
+	@go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v$(GRPC_GATEWAY_VERSION)
+	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v$(GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION)
+	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 proto-gen:
 	@echo "Generating protobuf files..."
 	@ignite generate proto-go --yes
 
-.PHONY: proto-gen
+.PHONY: proto-deps proto-gen
 
 #################
 ###  Linting  ###


### PR DESCRIPTION
Show how to install necessary proto dependencies (for those using buf directly) and not proto-builder (that may get out of date with go version change):

ref: https://github.com/cosmonity/example/commit/ac21eb6e9e77af68e4032a1f75af989b82fd9c18