### PR TITLE
feat: wire custom coin type and get bech32 prefix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - [#4509](https://github.com/ignite/cli/pull/4509) Upgrade to Go 1.24. Running `ignite doctor` migrates the scaffolded `tools.go` to the tool directive in the go.mod
 
+### Changes
+
+- [#4569](https://github.com/ignite/cli/pull/4569) Add flags to set coin type on commands. Add getters for bech32 prefix and coin type.
+
 ## [`v29.0.0-beta.1`](https://github.com/ignite/cli/releases/tag/v29.0.0-beta.1)
 
 ### Features

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ignite/cli/v29
 go 1.24.0
 
 require (
+	cosmossdk.io/core v0.11.2
 	cosmossdk.io/math v1.5.0
 	dario.cat/mergo v1.0.1
 	github.com/99designs/keyring v1.2.2
@@ -80,7 +81,6 @@ require (
 	connectrpc.com/otelconnect v0.7.1 // indirect
 	cosmossdk.io/api v0.7.6 // indirect
 	cosmossdk.io/collections v0.4.0 // indirect
-	cosmossdk.io/core v0.11.2 // indirect
 	cosmossdk.io/depinject v1.1.0 // indirect
 	cosmossdk.io/errors v1.0.1 // indirect
 	cosmossdk.io/log v1.4.1 // indirect

--- a/ignite/cmd/account.go
+++ b/ignite/cmd/account.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	flagAddressPrefix  = "address-prefix"
+	flagCoinType       = "coin-type"
 	flagPassphrase     = "passphrase"
 	flagNonInteractive = "non-interactive"
 	flagKeyringBackend = "keyring-backend"
@@ -100,6 +101,17 @@ func flagSetAccountPrefixes() *flag.FlagSet {
 func getAddressPrefix(cmd *cobra.Command) string {
 	prefix, _ := cmd.Flags().GetString(flagAddressPrefix)
 	return prefix
+}
+
+func flagSetCoinType() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.Uint32(flagCoinType, cosmosaccount.CoinTypeCosmos, "coin type to use for the account")
+	return fs
+}
+
+func getCoinType(cmd *cobra.Command) uint32 {
+	coinType, _ := cmd.Flags().GetUint32(flagCoinType)
+	return coinType
 }
 
 func flagSetAccountImport() *flag.FlagSet {

--- a/ignite/cmd/account_create.go
+++ b/ignite/cmd/account_create.go
@@ -16,6 +16,8 @@ func NewAccountCreate() *cobra.Command {
 		RunE:  accountCreateHandler,
 	}
 
+	c.Flags().AddFlagSet(flagSetCoinType())
+
 	return c
 }
 
@@ -29,6 +31,7 @@ func accountCreateHandler(cmd *cobra.Command, args []string) error {
 	ca, err := cosmosaccount.New(
 		cosmosaccount.WithKeyringBackend(getKeyringBackend(cmd)),
 		cosmosaccount.WithHome(getKeyringDir(cmd)),
+		cosmosaccount.WithCoinType(getCoinType(cmd)),
 	)
 	if err != nil {
 		return errors.Errorf("unable to create registry: %w", err)

--- a/ignite/cmd/account_import.go
+++ b/ignite/cmd/account_import.go
@@ -24,6 +24,7 @@ func NewAccountImport() *cobra.Command {
 
 	c.Flags().String(flagSecret, "", "Your mnemonic or path to your private key (use interactive mode instead to securely pass your mnemonic)")
 	c.Flags().AddFlagSet(flagSetAccountImport())
+	c.Flags().AddFlagSet(flagSetCoinType())
 
 	return c
 }
@@ -64,6 +65,7 @@ func accountImportHandler(cmd *cobra.Command, args []string) error {
 	ca, err := cosmosaccount.New(
 		cosmosaccount.WithKeyringBackend(getKeyringBackend(cmd)),
 		cosmosaccount.WithHome(getKeyringDir(cmd)),
+		cosmosaccount.WithCoinType(getCoinType(cmd)),
 	)
 	if err != nil {
 		return err

--- a/ignite/cmd/account_list.go
+++ b/ignite/cmd/account_list.go
@@ -22,6 +22,7 @@ func accountListHandler(cmd *cobra.Command, _ []string) error {
 	ca, err := cosmosaccount.New(
 		cosmosaccount.WithKeyringBackend(getKeyringBackend(cmd)),
 		cosmosaccount.WithHome(getKeyringDir(cmd)),
+		cosmosaccount.WithBech32Prefix(getAddressPrefix(cmd)),
 	)
 	if err != nil {
 		return err

--- a/ignite/cmd/account_show.go
+++ b/ignite/cmd/account_show.go
@@ -25,6 +25,7 @@ func accountShowHandler(cmd *cobra.Command, args []string) error {
 	ca, err := cosmosaccount.New(
 		cosmosaccount.WithKeyringBackend(getKeyringBackend(cmd)),
 		cosmosaccount.WithHome(getKeyringDir(cmd)),
+		cosmosaccount.WithBech32Prefix(getAddressPrefix(cmd)),
 	)
 	if err != nil {
 		return err

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -80,6 +80,7 @@ about Cosmos SDK on https://docs.cosmos.network
 
 	flagSetClearCache(c)
 	c.Flags().AddFlagSet(flagSetAccountPrefixes())
+	c.Flags().AddFlagSet(flagSetCoinType())
 	c.Flags().StringP(flagPath, "p", "", "create a project in a specific path")
 	c.Flags().Bool(flagNoDefaultModule, false, "create a project without a default module")
 	c.Flags().StringSlice(flagParams, []string{}, "add default module parameters")
@@ -102,6 +103,7 @@ func scaffoldChainHandler(cmd *cobra.Command, args []string) error {
 	var (
 		name          = args[0]
 		addressPrefix = getAddressPrefix(cmd)
+		coinType      = getCoinType(cmd)
 		appPath       = flagGetPath(cmd)
 
 		noDefaultModule, _ = cmd.Flags().GetBool(flagNoDefaultModule)
@@ -133,6 +135,7 @@ func scaffoldChainHandler(cmd *cobra.Command, args []string) error {
 		appPath,
 		name,
 		addressPrefix,
+		coinType,
 		protoDir,
 		noDefaultModule,
 		minimal,

--- a/ignite/cmd/scaffold_chain_registry.go
+++ b/ignite/cmd/scaffold_chain_registry.go
@@ -55,7 +55,7 @@ func scaffoldChainRegistryFiles(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if err = sc.AddChainRegistryFiles(c, cfg); err != nil {
+	if err = sc.CreateChainRegistryFiles(c, cfg); err != nil {
 		return err
 	}
 

--- a/ignite/pkg/chainregistry/chain.go
+++ b/ignite/pkg/chainregistry/chain.go
@@ -19,7 +19,7 @@ type Chain struct {
 	DaemonName   string      `json:"daemon_name"`
 	NodeHome     string      `json:"node_home"`
 	KeyAlgos     []KeyAlgos  `json:"key_algos"`
-	Slip44       int         `json:"slip44"`
+	Slip44       uint32      `json:"slip44"`
 	Fees         Fees        `json:"fees"`
 	Staking      Staking     `json:"staking"`
 	Codebase     Codebase    `json:"codebase"`

--- a/ignite/pkg/cosmosaccount/cosmosaccount.go
+++ b/ignite/pkg/cosmosaccount/cosmosaccount.go
@@ -9,13 +9,14 @@ import (
 	dkeyring "github.com/99designs/keyring"
 	"github.com/cosmos/go-bip39"
 
+	addresscodec "cosmossdk.io/core/address"
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/bech32"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/ignite/cli/v29/ignite/pkg/errors"
@@ -23,7 +24,7 @@ import (
 
 const (
 	// KeyringServiceName used for the name of keyring in OS backend.
-	KeyringServiceName = "starport"
+	KeyringServiceName = "ignite"
 
 	// DefaultAccount is the name of the default account.
 	DefaultAccount = "default"
@@ -35,6 +36,7 @@ var KeyringHome = os.ExpandEnv("$HOME/.ignite/accounts")
 var ErrAccountExists = errors.New("account already exists")
 
 const (
+	CoinTypeCosmos      = sdktypes.CoinType
 	AccountPrefixCosmos = "cosmos"
 )
 
@@ -59,6 +61,8 @@ type Registry struct {
 	homePath           string
 	keyringServiceName string
 	keyringBackend     KeyringBackend
+	addressCodec       addresscodec.Codec
+	coinType           uint32
 
 	Keyring keyring.Keyring
 }
@@ -84,12 +88,26 @@ func WithKeyringBackend(backend KeyringBackend) Option {
 	}
 }
 
+func WithBech32Prefix(prefix string) Option {
+	return func(c *Registry) {
+		c.addressCodec = address.NewBech32Codec(prefix)
+	}
+}
+
+func WithCoinType(coinType uint32) Option {
+	return func(c *Registry) {
+		c.coinType = coinType
+	}
+}
+
 // New creates a new registry to manage accounts.
 func New(options ...Option) (Registry, error) {
 	r := Registry{
 		keyringServiceName: sdktypes.KeyringServiceName(),
 		keyringBackend:     KeyringTest,
 		homePath:           KeyringHome,
+		addressCodec:       address.NewBech32Codec(AccountPrefixCosmos),
+		coinType:           CoinTypeCosmos,
 	}
 
 	for _, apply := range options {
@@ -146,7 +164,13 @@ func (a Account) Address(accPrefix string) (string, error) {
 		return "", err
 	}
 
-	return toBech32(accPrefix, pk.Address())
+	addressCodec := address.NewBech32Codec(accPrefix)
+	addr, err := addressCodec.BytesToString(pk.Address())
+	if err != nil {
+		return "", err
+	}
+
+	return addr, nil
 }
 
 // PubKey returns a public key for account.
@@ -157,14 +181,6 @@ func (a Account) PubKey() (string, error) {
 	}
 
 	return pk.String(), nil
-}
-
-func toBech32(prefix string, addr []byte) (string, error) {
-	bech32Addr, err := bech32.ConvertAndEncode(prefix, addr)
-	if err != nil {
-		return "", err
-	}
-	return bech32Addr, nil
 }
 
 // EnsureDefaultAccount ensures that default account exists.
@@ -289,11 +305,11 @@ func (r Registry) GetByName(name string) (Account, error) {
 
 // GetByAddress returns an account by its address.
 func (r Registry) GetByAddress(address string) (Account, error) {
-	sdkAddr, err := sdktypes.AccAddressFromBech32(address)
+	sdkAddr, err := r.addressCodec.StringToBytes(address)
 	if err != nil {
 		return Account{}, err
 	}
-	record, err := r.Keyring.KeyByAddress(sdkAddr)
+	record, err := r.Keyring.KeyByAddress(sdktypes.AccAddress(sdkAddr))
 	if errors.Is(err, dkeyring.ErrKeyNotFound) || errors.Is(err, sdkerrors.ErrKeyNotFound) {
 		return Account{}, &AccountDoesNotExistError{address}
 	}
@@ -335,7 +351,7 @@ func (r Registry) DeleteByName(name string) error {
 }
 
 func (r Registry) hdPath() string {
-	return hd.CreateHDPath(sdktypes.CoinType, 0, 0).String()
+	return hd.CreateHDPath(r.coinType, 0, 0).String()
 }
 
 func (r Registry) algo() (keyring.SignatureAlgo, error) {

--- a/ignite/pkg/cosmosaccount/cosmosaccount.go
+++ b/ignite/pkg/cosmosaccount/cosmosaccount.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/go-bip39"
 
 	addresscodec "cosmossdk.io/core/address"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/codec/types"

--- a/ignite/pkg/cosmosclient/bank.go
+++ b/ignite/pkg/cosmosclient/bank.go
@@ -26,7 +26,7 @@ func (c Client) BankBalances(ctx context.Context, address string, pagination *qu
 }
 
 func (c Client) BankSendTx(ctx context.Context, fromAccount cosmosaccount.Account, toAddress string, amount sdk.Coins) (TxService, error) {
-	addr, err := fromAccount.Address(c.addressPrefix)
+	addr, err := fromAccount.Address(c.bech32Prefix)
 	if err != nil {
 		return TxService{}, err
 	}

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ignite/cli/v29/ignite/pkg/cliui/colors"
 	uilog "github.com/ignite/cli/v29/ignite/pkg/cliui/log"
 	"github.com/ignite/cli/v29/ignite/pkg/confile"
+	"github.com/ignite/cli/v29/ignite/pkg/cosmosaccount"
 	"github.com/ignite/cli/v29/ignite/pkg/cosmosver"
 	"github.com/ignite/cli/v29/ignite/pkg/errors"
 	"github.com/ignite/cli/v29/ignite/pkg/events"
@@ -458,6 +459,39 @@ func (c *Chain) KeyringBackend() (chaincmd.KeyringBackend, error) {
 
 	// Use test backend as default when none is configured
 	return chaincmd.KeyringBackendTest, nil
+}
+
+// Bech32Prefix returns the bech32 prefix of the chain.
+func (c *Chain) Bech32Prefix() (string, error) {
+	// cfg, err := c.Config()
+	// if err != nil {
+	// 	return "", err
+	// }
+
+	//  cosmosutil.GetAddressPrefix
+
+	// 	validator, _ := chainconfig.FirstValidator(cfg)
+	// 	if validator.AddressPrefix != "" {
+	// 		return validator.AddressPrefix, nilc
+	// 	}
+
+	// 	return c.app.Bech32Prefix(), nil
+
+	return cosmosaccount.AccountPrefixCosmos, nil
+}
+
+func (c *Chain) CoinType() (uint32, error) {
+	// cfg, err := c.Config()
+	// if err != nil {
+	// 	return 0, err
+	// }
+
+	//  validator, _ := chainconfig.FirstValidator(cfg)
+	//  if validator.CoinType != 0 {
+	// 	 return validator.CoinType, nil
+	//  }
+
+	return cosmosaccount.CoinTypeCosmos, nil
 }
 
 // Commands returns the runner execute commands on the chain's binary.

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -463,34 +463,11 @@ func (c *Chain) KeyringBackend() (chaincmd.KeyringBackend, error) {
 
 // Bech32Prefix returns the bech32 prefix of the chain.
 func (c *Chain) Bech32Prefix() (string, error) {
-	// cfg, err := c.Config()
-	// if err != nil {
-	// 	return "", err
-	// }
-
-	//  cosmosutil.GetAddressPrefix
-
-	// 	validator, _ := chainconfig.FirstValidator(cfg)
-	// 	if validator.AddressPrefix != "" {
-	// 		return validator.AddressPrefix, nilc
-	// 	}
-
-	// 	return c.app.Bech32Prefix(), nil
-
 	return cosmosaccount.AccountPrefixCosmos, nil
 }
 
+// CoinType returns the coin type of the chain.
 func (c *Chain) CoinType() (uint32, error) {
-	// cfg, err := c.Config()
-	// if err != nil {
-	// 	return 0, err
-	// }
-
-	//  validator, _ := chainconfig.FirstValidator(cfg)
-	//  if validator.CoinType != 0 {
-	// 	 return validator.CoinType, nil
-	//  }
-
 	return cosmosaccount.CoinTypeCosmos, nil
 }
 

--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	uilog "github.com/ignite/cli/v29/ignite/pkg/cliui/log"
 	"github.com/ignite/cli/v29/ignite/pkg/confile"
 	"github.com/ignite/cli/v29/ignite/pkg/cosmosaccount"
+	"github.com/ignite/cli/v29/ignite/pkg/cosmosanalysis"
 	"github.com/ignite/cli/v29/ignite/pkg/cosmosver"
 	"github.com/ignite/cli/v29/ignite/pkg/errors"
 	"github.com/ignite/cli/v29/ignite/pkg/events"
@@ -461,16 +463,6 @@ func (c *Chain) KeyringBackend() (chaincmd.KeyringBackend, error) {
 	return chaincmd.KeyringBackendTest, nil
 }
 
-// Bech32Prefix returns the bech32 prefix of the chain.
-func (c *Chain) Bech32Prefix() (string, error) {
-	return cosmosaccount.AccountPrefixCosmos, nil
-}
-
-// CoinType returns the coin type of the chain.
-func (c *Chain) CoinType() (uint32, error) {
-	return cosmosaccount.CoinTypeCosmos, nil
-}
-
 // Commands returns the runner execute commands on the chain's binary.
 func (c *Chain) Commands(ctx context.Context) (chaincmdrunner.Runner, error) {
 	id, err := c.ID()
@@ -563,4 +555,119 @@ func expandHome(path string) (string, error) {
 		path = home + strings.TrimPrefix(path, "~")
 	}
 	return os.ExpandEnv(path), nil
+}
+
+// Bech32Prefix returns the bech32 prefix of the chain.
+func (c *Chain) Bech32Prefix() (string, error) {
+	prefix, err := c.parseAddressPrefix()
+	if err != nil || prefix == "" {
+		return cosmosaccount.AccountPrefixCosmos, err
+	}
+
+	return prefix, nil
+}
+
+// CoinType returns the coin type of the chain.
+func (c *Chain) CoinType() (uint32, error) {
+	coinType, err := c.parseCoinType()
+	if err != nil || coinType == 0 {
+		return cosmosaccount.CoinTypeCosmos, err
+	}
+
+	return coinType, nil
+}
+
+// parseAddressPrefix parses the address prefix from the app code.
+func (c *Chain) parseAddressPrefix() (string, error) {
+	appGoPath, err := c.findAppGoFile()
+	if err != nil {
+		return "", err
+	}
+
+	content, err := os.ReadFile(appGoPath)
+	if err != nil {
+		return "", err
+	}
+
+	// try to find the AccountAddressPrefix constant
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		// match both formats:
+		// AccountAddressPrefix = "cosmos"
+		// AccountAddressPrefix string = "cosmos"
+		if strings.Contains(line, "AccountAddressPrefix") && strings.Contains(line, "=") {
+			parts := strings.Split(line, "=")
+			if len(parts) < 2 {
+				continue
+			}
+
+			// extract the value within quotes
+			value := strings.TrimSpace(parts[1])
+			// remove comments if any
+			if idx := strings.Index(value, "//"); idx >= 0 {
+				value = value[:idx]
+			}
+			value = strings.TrimSpace(value)
+
+			// extract string between quotes
+			if start := strings.Index(value, "\""); start >= 0 {
+				if end := strings.Index(value[start+1:], "\""); end >= 0 {
+					return value[start+1 : start+1+end], nil
+				}
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// parseCoinType parses the coin type from the app code.
+func (c *Chain) parseCoinType() (uint32, error) {
+	appGoPath, err := c.findAppGoFile()
+	if err != nil {
+		return 0, err
+	}
+
+	content, err := os.ReadFile(appGoPath)
+	if err != nil {
+		return 0, err
+	}
+
+	// try to find the ChainCoinType constant
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "ChainCoinType") && strings.Contains(line, "=") {
+			parts := strings.Split(line, "=")
+			if len(parts) < 2 {
+				continue
+			}
+
+			// extract the numeric value
+			value := strings.TrimSpace(parts[1])
+			// remove comments if any
+			if idx := strings.Index(value, "//"); idx >= 0 {
+				value = value[:idx]
+			}
+			value = strings.TrimSpace(value)
+
+			// parse the value as uint32
+			var coinType uint32
+			if _, err := fmt.Sscanf(value, "%d", &coinType); err == nil {
+				return coinType, nil
+			}
+		}
+	}
+
+	return 0, nil
+}
+
+// findAppGoFile attempts to find the app.go file in the project.
+func (c *Chain) findAppGoFile() (string, error) {
+	// Look for the app.go file in common locations
+	commonPath := filepath.Join(c.app.Path, "app", "app.go")
+	if _, err := os.Stat(commonPath); err == nil {
+		return commonPath, nil
+	}
+
+	return cosmosanalysis.FindAppFilePath(c.app.Path)
 }

--- a/ignite/services/chain/chain_test.go
+++ b/ignite/services/chain/chain_test.go
@@ -29,6 +29,120 @@ func TestSourceVersion(t *testing.T) {
 	})
 }
 
+func TestBech32Prefix(t *testing.T) {
+	t.Run("default prefix when not specified", func(t *testing.T) {
+		dir, err := tempSourceWithApp(t)
+		require.NoError(t, err)
+		c, err := New(dir)
+		require.NoError(t, err)
+
+		prefix, err := c.Bech32Prefix()
+		require.NoError(t, err)
+
+		// Should return the default Cosmos prefix
+		assert.Equal(t, "cosmos", prefix)
+	})
+
+	t.Run("returns custom prefix when specified", func(t *testing.T) {
+		dir, err := tempSourceWithApp(t)
+		require.NoError(t, err)
+
+		// Create mock app.go with custom prefix
+		mockAppGo := `package app
+
+		const (
+			AccountAddressPrefix = "mars"
+		)
+		`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "app", "app.go"), []byte(mockAppGo), 0644))
+
+		c, err := New(dir)
+		require.NoError(t, err)
+
+		prefix, err := c.Bech32Prefix()
+		require.NoError(t, err)
+
+		assert.Equal(t, "mars", prefix)
+	})
+
+	t.Run("handles alternate prefix declaration format", func(t *testing.T) {
+		dir, err := tempSourceWithApp(t)
+		require.NoError(t, err)
+
+		// Create mock app.go with custom prefix in alternate format
+		mockAppGo := `package app
+
+		const AccountAddressPrefix string = "jupiter" // Some comment
+		`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "app", "app.go"), []byte(mockAppGo), 0644))
+
+		c, err := New(dir)
+		require.NoError(t, err)
+
+		prefix, err := c.Bech32Prefix()
+		require.NoError(t, err)
+
+		assert.Equal(t, "jupiter", prefix)
+	})
+}
+
+func TestCoinType(t *testing.T) {
+	t.Run("default coin type when not specified", func(t *testing.T) {
+		dir, err := tempSourceWithApp(t)
+		require.NoError(t, err)
+
+		c, err := New(dir)
+		require.NoError(t, err)
+
+		coinType, err := c.CoinType()
+		require.NoError(t, err)
+
+		assert.Equal(t, uint32(118), coinType)
+	})
+
+	t.Run("returns custom coin type when specified", func(t *testing.T) {
+		dir, err := tempSourceWithApp(t)
+		require.NoError(t, err)
+
+		// Create mock app.go with custom coin type
+		mockAppGo := `package app
+
+		const (
+			ChainCoinType = 529
+		)
+		`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "app", "app.go"), []byte(mockAppGo), 0644))
+
+		c, err := New(dir)
+		require.NoError(t, err)
+
+		coinType, err := c.CoinType()
+		require.NoError(t, err)
+
+		assert.Equal(t, uint32(529), coinType)
+	})
+
+	t.Run("handles coin type with comments", func(t *testing.T) {
+		dir, err := tempSourceWithApp(t)
+		require.NoError(t, err)
+
+		mockAppGo := `package app
+
+		// ChainCoinType is the coin type for this chain
+		const ChainCoinType = 330 // Custom coin type for test
+		`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "app", "app.go"), []byte(mockAppGo), 0644))
+
+		c, err := New(dir)
+		require.NoError(t, err)
+
+		coinType, err := c.CoinType()
+		require.NoError(t, err)
+
+		assert.Equal(t, uint32(330), coinType)
+	})
+}
+
 func tempSource(t *testing.T, tarPath string) (path string) {
 	t.Helper()
 
@@ -45,4 +159,32 @@ func tempSource(t *testing.T, tarPath string) (path string) {
 	require.NoError(t, err)
 
 	return filepath.Join(dir, dirs[0].Name())
+}
+
+func tempSourceWithApp(t *testing.T) (string, error) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	emptyFilesPaths := []string{
+		filepath.Join(tmpDir, "go.mod"),
+		filepath.Join(tmpDir, "app", "app.go"),
+	}
+
+	if err := os.WriteFile(emptyFilesPaths[0], []byte("module my-new-chain"), 0o755); err != nil {
+		return "", err
+	}
+
+	for _, f := range emptyFilesPaths[1:] {
+		if err := os.MkdirAll(filepath.Dir(f), 0o755); err != nil {
+			return "", err
+		}
+
+		if err := os.WriteFile(f, []byte("package my-new-chain"), 0o755); err != nil {
+			return "", err
+		}
+
+	}
+
+	return tmpDir, nil
 }

--- a/ignite/services/scaffolder/chain_registry.go
+++ b/ignite/services/scaffolder/chain_registry.go
@@ -80,19 +80,29 @@ func (s Scaffolder) AddChainRegistryFiles(chain *chain.Chain, cfg *chainconfig.C
 		}
 	}
 
+	bech32Prefix, err := chain.Bech32Prefix()
+	if err != nil {
+		return errors.Wrap(err, "failed to get bech32 prefix")
+	}
+
+	coinType, err := chain.CoinType()
+	if err != nil {
+		return errors.Wrap(err, "failed to get coin type")
+	}
+
 	chainData := chainregistry.Chain{
 		ChainName:    chain.Name(),
 		PrettyName:   chain.Name(),
 		ChainType:    chainregistry.ChainTypeCosmos,
 		Status:       chainregistry.ChainStatusUpcoming,
 		NetworkType:  chainregistry.NetworkTypeDevnet,
-		Website:      "https://example.com",
+		Website:      fmt.Sprintf("https://%s.zone", chain.Name()),
 		ChainID:      chainID,
-		Bech32Prefix: "cosmos",
+		Bech32Prefix: bech32Prefix,
 		DaemonName:   binaryName,
 		NodeHome:     chainHome,
 		KeyAlgos:     []chainregistry.KeyAlgos{chainregistry.KeyAlgoSecp256k1},
-		Slip44:       118,
+		Slip44:       coinType,
 		Fees: chainregistry.Fees{
 			FeeTokens: []chainregistry.FeeToken{
 				{

--- a/ignite/services/scaffolder/chain_registry.go
+++ b/ignite/services/scaffolder/chain_registry.go
@@ -21,8 +21,8 @@ const (
 	assetListFilename = "assetlist.json"
 )
 
-// AddChainRegistryFiles generates the chain registry files in the scaffolded chains.
-func (s Scaffolder) AddChainRegistryFiles(chain *chain.Chain, cfg *chainconfig.Config) error {
+// CreateChainRegistryFiles generates the chain registry files in the scaffolded chains.
+func (s Scaffolder) CreateChainRegistryFiles(chain *chain.Chain, cfg *chainconfig.Config) error {
 	binaryName, err := chain.Binary()
 	if err != nil {
 		return errors.Wrap(err, "failed to get binary name")

--- a/ignite/services/scaffolder/init.go
+++ b/ignite/services/scaffolder/init.go
@@ -19,7 +19,9 @@ import (
 func Init(
 	ctx context.Context,
 	runner *xgenny.Runner,
-	root, name, addressPrefix, protoDir string,
+	root, name, addressPrefix string,
+	coinType uint32,
+	protoDir string,
 	noDefaultModule, minimal bool,
 	params, moduleConfigs []string,
 ) (string, string, error) {
@@ -55,6 +57,7 @@ func Init(
 		runner,
 		pathInfo,
 		addressPrefix,
+		coinType,
 		protoDir,
 		path,
 		noDefaultModule,
@@ -70,7 +73,8 @@ func generate(
 	_ context.Context,
 	runner *xgenny.Runner,
 	pathInfo gomodulepath.Path,
-	addressPrefix,
+	addressPrefix string,
+	coinType uint32,
 	protoDir,
 	absRoot string,
 	noDefaultModule, minimal bool,
@@ -103,6 +107,7 @@ func generate(
 		GitHubPath:       githubPath,
 		BinaryNamePrefix: pathInfo.Root,
 		AddressPrefix:    addressPrefix,
+		CoinType:         coinType,
 		IsChainMinimal:   minimal,
 	})
 	if err != nil {

--- a/ignite/templates/app/app.go
+++ b/ignite/templates/app/app.go
@@ -38,6 +38,7 @@ func NewGenerator(opts *Options) (*genny.Generator, error) {
 		excludePrefix []string
 		overridesFS   = make(map[string]embed.FS)
 	)
+
 	if opts.IsChainMinimal {
 		// minimal chain does not have ibc
 		excludePrefix = append(excludePrefix, ibcConfig)
@@ -68,6 +69,7 @@ func NewGenerator(opts *Options) (*genny.Generator, error) {
 	ctx.Set("GitHubPath", opts.GitHubPath)
 	ctx.Set("BinaryNamePrefix", opts.BinaryNamePrefix)
 	ctx.Set("AddressPrefix", opts.AddressPrefix)
+	ctx.Set("CoinType", opts.CoinType)
 	ctx.Set("DepTools", cosmosgen.DepTools())
 	ctx.Set("IsChainMinimal", opts.IsChainMinimal)
 

--- a/ignite/templates/app/files-minimal/app/app.go.plush
+++ b/ignite/templates/app/files-minimal/app/app.go.plush
@@ -31,8 +31,12 @@ import (
 )
 
 const (
-	AccountAddressPrefix = "<%= AddressPrefix %>"
+	// Name is the name of the application.
 	Name                 = "<%= BinaryNamePrefix %>"
+	// AccountAddressPrefix is the prefix for accounts addresses.
+	AccountAddressPrefix = "<%= AddressPrefix %>"
+	// ChainCoinType is the coin type of the chain.
+	ChainCoinType        = <%= CoinType %>
 )
 
 // DefaultNodeHome default home directories for the application daemon

--- a/ignite/templates/app/files/app/app.go.plush
+++ b/ignite/templates/app/files/app/app.go.plush
@@ -50,8 +50,12 @@ import (
 )
 
 const (
-	AccountAddressPrefix = "<%= AddressPrefix %>"
+	// Name is the name of the application.
 	Name                 = "<%= BinaryNamePrefix %>"
+	// AccountAddressPrefix is the prefix for accounts addresses.
+	AccountAddressPrefix = "<%= AddressPrefix %>"
+	// ChainCoinType is the coin type of the chain.
+	ChainCoinType        = <%= CoinType %>
 )
 
 // DefaultNodeHome default home directories for the application daemon

--- a/ignite/templates/app/files/app/config.go.plush
+++ b/ignite/templates/app/files/app/config.go.plush
@@ -12,6 +12,7 @@ func init() {
 
 	// Set and seal config
 	config := sdk.GetConfig()
+	config.SetCoinType(ChainCoinType)
 	config.SetBech32PrefixForAccount(AccountAddressPrefix, accountPubKeyPrefix)
 	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
 	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)

--- a/ignite/templates/app/options.go
+++ b/ignite/templates/app/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	BinaryNamePrefix string
 	ModulePath       string
 	AddressPrefix    string
+	CoinType         uint32
 	// IncludePrefixes is used to filter the files to include from the generator
 	IncludePrefixes []string
 	IsChainMinimal  bool

--- a/integration/app/cmd_app_test.go
+++ b/integration/app/cmd_app_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ignite/cli/v29/ignite/pkg/cmdrunner/step"
+	"github.com/ignite/cli/v29/ignite/services/chain"
 	envtest "github.com/ignite/cli/v29/integration"
 )
 
@@ -200,6 +201,30 @@ func TestGenerateAppWithEmptyModule(t *testing.T) {
 		)),
 		envtest.ExecShouldError(),
 	))
+
+	app.EnsureSteady()
+}
+
+func TestGenerateAnAppWithAddressPrefix(t *testing.T) {
+	var (
+		env = envtest.New(t)
+		app = env.Scaffold("github.com/test/blog", "--address-prefix=gm", "--coin-type=60")
+	)
+
+	_, statErr := os.Stat(filepath.Join(app.SourcePath(), "x", "blog"))
+	require.False(t, os.IsNotExist(statErr), "the default module should be scaffolded")
+
+	c, err := chain.New(app.SourcePath())
+	require.NoError(t, err, "failed to get new chain")
+
+	bech32Prefix, err := c.Bech32Prefix()
+	require.NoError(t, err)
+
+	require.Equal(t, bech32Prefix, "gm")
+
+	coinType, err := c.CoinType()
+	require.NoError(t, err, "failed to get coin type")
+	require.Equal(t, coinType, uint32(60))
 
 	app.EnsureSteady()
 }


### PR DESCRIPTION
Add flags to set coin type on commands. Add getters for bech32 prefix and coin type.
It is useful for the chain-registry config, and web explorer config. 