### PR TITLE
Revert "fix: set address prefix with sdk v0.52 (#4486)"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -50,7 +50,6 @@
 - [#4361](https://github.com/ignite/cli/pull/4361) Remove unused `KeyPrefix` method
 - [#4384](https://github.com/ignite/cli/pull/4384) Compare genesis params into chain genesis tests
 - [#4463](https://github.com/ignite/cli/pull/4463) Run `chain simulation` with any simulation test case
-- [#4486](https://github.com/ignite/cli/pull/4486) Fix issue when set account prefix with sdk v0.52
 
 ### Fixes
 

--- a/ignite/pkg/cosmosclient/cosmosclient.go
+++ b/ignite/pkg/cosmosclient/cosmosclient.go
@@ -364,6 +364,8 @@ func New(ctx context.Context, options ...Option) (Client, error) {
 	if c.signer == nil {
 		c.signer = signer{}
 	}
+	// set address prefix in SDK global config
+	c.SetConfigAddressPrefix()
 
 	return c, nil
 }
@@ -464,6 +466,16 @@ func (c Client) Address(accountName string) (string, error) {
 // Context returns client context.
 func (c Client) Context() client.Context {
 	return c.context
+}
+
+// SetConfigAddressPrefix sets the account prefix in the SDK global config.
+func (c Client) SetConfigAddressPrefix() {
+	// TODO find a better way if possible.
+	// https://github.com/ignite/cli/issues/2744
+	mconf.Lock()
+	defer mconf.Unlock()
+	config := sdktypes.GetConfig()
+	config.SetBech32PrefixForAccount(c.addressPrefix, c.addressPrefix+"pub")
 }
 
 // Response of your broadcasted transaction.
@@ -837,8 +849,7 @@ func (c Client) newContext() client.Context {
 		WithGenerateOnly(c.generateOnly).
 		WithAddressCodec(addressCodec).
 		WithValidatorAddressCodec(validatorAddressCodec).
-		WithConsensusAddressCodec(consensusAddressCodec).
-		WithAddressPrefix(c.addressPrefix)
+		WithConsensusAddressCodec(consensusAddressCodec)
 }
 
 func newFactory(clientCtx client.Context) tx.Factory {


### PR DESCRIPTION
This reverts commit 8a382f92158f636bf9831cf3cc6309e8fe5d862b.
ref: https://github.com/ignite/cli/pull/4487#issuecomment-2649186038