### PR TITLE
docs: Add fmt to imports hello-world

### DIFF
--- a/docs/docs/02-guide/03-hello-world.md
+++ b/docs/docs/02-guide/03-hello-world.md
@@ -53,6 +53,7 @@ package keeper
 
 import (
  "context"
+ "fmt"
 
  "hello/x/hello/types"
 


### PR DESCRIPTION
"fmt" was missing in the imports of the hello-world tutorial but used.