### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/ignite/pkg/cosmosbuf/buf.go
+++ b/ignite/pkg/cosmosbuf/buf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"strings"
 
@@ -277,9 +278,7 @@ func (b Buf) Generate(
 		flagErrorFormat: fmtJSON,
 		flagLogFormat:   fmtJSON,
 	}
-	for k, v := range opts.flags {
-		flags[k] = v
-	}
+	maps.Copy(flags, opts.flags)
 	if opts.includeImports {
 		flags[flagIncludeImports] = "true"
 	}

--- a/integration/client.go
+++ b/integration/client.go
@@ -2,6 +2,7 @@ package envtest
 
 import (
 	"bytes"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,9 +26,7 @@ type ClientOption func(*clientOptions)
 // ClientEnv option defines environment values for the tests.
 func ClientEnv(env map[string]string) ClientOption {
 	return func(o *clientOptions) {
-		for k, v := range env {
-			o.env[k] = v
-		}
+		maps.Copy(o.env, env)
 	}
 }
 


### PR DESCRIPTION
Optimize code using a more modern writing style.