### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/ignite/pkg/cosmosutil/genesis/genesis.go
+++ b/ignite/pkg/cosmosutil/genesis/genesis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/ignite/cli/v29/ignite/pkg/jsonfile"
 )
@@ -83,12 +84,7 @@ func (g Genesis) HasAccount(address string) bool {
 	if err != nil {
 		return false
 	}
-	for _, account := range accounts {
-		if account == address {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(accounts, address)
 }
 
 // StakeDenom returns the stake denom from the genesis.

--- a/ignite/pkg/goanalysis/goanalysis.go
+++ b/ignite/pkg/goanalysis/goanalysis.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/mod/modfile"
@@ -139,10 +140,8 @@ func declVarExists(decl ast.Decl, methodDecl string) bool {
 		if err != nil {
 			return false
 		}
-		for _, decl := range decls {
-			if decl == methodDecl {
-				return true
-			}
+		if slices.Contains(decls, methodDecl) {
+			return true
 		}
 	}
 	return false

--- a/ignite/pkg/gomodule/gomodule.go
+++ b/ignite/pkg/gomodule/gomodule.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/mod/modfile"
@@ -63,11 +64,8 @@ func FilterVersions(dependencies []Version, paths ...string) []Version {
 	var filtered []Version
 
 	for _, dep := range dependencies {
-		for _, path := range paths {
-			if dep.Path == path {
-				filtered = append(filtered, dep)
-				break
-			}
+		if slices.Contains(paths, dep.Path) {
+			filtered = append(filtered, dep)
 		}
 	}
 

--- a/ignite/pkg/protoanalysis/protoanalysis.go
+++ b/ignite/pkg/protoanalysis/protoanalysis.go
@@ -4,6 +4,7 @@ package protoanalysis
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/ignite/cli/v29/ignite/pkg/errors"
@@ -94,13 +95,7 @@ func IsImported(path string, dependencies ...string) error {
 	}
 
 	for _, wantDep := range dependencies {
-		found := false
-		for _, fileDep := range f.Dependencies {
-			if wantDep == fileDep {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(f.Dependencies, wantDep)
 		if !found {
 			return errors.Wrap(ErrImportNotFound, fmt.Sprintf(
 				"invalid proto dependency %s for file %s", wantDep, path),


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.