### PR TITLE
fix(chaincmd): skip non json in JSONEnsuredBytes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,7 +58,7 @@
 - [#4091](https://github.com/ignite/cli/pull/4091) Fix race conditions in the plugin logic
 - [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
 - [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
-- [#4540](https://github.com/ignite/cli/pull/4540) Skip logs / gibberish when parsing commands
+- [#4540](https://github.com/ignite/cli/pull/4540) Skip logs / gibberish when parsing commands outputs
 
 ## [`v28.8.0`](https://github.com/ignite/cli/releases/tag/v28.8.0)
 

--- a/changelog.md
+++ b/changelog.md
@@ -58,7 +58,7 @@
 - [#4091](https://github.com/ignite/cli/pull/4091) Fix race conditions in the plugin logic
 - [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
 - [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
-- []() Skip logs / gibberish when parsing commands
+- [#4540](https://github.com/ignite/cli/pull/4540) Skip logs / gibberish when parsing commands
 
 ## [`v28.8.0`](https://github.com/ignite/cli/releases/tag/v28.8.0)
 

--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,7 @@
 - [#4091](https://github.com/ignite/cli/pull/4091) Fix race conditions in the plugin logic
 - [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
 - [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
+- []() Skip logs / gibberish when parsing commands
 
 ## [`v28.8.0`](https://github.com/ignite/cli/releases/tag/v28.8.0)
 

--- a/ignite/pkg/chaincmd/runner/runner.go
+++ b/ignite/pkg/chaincmd/runner/runner.go
@@ -165,7 +165,7 @@ func (b *buffer) JSONEnsuredBytes() ([]byte, error) {
 			bz = bz[startIndex : endIndex+1]
 
 			// Verify it's actually valid JSON
-			var jsonTest interface{}
+			var jsonTest any
 			if err := json.Unmarshal(bz, &jsonTest); err == nil {
 				return bz, nil
 			}

--- a/ignite/pkg/chaincmd/runner/runner.go
+++ b/ignite/pkg/chaincmd/runner/runner.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 
@@ -145,12 +146,43 @@ type buffer struct {
 func (b *buffer) JSONEnsuredBytes() ([]byte, error) {
 	bz := b.Bytes()
 
-	var out interface{}
+	// Attempt to find valid JSON in the buffer
+	startIndex := strings.IndexAny(string(bz), "{[")
+	if startIndex >= 0 {
+		// Check if we need to find the matching closing bracket
+		opening := bz[startIndex]
+		var closing byte
+		if opening == '{' {
+			closing = '}'
+		} else {
+			closing = ']'
+		}
 
+		// Look for the last matching closing bracket
+		endIndex := bytes.LastIndexByte(bz, closing)
+		if endIndex > startIndex {
+			// Extract what appears to be valid JSON
+			bz = bz[startIndex : endIndex+1]
+
+			// Verify it's actually valid JSON
+			var jsonTest interface{}
+			if err := json.Unmarshal(bz, &jsonTest); err == nil {
+				return bz, nil
+			}
+		}
+	}
+
+	// If we couldn't extract valid JSON, try parsing as YAML
+	var out interface{}
 	if err := yaml.Unmarshal(bz, &out); err == nil {
 		return yaml.YAMLToJSON(bz)
 	}
 
+	// If neither JSON nor YAML parsing succeeded, return the original bytes
+	// starting from the first opening brace if found, or the entire buffer
+	if startIndex >= 0 {
+		return bz[startIndex:], nil
+	}
 	return bz, nil
 }
 

--- a/ignite/pkg/chaincmd/runner/runner.go
+++ b/ignite/pkg/chaincmd/runner/runner.go
@@ -146,10 +146,10 @@ type buffer struct {
 func (b *buffer) JSONEnsuredBytes() ([]byte, error) {
 	bz := b.Bytes()
 
-	// Attempt to find valid JSON in the buffer
+	// check for valid json
 	startIndex := strings.IndexAny(string(bz), "{[")
 	if startIndex >= 0 {
-		// Check if we need to find the matching closing bracket
+		// check if we need to find the matching closing bracket
 		opening := bz[startIndex]
 		var closing byte
 		if opening == '{' {
@@ -158,13 +158,13 @@ func (b *buffer) JSONEnsuredBytes() ([]byte, error) {
 			closing = ']'
 		}
 
-		// Look for the last matching closing bracket
+		// look for the last matching closing bracket
 		endIndex := bytes.LastIndexByte(bz, closing)
 		if endIndex > startIndex {
-			// Extract what appears to be valid JSON
+			// extract what appears to be valid JSON
 			bz = bz[startIndex : endIndex+1]
 
-			// Verify it's actually valid JSON
+			// verify it's actually valid JSON
 			var jsonTest any
 			if err := json.Unmarshal(bz, &jsonTest); err == nil {
 				return bz, nil
@@ -172,17 +172,18 @@ func (b *buffer) JSONEnsuredBytes() ([]byte, error) {
 		}
 	}
 
-	// If we couldn't extract valid JSON, try parsing as YAML
-	var out interface{}
+	// fallback to yaml parsing
+	var out any
 	if err := yaml.Unmarshal(bz, &out); err == nil {
 		return yaml.YAMLToJSON(bz)
 	}
 
-	// If neither JSON nor YAML parsing succeeded, return the original bytes
+	// if neither JSON nor YAML parsing succeeded, return the original bytes
 	// starting from the first opening brace if found, or the entire buffer
 	if startIndex >= 0 {
 		return bz[startIndex:], nil
 	}
+
 	return bz, nil
 }
 


### PR DESCRIPTION
Should resolve the issue when using Go 1.24 with Ignite.
Won't solve the nasty logs sonic is printing however, as it will be fixed in https://github.com/ignite/cli/pull/4509 after the sonic library bump.