### PR TITLE
chore: prepare v29.0.0-beta.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [`v29.0.0-beta.1`](https://github.com/ignite/cli/releases/tag/v29.0.0-beta.1)
+
 ### Features
 
 - [#3707](https://github.com/ignite/cli/pull/3707) and [#4094](https://github.com/ignite/cli/pull/4094) Add collections support.


### PR DESCRIPTION
## 🚀 Highlights

Ignite CLI v29.0.0-beta.1 introduces **IBC-go v10 (IBC v2) support** and default **collections support**, enhancing blockchain interoperability and data management. Other key additions include `scaffold configs`, `scaffold params` commands, to help you best in your module development. New tools like `chain lint` and automatic buf config migration to v2 (via `ignite doctor`) have been added to streamline development, and much more!

The [`gen-mig-diffs`](https://tutorials.ignite.com/guide-to-use-gen-mig-diffs-for) tool can help you upgrade to v29 easily.
Any feedback and bug reports are welcome. Documentation is being updated to reflect this new beta.

## 📝 Changelog

Following an exhaustive list of changes in this release:

### Features

- [#3707](https://github.com/ignite/cli/pull/3707) and [#4094](https://github.com/ignite/cli/pull/4094) Add collections support.
- [#3977](https://github.com/ignite/cli/pull/3977) Add `chain lint` command to lint the chain's codebase using `golangci-lint`
- [#3770](https://github.com/ignite/cli/pull/3770) Add `scaffold configs` and `scaffold params` commands
- [#4001](https://github.com/ignite/cli/pull/4001) Improve `xgenny` dry run
- [#3967](https://github.com/ignite/cli/issues/3967) Add HD wallet parameters `address index` and `account number` to the chain account config
- [#4004](https://github.com/ignite/cli/pull/4004) Remove all import placeholders using the `xast` pkg
- [#4071](https://github.com/ignite/cli/pull/4071) Support custom proto path
- [#3718](https://github.com/ignite/cli/pull/3718) Add `gen-mig-diffs` tool app to compare scaffold output of two versions of ignite
- [#4100](https://github.com/ignite/cli/pull/4100) Set the `proto-dir` flag only for the `scaffold chain` command and use the proto path from the config
- [#4111](https://github.com/ignite/cli/pull/4111) Remove vuex generation
- [#4113](https://github.com/ignite/cli/pull/4113) Generate chain config documentation automatically
- [#4131](https://github.com/ignite/cli/pull/4131) Support `bytes` as data type in the `scaffold` commands
- [#4300](https://github.com/ignite/cli/pull/4300) Only panics the module in the most top function level
- [#4327](https://github.com/ignite/cli/pull/4327) Use the TxConfig from simState instead create a new one
- [#4326](https://github.com/ignite/cli/pull/4326) Add `buf.build` version to `ignite version` command
- [#4436](https://github.com/ignite/cli/pull/4436) Return tx hash to the faucet API
- [#4437](https://github.com/ignite/cli/pull/4437) Remove module placeholders
- [#4289](https://github.com/ignite/cli/pull/4289), [#4423](https://github.com/ignite/cli/pull/4423), [#4432](https://github.com/ignite/cli/pull/4432), [#4507](https://github.com/ignite/cli/pull/4507), [#4524](https://github.com/ignite/cli/pull/4524) Cosmos SDK v0.52 support and downgrade back to 0.50, while keeping latest improvements.
- [#4480](https://github.com/ignite/cli/pull/4480) Add field max length
- [#4477](https://github.com/ignite/cli/pull/4477) IBC v10 support
- [#4166](https://github.com/ignite/cli/issues/4166) Migrate buf config files to v2
- [#4494](https://github.com/ignite/cli/pull/4494) Automatic migrate the buf configs to v2

### Changes

- [#4094](https://github.com/ignite/cli/pull/4094) Scaffolding a multi-index map using `ignite s map foo bar baz --index foobar,foobaz` is no longer supported. Use one index instead of use `collections.IndexedMap`.
- [#4058](https://github.com/ignite/cli/pull/4058) Simplify scaffolded modules by including `ValidateBasic()` logic in message handler.
- [#4058](https://github.com/ignite/cli/pull/4058) Use `address.Codec` instead of `AccAddressFromBech32`.
- [#3993](https://github.com/ignite/cli/pull/3993) Oracle scaffolding was deprecated and has been removed
- [#3962](https://github.com/ignite/cli/pull/3962) Rename all RPC endpoints and autocli commands generated for `map`/`list`/`single` types
- [#3976](https://github.com/ignite/cli/pull/3976) Remove error checks for Cobra command value get calls
- [#4002](https://github.com/ignite/cli/pull/4002) Bump buf build
- [#4008](https://github.com/ignite/cli/pull/4008) Rename `pkg/yaml` to `pkg/xyaml`
- [#4075](https://github.com/ignite/cli/pull/4075) Use `gopkg.in/yaml.v3` instead `gopkg.in/yaml.v2`
- [#4118](https://github.com/ignite/cli/pull/4118) Version scaffolded protos as `v1` to follow SDK structure.
- [#4167](https://github.com/ignite/cli/pull/4167) Scaffold `int64` instead of `int32` when a field type is `int`
- [#4159](https://github.com/ignite/cli/pull/4159) Enable gci linter
- [#4160](https://github.com/ignite/cli/pull/4160) Enable copyloopvar linter
- [#4162](https://github.com/ignite/cli/pull/4162) Enable errcheck linter
- [#4189](https://github.com/ignite/cli/pull/4189) Deprecate `ignite node` for `ignite connect` app
- [#4290](https://github.com/ignite/cli/pull/4290) Remove ignite ics logic from ignite cli (this functionality will be in the `consumer` app)
- [#4295](https://github.com/ignite/cli/pull/4295) Stop scaffolding `pulsar` files
- [#4317](https://github.com/ignite/cli/pull/4317) Remove xchisel dependency
- [#4361](https://github.com/ignite/cli/pull/4361) Remove unused `KeyPrefix` method
- [#4384](https://github.com/ignite/cli/pull/4384) Compare genesis params into chain genesis tests
- [#4463](https://github.com/ignite/cli/pull/4463) Run `chain simulation` with any simulation test case
- [#4533](https://github.com/ignite/cli/pull/4533) Promote GitHub codespace instead of Gitpod

### Fixes

- [#4000](https://github.com/ignite/cli/pull/4000) Run all dry runners before the wet run in the `xgenny` pkg
- [#4091](https://github.com/ignite/cli/pull/4091) Fix race conditions in the plugin logic
- [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
- [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
- [#4552](https://github.com/ignite/cli/pull/4552) Avoid direct access to proto field `perms.Account` and `perms.Permissions`