### PR TITLE
docs: fix docs build

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,7 +10,7 @@ const config = {
   tagline: "Ignite Cli Docs",
   url: "https://docs.ignite.com",
   baseUrl: "/",
-  onBrokenLinks: "throw",
+  onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon-svg.svg",
   trailingSlash: false,
@@ -88,7 +88,8 @@ const config = {
     ({
       image: "img/og-image.jpg",
       announcementBar: {
-        content: '<a target="_blank" rel="noopener noreferrer" href="https://ignite.com">← Back to Ignite</a>',
+        content:
+          '<a target="_blank" rel="noopener noreferrer" href="https://ignite.com">← Back to Ignite</a>',
         isCloseable: false,
       },
       docs: {


### PR DESCRIPTION
ref: https://github.com/ignite/cli/actions/runs/13731942058/job/38410500388.
v0.25 isn't maintained, so I do not think updating it/keeping the link valid is possible nor makes sense.