### PR TITLE
feat: add verbose flag to scaffold and generate commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@
 - [#4624](https://github.com/ignite/cli/pull/4624) Fix autocli templates for variadics.
 - [#4644](https://github.com/ignite/cli/pull/4644) Improve UI and UX for `testnet multi-node` command.
 - [#4645](https://github.com/ignite/cli/pull/4645) Refactor the xast.ModifyFunction to improve the readability.
-- []() Add verbose flags on `scaffold` and `generate` commands.
+- [#4664](https://github.com/ignite/cli/pull/4664) Add verbose flags on `scaffold` and `generate` commands.
   - The flag displays the steps Ignite is taking to generate the code.
   - The verbosity only applies to the command. For full verbosity use the `IGNT_DEBUG` environment variable instead.
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,9 @@
 - [#4624](https://github.com/ignite/cli/pull/4624) Fix autocli templates for variadics.
 - [#4644](https://github.com/ignite/cli/pull/4644) Improve UI and UX for `testnet multi-node` command.
 - [#4645](https://github.com/ignite/cli/pull/4645) Refactor the xast.ModifyFunction to improve the readability.
+- []() Add verbose flags on `scaffold` and `generate` commands.
+  - The flag displays the steps Ignite is taking to generate the code.
+  - The verbosity only applies to the command. For full verbosity use the `IGNT_DEBUG` environment variable instead.
 
 ### Fixes
 

--- a/ignite/cmd/generate.go
+++ b/ignite/cmd/generate.go
@@ -28,6 +28,7 @@ meant to be edited by hand.
 	}
 
 	c.PersistentFlags().AddFlagSet(flagSetEnableProtoVendor())
+	c.PersistentFlags().AddFlagSet(flagSetVerbose())
 
 	flagSetPath(c)
 	flagSetClearCache(c)

--- a/ignite/cmd/scaffold.go
+++ b/ignite/cmd/scaffold.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ignite/cli/v29/ignite/pkg/cliui"
 	"github.com/ignite/cli/v29/ignite/pkg/cosmosver"
+	"github.com/ignite/cli/v29/ignite/pkg/env"
 	"github.com/ignite/cli/v29/ignite/pkg/errors"
 	"github.com/ignite/cli/v29/ignite/pkg/gocmd"
 	"github.com/ignite/cli/v29/ignite/pkg/xgit"
@@ -130,10 +131,20 @@ with an "--ibc" flag. Note that the default module is not IBC-enabled.
 		NewScaffoldChainRegistry(),
 	)
 
+	// same flag as for chain serve but different behavior
+	// the verbose flag on scaffold sets the IGNT_DEBUG env var
+	// while on serve it bypass the session logger for the app default
+	c.PersistentFlags().AddFlagSet(flagSetVerbose())
+
 	return c
 }
 
 func migrationPreRunHandler(cmd *cobra.Command, args []string) error {
+	if verbose := flagGetVerbose(cmd); verbose {
+		// sets the IGNT_DEBUG env var to enable verbose logging
+		env.SetDebug()
+	}
+
 	if err := gitChangesConfirmPreRunHandler(cmd, args); err != nil {
 		return err
 	}
@@ -314,4 +325,9 @@ func flagGetNoMessage(cmd *cobra.Command) bool {
 func flagGetSigner(cmd *cobra.Command) string {
 	signer, _ := cmd.Flags().GetString(flagSigner)
 	return signer
+}
+
+func flagGetVerbose(cmd *cobra.Command) bool {
+	verbose, _ := cmd.Flags().GetBool(flagVerbose)
+	return verbose
 }

--- a/ignite/cmd/scaffold_chain.go
+++ b/ignite/cmd/scaffold_chain.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ignite/cli/v29/ignite/config/chain/defaults"
 	"github.com/ignite/cli/v29/ignite/pkg/cliui"
+	"github.com/ignite/cli/v29/ignite/pkg/env"
 	"github.com/ignite/cli/v29/ignite/pkg/errors"
 	"github.com/ignite/cli/v29/ignite/pkg/xfilepath"
 	"github.com/ignite/cli/v29/ignite/pkg/xgenny"
@@ -75,6 +76,11 @@ The blockchain is using the Cosmos SDK modular blockchain framework. Learn more
 about Cosmos SDK on https://docs.cosmos.network
 `,
 		Args: cobra.ExactArgs(1),
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			if verbose := flagGetVerbose(cmd); verbose {
+				env.SetDebug()
+			}
+		},
 		RunE: scaffoldChainHandler,
 	}
 

--- a/ignite/pkg/cmdrunner/cmdrunner.go
+++ b/ignite/pkg/cmdrunner/cmdrunner.go
@@ -81,7 +81,7 @@ func EnableDebug() Option {
 func New(options ...Option) *Runner {
 	runner := &Runner{
 		endSignal: os.Interrupt,
-		debug:     env.DebugEnabled(),
+		debug:     env.IsDebug(),
 	}
 	for _, apply := range options {
 		apply(runner)

--- a/ignite/pkg/env/env.go
+++ b/ignite/pkg/env/env.go
@@ -13,7 +13,15 @@ const (
 	configDir = "IGNT_CONFIG_DIR"
 )
 
-func DebugEnabled() bool {
+// SetDebug sets the debug environment variable to "1".
+// This is used to enable debug mode in the application.
+func SetDebug() {
+	_ = os.Setenv(debug, "1")
+}
+
+// IsDebug checks if the debug environment variable is set to "1".
+// This is used to determine if the application is running in debug mode.
+func IsDebug() bool {
 	return os.Getenv(debug) == "1"
 }
 

--- a/ignite/services/plugin/plugin.go
+++ b/ignite/services/plugin/plugin.go
@@ -275,7 +275,7 @@ func (p *Plugin) load(ctx context.Context) {
 	}
 	// Create an hclog.Logger
 	logLevel := hclog.Error
-	if env.DebugEnabled() {
+	if env.IsDebug() {
 		logLevel = hclog.Trace
 	}
 	logger := hclog.New(&hclog.LoggerOptions{


### PR DESCRIPTION
Closes: https://github.com/ignite/cli/issues/3077

While the environment variable was doing what this issue was requesting, adding it to the command makes the UX better and the verbosity only apply for the CLI part only (and not the plugin part).