### PR TITLE
feat(cosmosfaucet): loosen faucet check when indexer disabled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 - [#4613](https://github.com/ignite/cli/pull/4613) Improve and simplify prompting logic by bubbletea.
 - [#4615](https://github.com/ignite/cli/pull/4615) Fetch Ignite announcements from API.
 - [#4624](https://github.com/ignite/cli/pull/4624) Fix autocli templates for variadics.
+- [#4633](https://github.com/ignite/cli/pull/4633) Loosen faucet check when indexer disabled.
 
 ### Fixes
 

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -143,8 +143,7 @@ func Version(version cosmosver.Version) Option {
 }
 
 // IndexerDisabled tells whether the indexing is disabled on the node.
-// Without indexing, the faucet won't be able to check the limits for each account,
-// nor verify the transaction status.
+// Without indexing, the faucet won't be able to check the limits for each account, nor verify the transaction status.
 func IndexerDisabled() Option {
 	return func(f *Faucet) {
 		f.indexerDisabled = true

--- a/ignite/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/ignite/pkg/cosmosfaucet/cosmosfaucet.go
@@ -74,6 +74,9 @@ type Faucet struct {
 
 	// version holds the cosmos-sdk version.
 	version cosmosver.Version
+
+	// indexerDisabled tells whether the indexing is disabled on the node.
+	indexerDisabled bool
 }
 
 // Option configures the faucetOptions.
@@ -136,6 +139,15 @@ func OpenAPI(apiAddress string) Option {
 func Version(version cosmosver.Version) Option {
 	return func(f *Faucet) {
 		f.version = version
+	}
+}
+
+// IndexerDisabled tells whether the indexing is disabled on the node.
+// Without indexing, the faucet won't be able to check the limits for each account,
+// nor verify the transaction status.
+func IndexerDisabled() Option {
+	return func(f *Faucet) {
+		f.indexerDisabled = true
 	}
 }
 

--- a/ignite/pkg/cosmosfaucet/transfer.go
+++ b/ignite/pkg/cosmosfaucet/transfer.go
@@ -73,7 +73,7 @@ func (f *Faucet) Transfer(ctx context.Context, toAccountAddress string, coins sd
 	transfer := sdk.NewCoins()
 	// check for each coin, the max transferred amount hasn't been reached
 	for _, c := range coins {
-		if f.indexerDisabled { // we cannot check the amount if indexer is disabled
+		if f.indexerDisabled { // we cannot check the transfer history if indexer is disabled
 			transfer = transfer.Add(c)
 			continue
 		}

--- a/ignite/services/chain/faucet.go
+++ b/ignite/services/chain/faucet.go
@@ -141,6 +141,7 @@ func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
 }
 
 // indexerDisabled checks if the indexer is disabled in the config.yml.
+// More specifically, it checks if a kv indexer is used (psql indexer is not supported).
 func indexerDisabled(valCfg xyaml.Map) bool {
 	const txIndexKey = "tx_index"
 	v, ok := valCfg[txIndexKey]


### PR DESCRIPTION
Closes: https://github.com/ignite/cli/issues/4528

Ignite CLI will now check the user `config.yml` for an indexer override and skip the checks accordignly:

```yaml
validators:
  - name: alice
    bonded: 100000000stake
    config:
      tx_index:
        indexer: "null"
```