### PR TITLE
feat(xast): allow append arbitrary blocks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@
 - [#4601](https://github.com/ignite/cli/pull/4601) Add `appregistry` as default plugin
 - [#4613](https://github.com/ignite/cli/pull/4613) Improve and simplify prompting logic by bubbletea.
 - [#4624](https://github.com/ignite/cli/pull/4624) Fix autocli templates for variadics.
-- []() Allow append abritrary blocks in `AppendFuncAtLine`.
+- [#4643](https://github.com/ignite/cli/pull/4643) Allow append abritrary blocks in `AppendFuncAtLine`.
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - [#4601](https://github.com/ignite/cli/pull/4601) Add `appregistry` as default plugin
 - [#4613](https://github.com/ignite/cli/pull/4613) Improve and simplify prompting logic by bubbletea.
 - [#4624](https://github.com/ignite/cli/pull/4624) Fix autocli templates for variadics.
+- []() Allow append abritrary blocks in `AppendFuncAtLine`.
 
 ### Fixes
 

--- a/ignite/pkg/xast/function.go
+++ b/ignite/pkg/xast/function.go
@@ -83,6 +83,9 @@ func AppendFuncCode(code string) FunctionOptions {
 	}
 }
 
+// AppendFuncCodeAtLine append a new code at line.
+var AppendFuncCodeAtLine = AppendFuncAtLine
+
 // AppendFuncAtLine append a new code at line.
 func AppendFuncAtLine(code string, lineNumber uint64) FunctionOptions {
 	return func(c *functionOpts) {
@@ -252,16 +255,18 @@ func ModifyFunction(fileContent, functionName string, functions ...FunctionOptio
 				errInspect = errors.Errorf("line number %d out of range", newLine.number)
 				return false
 			}
+
 			// Parse the Go code to insert.
-			insertionExpr, err := parser.ParseExprFrom(fileSet, "", []byte(newLine.code), parser.ParseComments)
+			body, err := codeToBlockStmt(fileSet, newLine.code)
 			if err != nil {
 				errInspect = err
 				return false
 			}
+
 			// Insert code at the specified line number.
 			funcDecl.Body.List = append(
 				funcDecl.Body.List[:newLine.number],
-				append([]ast.Stmt{&ast.ExprStmt{X: insertionExpr}}, funcDecl.Body.List[newLine.number:]...)...,
+				append(body.List, funcDecl.Body.List[newLine.number:]...)...,
 			)
 		}
 

--- a/ignite/pkg/xast/function_test.go
+++ b/ignite/pkg/xast/function_test.go
@@ -72,6 +72,9 @@ func TestValidate(t *testing.T) {
 					ReplaceFuncBody(`return false`),
 					AppendFuncAtLine(`fmt.Println("Appended at line 0.")`, 0),
 					AppendFuncAtLine(`SimpleCall(foo, bar)`, 1),
+					AppendFuncAtLine(`if param1 == "" {
+						return false
+					}`, 2),
 					AppendFuncCode(`fmt.Println("Appended code.")`),
 					AppendFuncCode(`Param{Baz: baz, Foo: foo}`),
 					NewFuncReturn("1"),
@@ -99,6 +102,9 @@ func main() {
 func anotherFunction(param1 string) bool {
 	fmt.Println("Appended at line 0.", "test")
 	SimpleCall(baz, foo, bar, bla)
+	if param1 == "" {
+		return false
+	}
 	fmt.Println("Appended code.", "test")
 	Param{Baz: baz, Foo: foo, Bar: "bar"}
 	return 1
@@ -545,7 +551,7 @@ func TestValidate(t *testing.T) {
 				functionName: "anotherFunction",
 				functions:    []FunctionOptions{AppendFuncAtLine("9#.(c", 0)},
 			},
-			err: errors.New("1:2: illegal character U+0023 '#'"),
+			err: errors.New("1:24: illegal character U+0023 '#'"),
 		},
 		{
 			name: "invalid code append",


### PR DESCRIPTION
`AppendFuncAtLine` would only work with one line expression.
This fixes it by re-using `codeToBlockStmt`.