### PR TITLE
chore: bump client/v2 + prepare v29

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@
 - [#4707](https://github.com/ignite/cli/pull/4707) Show `buf` version in `ignite version` only when in a go module.
 - [#4709](https://github.com/ignite/cli/pull/4709) Remove legacy msgServer support
 
-### Bug Fixes
+### Fixes
 
 - [#4686](https://github.com/ignite/cli/pull/4686) Filter discovered protos to only messages.
 - [#4694](https://github.com/ignite/cli/issues/4694) Install an app using the `.` as a current path show a wrong app name.
@@ -208,7 +208,7 @@
 
 - [#4376](https://github.com/ignite/cli/pull/4376) Set different chain-id for in place testnet
 
-### Bug Fixes
+### Fixes
 
 - [#4421](https://github.com/ignite/cli/pull/4422) Fix typo in simulation template
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [`v29.0.0`](https://github.com/ignite/cli/releases/tag/v29.0.0)
+
 ### Features
 
 - [#4683](https://github.com/ignite/cli/pull/4683) Allow to change default denom via flag.

--- a/ignite/cmd/generate_typescript_client.go
+++ b/ignite/cmd/generate_typescript_client.go
@@ -36,7 +36,8 @@ changes when the blockchain is started with a flag:
 
 	ignite chain serve --generate-clients
 `,
-		RunE: generateTSClientHandler,
+		RunE:   generateTSClientHandler,
+		Hidden: true, // TODO(julienrbrt): remove this after https://github.com/ignite/cli/pull/4706.
 	}
 
 	c.Flags().AddFlagSet(flagSetYes())

--- a/ignite/templates/app/files/go.mod.plush
+++ b/ignite/templates/app/files/go.mod.plush
@@ -13,7 +13,7 @@ replace (
 
 require (
 	cosmossdk.io/api v0.9.2
-	cosmossdk.io/client/v2 v2.0.0-beta.8.0.20250402172810-41e3e9d004a1
+	cosmossdk.io/client/v2 v2.0.0-beta.11
 	cosmossdk.io/collections v1.2.0
 	cosmossdk.io/core v0.11.3
 	cosmossdk.io/depinject v1.2.0


### PR DESCRIPTION
Closes: https://github.com/ignite/cli/issues/4623, https://github.com/ignite/cli/issues/4708

---

## 🚀 Highlights

Ignite CLI v29.0.0 is finally there! This new version is packed with new features and dev ux improvement: 

* As always, Ignite scaffolds the latest Cosmos Stack: Cosmos SDK v0.53, IBC-go v10 (IBC v1 and v2 enabled), and all the latest features enabled 💥.
* New scaffolding commands: `config`, `params` and new scaffolding flags: `--default-denom` to allow you to do more, with less.
* Thanks to an overhaul of the CLI internal, Ignite now scaffolds a chain without cluttering it with the infamous `// this line is used by starport scaffolding` line.
* Scaffolded modules now uses `cosmossdk.io/collections` for state management.
* New `xast` package to help developers make Ignite Apps even easily (an Ignite EVM App is coming, thanks to that).
* The CLI stays compatible with all [Ignite Apps](https://github.com/ignite/apps), only some are being updated to work with IBC-go v10 (notably Ignite Wasm App).
* Improved tooling, by using the latest Go 1.24 and buf features. Only a `ignite doctor` away, when upgrading from v28.

Upgrade today and supercharge your chain development with the best Ignite experience yet!

## 📝 Changelog

Following an exhaustive list of changes in this release:

## [`v29.0.0`](https://github.com/ignite/cli/releases/tag/v29.0.0)

### Features

- [#3707](https://github.com/ignite/cli/pull/3707) and [#4094](https://github.com/ignite/cli/pull/4094) Add collections support.
- [#3977](https://github.com/ignite/cli/pull/3977) Add `chain lint` command to lint the chain's codebase using `golangci-lint`
- [#3770](https://github.com/ignite/cli/pull/3770) Add `scaffold configs` and `scaffold params` commands
- [#4001](https://github.com/ignite/cli/pull/4001) Improve `xgenny` dry run
- [#3967](https://github.com/ignite/cli/issues/3967) Add HD wallet parameters `address index` and `account number` to the chain account config
- [#4004](https://github.com/ignite/cli/pull/4004) Remove all import placeholders using the `xast` pkg
- [#4071](https://github.com/ignite/cli/pull/4071) Support custom proto path
- [#3718](https://github.com/ignite/cli/pull/3718) Add `gen-mig-diffs` tool app to compare scaffold output of two versions of ignite
- [#4100](https://github.com/ignite/cli/pull/4100) Set the `proto-dir` flag only for the `scaffold chain` command and use the proto path from the config
- [#4111](https://github.com/ignite/cli/pull/4111) Remove vuex generation
- [#4113](https://github.com/ignite/cli/pull/4113) Generate chain config documentation automatically
- [#4131](https://github.com/ignite/cli/pull/4131) Support `bytes` as data type in the `scaffold` commands
- [#4300](https://github.com/ignite/cli/pull/4300) Only panics the module in the most top function level
- [#4327](https://github.com/ignite/cli/pull/4327) Use the TxConfig from simState instead create a new one
- [#4326](https://github.com/ignite/cli/pull/4326) Add `buf.build` version to `ignite version` command
- [#4436](https://github.com/ignite/cli/pull/4436) Return tx hash to the faucet API
- [#4437](https://github.com/ignite/cli/pull/4437) Remove module placeholders
- [#4289](https://github.com/ignite/cli/pull/4289), [#4423](https://github.com/ignite/cli/pull/4423), [#4432](https://github.com/ignite/cli/pull/4432), [#4507](https://github.com/ignite/cli/pull/4507), [#4524](https://github.com/ignite/cli/pull/4524) Cosmos SDK v0.52 support and downgrade back to 0.50, while keeping latest improvements.
- [#4480](https://github.com/ignite/cli/pull/4480) Add field max length
- [#4477](https://github.com/ignite/cli/pull/4477), [#4559](https://github.com/ignite/cli/pull/4559) IBC v10 support
- [#4166](https://github.com/ignite/cli/issues/4166) Migrate buf config files to v2
- [#4494](https://github.com/ignite/cli/pull/4494) Automatic migrate the buf configs to v2
- [#4509](https://github.com/ignite/cli/pull/4509) Upgrade to Go 1.24. Running `ignite doctor` migrates the scaffolded `tools.go` to the tool directive in the go.mod
- [#4588](https://github.com/ignite/cli/pull/4588) Run `buf format after scaffold proto files.
- [#4603](https://github.com/ignite/cli/issues/4603) Add `GetIgniteInfo` gRPC API for apps.
- [#4657](https://github.com/ignite/cli/pull/4657) Upgrade to Cosmos SDK [v0.53.0](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.0).
  - Add x/epochs module to default template (except for minimal template).
  - Bump minimum compatible Cosmos SDK version to `v0.50.0`.
- [#4683](https://github.com/ignite/cli/pull/4683) Allow to change default denom via flag.
- [#4687](https://github.com/ignite/cli/pull/4687) Add address type with `scalar` annotations, and add `scalar` type to signer field.
- [#4686](https://github.com/ignite/cli/pull/4686) Filter discovered protos to only messages.
- [#4694](https://github.com/ignite/cli/issues/4694) Install an app using the `.` as a current path show a wrong app name.

### Changes

- [#4094](https://github.com/ignite/cli/pull/4094) Scaffolding a multi-index map using `ignite s map foo bar baz --index foobar,foobaz` is no longer supported. Use one index instead of use `collections.IndexedMap`.
- [#4058](https://github.com/ignite/cli/pull/4058) Simplify scaffolded modules by including `ValidateBasic()` logic in message handler.
- [#4058](https://github.com/ignite/cli/pull/4058) Use `address.Codec` instead of `AccAddressFromBech32`.
- [#3993](https://github.com/ignite/cli/pull/3993) Oracle scaffolding was deprecated and has been removed
- [#3962](https://github.com/ignite/cli/pull/3962) Rename all RPC endpoints and autocli commands generated for `map`/`list`/`single` types
- [#3976](https://github.com/ignite/cli/pull/3976) Remove error checks for Cobra command value get calls
- [#4002](https://github.com/ignite/cli/pull/4002) Bump buf build
- [#4008](https://github.com/ignite/cli/pull/4008) Rename `pkg/yaml` to `pkg/xyaml`
- [#4075](https://github.com/ignite/cli/pull/4075) Use `gopkg.in/yaml.v3` instead `gopkg.in/yaml.v2`
- [#4118](https://github.com/ignite/cli/pull/4118) Version scaffolded protos as `v1` to follow SDK structure.
- [#4167](https://github.com/ignite/cli/pull/4167) Scaffold `int64` instead of `int32` when a field type is `int`
- [#4159](https://github.com/ignite/cli/pull/4159) Enable gci linter
- [#4160](https://github.com/ignite/cli/pull/4160) Enable copyloopvar linter
- [#4162](https://github.com/ignite/cli/pull/4162) Enable errcheck linter
- [#4189](https://github.com/ignite/cli/pull/4189) Deprecate `ignite node` for `ignite connect` app
- [#4290](https://github.com/ignite/cli/pull/4290) Remove ignite ics logic from ignite cli (this functionality will be in the `consumer` app)
- [#4295](https://github.com/ignite/cli/pull/4295) Stop scaffolding `pulsar` files
- [#4317](https://github.com/ignite/cli/pull/4317) Remove xchisel dependency
- [#4361](https://github.com/ignite/cli/pull/4361) Remove unused `KeyPrefix` method
- [#4384](https://github.com/ignite/cli/pull/4384) Compare genesis params into chain genesis tests
- [#4463](https://github.com/ignite/cli/pull/4463) Run `chain simulation` with any simulation test case
- [#4533](https://github.com/ignite/cli/pull/4533) Promote GitHub codespace instead of Gitpod
- [#4549](https://github.com/ignite/cli/pull/4549) Remove unused placeholder vars
- [#4557](https://github.com/ignite/cli/pull/4557) Remove github.com/gookit/color
- [#4596](https://github.com/ignite/cli/pull/4596) Add default `openapi.yml` when skipping proto gen.
- [#4601](https://github.com/ignite/cli/pull/4601) Add `appregistry` as default plugin
- [#4613](https://github.com/ignite/cli/pull/4613) Improve and simplify prompting logic by bubbletea.
- [#4624](https://github.com/ignite/cli/pull/4624) Fix autocli templates for variadics.
- [#4644](https://github.com/ignite/cli/pull/4644) Improve UI and UX for `testnet multi-node` command.
- [#4645](https://github.com/ignite/cli/pull/4645) Refactor the xast.ModifyFunction to improve the readability.
- [#3393](https://github.com/ignite/cli/issues/3393) Remove xgenny embed walker
- [#4664](https://github.com/ignite/cli/pull/4664) Add verbose flags on `scaffold` and `generate` commands.
  - The flag displays the steps Ignite is taking to generate the code.
  - The verbosity only applies to the command. For full verbosity use the `IGNT_DEBUG` environment variable instead.
- [#4689](https://github.com/ignite/cli/pull/4689) Revert `HasGenesis` implementation from retracted `core` v1 to SDK `HasGenesis` interface.
- [#4701](https://github.com/ignite/cli/pull/4701) Improve `ignite doctor` by removing manual migration step. Additionally, remove protoc to buf migrations logic.
- [#4703](https://github.com/ignite/cli/pull/4703) Remove testutil.Register function.
- [#4702](https://github.com/ignite/cli/pull/4702) Improve app detection by checking for inheritance instead of interface implementation.
- [#4707](https://github.com/ignite/cli/pull/4707) Show `buf` version in `ignite version` only when in a go module.
- [#4709](https://github.com/ignite/cli/pull/4709) Remove legacy msgServer support

### Fixes

- [#4000](https://github.com/ignite/cli/pull/4000) Run all dry runners before the wet run in the `xgenny` pkg
- [#4091](https://github.com/ignite/cli/pull/4091) Fix race conditions in the plugin logic
- [#4128](https://github.com/ignite/cli/pull/4128) Check for duplicate proto fields in config
- [#4402](https://github.com/ignite/cli/pull/4402) Fix gentx parser into the cosmosutil package
- [#4552](https://github.com/ignite/cli/pull/4552) Avoid direct access to proto field `perms.Account` and `perms.Permissions`
- [#4555](https://github.com/ignite/cli/pull/4555) Fix buf lint issues into the chain code
- [#4347](https://github.com/ignite/cli/pull/4347) Fix `ts-client` generation
- [#4577](https://github.com/ignite/cli/pull/4577) Add proto version to query path.
- [#4579](https://github.com/ignite/cli/pull/4579) Fix empty params response.
- [#4585](https://github.com/ignite/cli/pull/4585) Fix faucet cmd issue.
- [#4587](https://github.com/ignite/cli/pull/4587) Add missing light clients routes to IBC client keeper.
- [#4595](https://github.com/ignite/cli/pull/4595) Fix wrong InterfaceRegistry for IBC modules.
- [#4609](https://github.com/ignite/cli/pull/4609) Add work dir for relayer integration tests.
- [#4658](https://github.com/ignite/cli/pull/4658) Fix indentation for params scaffolded into a struct.
- [#4582](https://github.com/ignite/cli/issues/4582) Fix xast misplacing comments.
- [#4660](https://github.com/ignite/cli/pull/4660) Fix xast test case indentation.
- [#4667](https://github.com/ignite/cli/pull/4667) Harden `IsSlice`