### PR TITLE
Fix nightly build latest release

### DIFF
--- a/.github/workflows/gen-docs-version.yml
+++ b/.github/workflows/gen-docs-version.yml
@@ -48,24 +48,6 @@ jobs:
             DOCUSAURUS_VERSION=${MAJOR_VERSION:1}
           fi
 
-          # Check if this version is newer than existing versions
-          # Extract major version number for comparison
-          CURRENT_MAJOR=$(echo $DOCUSAURUS_VERSION | sed 's/^v//')
-
-          # Check if there's already a newer major version in versions.json
-          NEWER_EXISTS=$(jq -r --arg current "$CURRENT_MAJOR" '
-            map(select(. != ("v" + $current))) |
-            map(select(. | test("^v[0-9]+$"))) |
-            map(ltrimstr("v") | tonumber) |
-            map(select(. > ($current | tonumber))) |
-            length > 0
-          ' versions.json)
-
-          if [[ "$NEWER_EXISTS" == "true" ]]; then
-            echo "Skipping deployment for v$DOCUSAURUS_VERSION as newer major version already exists"
-            exit 0
-          fi
-
           jq --arg version "v$DOCUSAURUS_VERSION" 'del(.[] | select(. == $version))' versions.json > versions.json.tmp
           mv versions.json.tmp versions.json
           rm -rf versioned_docs/version-v$DOCUSAURUS_VERSION

--- a/.github/workflows/gen-docs-version.yml
+++ b/.github/workflows/gen-docs-version.yml
@@ -48,6 +48,24 @@ jobs:
             DOCUSAURUS_VERSION=${MAJOR_VERSION:1}
           fi
 
+          # Check if this version is newer than existing versions
+          # Extract major version number for comparison
+          CURRENT_MAJOR=$(echo $DOCUSAURUS_VERSION | sed 's/^v//')
+
+          # Check if there's already a newer major version in versions.json
+          NEWER_EXISTS=$(jq -r --arg current "$CURRENT_MAJOR" '
+            map(select(. != ("v" + $current))) |
+            map(select(. | test("^v[0-9]+$"))) |
+            map(ltrimstr("v") | tonumber) |
+            map(select(. > ($current | tonumber))) |
+            length > 0
+          ' versions.json)
+
+          if [[ "$NEWER_EXISTS" == "true" ]]; then
+            echo "Skipping deployment for v$DOCUSAURUS_VERSION as newer major version already exists"
+            exit 0
+          fi
+
           jq --arg version "v$DOCUSAURUS_VERSION" 'del(.[] | select(. == $version))' versions.json > versions.json.tmp
           mv versions.json.tmp versions.json
           rm -rf versioned_docs/version-v$DOCUSAURUS_VERSION

--- a/ignite/version/version.go
+++ b/ignite/version/version.go
@@ -112,8 +112,14 @@ func resolveDevVersion(ctx context.Context) string {
 
 	// if the module version is higher than the latest tag, use the module version
 	if info, ok := debug.ReadBuildInfo(); ok {
-		if version := path.Base(info.Main.Path); version > tag {
-			tag = fmt.Sprintf("%s.0.0", version)
+		if version := path.Base(info.Main.Path); version != "" {
+			// Parse both versions for proper semantic comparison
+			moduleVer, err1 := semver.ParseTolerant(version + ".0.0")
+			tagVer, err2 := semver.ParseTolerant(tag)
+
+			if err1 == nil && err2 == nil && moduleVer.GT(tagVer) {
+				tag = fmt.Sprintf("%s.0.0", version)
+			}
 		}
 	}
 


### PR DESCRIPTION
`version.go` is doing a string comparison (`version > tag`) instead of proper semantic version comparison.

This could cause:
  - "v28.11.0" > "v29.1.0" to be true (string comparison)
  - When it should be false (semantic version comparison)

Fix:
  - Replace string comparison with proper semantic version
  - Added error handling to ensure both versions parse correctly before comparison
  - Used `moduleVer.GT(tagVer)` for proper semantic version comparison

Context:

<img width="837" height="555" alt="Screenshot 2025-07-15 at 10 04 13 AM" src="https://github.com/user-attachments/assets/a0e55727-3d75-4c41-905d-586b6c8c1dbb" />
