### PR TITLE
refactor(templates): harden `IsSlice`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 - [#4658](https://github.com/ignite/cli/pull/4658) Fix indentation for params scaffolded into a struct.
 - [#4582](https://github.com/ignite/cli/issues/4582) Fix xast misplacing comments.
 - [#4660](https://github.com/ignite/cli/pull/4660) Fix xast test case indentation.
+- [#4667](https://github.com/ignite/cli/pull/4667) Harden `IsSlice`
 
 ## [`v29.0.0-beta.1`](https://github.com/ignite/cli/releases/tag/v29.0.0-beta.1)
 

--- a/ignite/templates/field/field.go
+++ b/ignite/templates/field/field.go
@@ -38,12 +38,22 @@ func (f Field) IsSlice() bool {
 	case datatype.StringSlice,
 		datatype.IntSlice,
 		datatype.UintSlice,
+		datatype.Coins,
 		datatype.StringSliceAlias,
 		datatype.IntSliceAlias,
 		datatype.UintSliceAlias,
-		datatype.CoinSliceAlias:
+		datatype.CoinSliceAlias,
+		datatype.Bytes:
 		return true
-	case datatype.Coin, datatype.Custom:
+	case
+		datatype.String,
+		datatype.Bool,
+		datatype.Int,
+		datatype.Int64,
+		datatype.Uint,
+		datatype.Uint64,
+		datatype.Coin,
+		datatype.Custom:
 		return false
 	default:
 		// For other types, we assume that it is a slice if non indexable.

--- a/ignite/templates/field/field.go
+++ b/ignite/templates/field/field.go
@@ -35,7 +35,7 @@ func (f Field) IsSlice() bool {
 		panic(fmt.Sprintf("unknown type %s", f.DatatypeName))
 	}
 
-	return dt.NonIndex
+	return dt.NonIndex && f.Datatype != string(datatype.Coin)
 }
 
 // ProtoFieldName returns the field name used in proto.

--- a/ignite/templates/field/field.go
+++ b/ignite/templates/field/field.go
@@ -28,14 +28,27 @@ func (f Field) DataType() string {
 }
 
 // IsSlice returns true if the field is a slice.
-// It assumes that a non indexable type is a slice.
 func (f Field) IsSlice() bool {
 	dt, ok := datatype.IsSupportedType(f.DatatypeName)
 	if !ok {
 		panic(fmt.Sprintf("unknown type %s", f.DatatypeName))
 	}
 
-	return dt.NonIndex && f.Datatype != string(datatype.Coin)
+	switch f.DatatypeName {
+	case datatype.StringSlice,
+		datatype.IntSlice,
+		datatype.UintSlice,
+		datatype.StringSliceAlias,
+		datatype.IntSliceAlias,
+		datatype.UintSliceAlias,
+		datatype.CoinSliceAlias:
+		return true
+	case datatype.Coin, datatype.Custom:
+		return false
+	default:
+		// For other types, we assume that it is a slice if non indexable.
+		return dt.NonIndex
+	}
 }
 
 // ProtoFieldName returns the field name used in proto.

--- a/ignite/templates/field/field_test.go
+++ b/ignite/templates/field/field_test.go
@@ -1,0 +1,80 @@
+package field
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ignite/cli/v29/ignite/pkg/multiformatname"
+	"github.com/ignite/cli/v29/ignite/templates/field/datatype"
+)
+
+// TestField_IsSlice tests the IsSlice method of Field struct.
+func TestField_IsSlice(t *testing.T) {
+	testCases := []struct {
+		name     string
+		field    Field
+		expected bool
+	}{
+		{
+			name: "array type should be slice",
+			field: Field{
+				Name:         multiformatname.Name{},
+				DatatypeName: datatype.IntSlice,
+				Datatype:     string(datatype.IntSlice),
+			},
+			expected: true,
+		},
+		{
+			name: "array type should be slice",
+			field: Field{
+				Name:         multiformatname.Name{},
+				DatatypeName: datatype.Bytes,
+				Datatype:     string(datatype.Bytes),
+			},
+			expected: true,
+		},
+		{
+			name: "array type should be slice",
+			field: Field{
+				Name:         multiformatname.Name{},
+				DatatypeName: datatype.CoinSliceAlias,
+				Datatype:     string(datatype.CoinSliceAlias),
+			},
+			expected: true,
+		},
+		{
+			name: "coin type should not be slice",
+			field: Field{
+				Name:         multiformatname.Name{},
+				DatatypeName: datatype.Coin,
+				Datatype:     string(datatype.Coin),
+			},
+			expected: false,
+		},
+		{
+			name: "string type should not be slice",
+			field: Field{
+				Name:         multiformatname.Name{},
+				DatatypeName: datatype.String,
+				Datatype:     "",
+			},
+			expected: false,
+		},
+		{
+			name: "int type should not be slice",
+			field: Field{
+				Name:         multiformatname.Name{},
+				DatatypeName: datatype.Int,
+				Datatype:     "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.field.IsSlice())
+		})
+	}
+}


### PR DESCRIPTION
`IsSlice` was doing the shortcut of NonIndexable = Slices.
While 99% true, this isn't the case for Coin.

- [x] check for all supported data types if there're not other mismatch.