### PR TITLE
fix: add missing light clients routes to IBC client keeper

### DIFF
--- a/ignite/templates/app/files/app/ibc.go.plush
+++ b/ignite/templates/app/files/app/ibc.go.plush
@@ -115,9 +115,14 @@ func (app *App) registerIBCModules(appOpts servertypes.AppOptions) error {
 
 	app.IBCKeeper.SetRouter(ibcRouter)
 
-	storeProvider := app.IBCKeeper.ClientKeeper.GetStoreProvider()
+	clientKeeper := app.IBCKeeper.ClientKeeper
+	storeProvider := clientKeeper.GetStoreProvider()
+
 	tmLightClientModule := ibctm.NewLightClientModule(app.appCodec, storeProvider)
+	clientKeeper.AddRoute(ibctm.ModuleName, &tmLightClientModule)
+
 	soloLightClientModule := solomachine.NewLightClientModule(app.appCodec, storeProvider)
+	clientKeeper.AddRoute(solomachine.ModuleName, &soloLightClientModule)
 
 	// register IBC modules
 	if err := app.RegisterModules(


### PR DESCRIPTION
### Description

Add solo machine and tendermint light clients routes to IBC client keeper.