### PR TITLE
fix(templates): make v29 compatible with wasm app

### DIFF
--- a/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/commands.go.plush
+++ b/ignite/templates/app/files/cmd/{{binaryNamePrefix}}d/cmd/commands.go.plush
@@ -42,7 +42,9 @@ func initRootCmd(
 		snapshot.Cmd(newApp),
 	)
 
-	server.AddCommandsWithStartCmdOptions(rootCmd, app.DefaultNodeHome, newApp, appExport, server.StartCmdOptions{})
+	server.AddCommandsWithStartCmdOptions(rootCmd, app.DefaultNodeHome, newApp, appExport, server.StartCmdOptions{
+		AddFlags: addModuleInitFlags,
+	})
 
 	// add keybase, auxiliary RPC, query, genesis, and tx child commands
 	rootCmd.AddCommand(
@@ -54,6 +56,9 @@ func initRootCmd(
 	)
 }
 
+// addModuleInitFlags adds more flags to the start command.
+func addModuleInitFlags(startCmd *cobra.Command) {
+}
 
 func queryCommand() *cobra.Command {
 	cmd := &cobra.Command{


### PR DESCRIPTION
The wasm app adds the flags to `addModuleInitFlags`, which is great, as multiple app may add flags (think of rollkit + 
cosmwasm).

We should re-add this to the template as no-op to not break plugins.