### PR TITLE
fix: Adjust GHA Dockerfile UID/GID and fix tarball_prefix quotes

### DIFF
--- a/actions/cli/Dockerfile
+++ b/actions/cli/Dockerfile
@@ -1,3 +1,4 @@
 FROM ignitehq/cli:latest
 
-USER root
+# Set the github runner user and group id
+USER 1001:121

--- a/actions/release/vars/action.yml
+++ b/actions/release/vars/action.yml
@@ -40,7 +40,7 @@ runs:
         echo "should_release=$should_release" >> $GITHUB_OUTPUT
         echo "is_release_type_latest=$is_release_type_latest" >> $GITHUB_OUTPUT
         echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-        echo "tarball_prefix='$repo_name'_$tag_name" >> $GITHUB_OUTPUT
+        echo "tarball_prefix=$repo_name_$tag_name" >> $GITHUB_OUTPUT
       shell: bash
     - run: |
         echo "- should_release: ${{ steps.vars.outputs.should_release }}"


### PR DESCRIPTION
### Problem with quotation marks in `tarball_prefix`

**Environment:**
- action version: v28.9.0
- reponame: kepler
- cosmos version: v0.50.13


**Step output:**
```bash
echo "- should_release: true"
echo "- is_release_type_latest: true"
echo "- tag_name: latest"
echo "- tarball_prefix: 'kepler'_latest"
```

**Result:**
```
fe7c65961ba0a91e097c75c78d68ecaf06d8ae078320ab2b5a11383a05f912d6  'kepler'_latest_darwin_amd64.tar.gz
64dd9ecf56ad50a195f6f493d5f10ed0ec9d95bf6b366d3a3c903fe8d11cb739  'kepler'_latest_darwin_arm64.tar.gz
e872fda69c7d951f5b626f32035b37876358f0addec13dc78d6c797f8dea8359  'kepler'_latest_linux_amd64.tar.gz
```

---

### Problem with `root` user in Dockerfile

Root was set, but I was having issues getting the `release_checksum` from:

```yaml
      - name: Publish the Release
        uses: softprops/action-gh-release@v1
        if: ${{ steps.vars.outputs.should_release == 'true' }}
        with:
          tag_name: ${{ steps.vars.outputs.tag_name }}
          files: release/*
          prerelease: true
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Error: `EACCES: permission denied, open 'release/release_checksum'`

I specified `1001:121` (these are GitHub runner IDs). It's quite possible that they didn't need to be specified at all, but I'm not deeply familiar with the GitHub runner architecture to say for certain whether specifying the user is strictly necessary. However, the current configuration works successfully.

