### PR TITLE
feat(cmd): add `--output-file` flag to `chain serve`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@
 
 - [#4676](https://github.com/ignite/cli/issues/4676) Add Decimal Coin Type.
 - [#4765](https://github.com/ignite/cli/pull/4765) Create `scaffold type-list` command.
-- [#4770](https://github.com/ignite/cli/pull/4770) Add `--daemon` flag to `chain serve` command to allow running the chain in the background.
+- [#4770](https://github.com/ignite/cli/pull/4770) Add `--output-file` flag to `chain serve` command to improve running `chain serve` in the background.
 
 ### Changes
 


### PR DESCRIPTION
Add helper to easily setup `chain serve` to run as daemon.
Note, it doesn't fork the process and does anything like this as it wouldn't be Go idiomatic. We should let the shell handle putting the process in background with `&`.

cc @clockworkgr 