### PR TITLE
chore: skip checkout and run mod tidy for each integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -18,9 +18,24 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+
       - name: Finding files and store to output
         id: set-matrix
         run: echo "matrix=$({ cd integration && find . -type d ! -name testdata -maxdepth 1 -print; } | tail -n +2 | cut -c 3- | jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Download Go modules
+        run: go mod tidy
+
+      - name: Upload prepared workspace
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace
+          path: .
+          retention-days: 1
 
   integration:
     name: test ${{ matrix.test-path }} on ${{ matrix.os }}
@@ -31,10 +46,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        test-path: ${{fromJson(needs.pre-test.outputs.matrix)}}
+        os: [ ubuntu-latest, macos-latest ]
+        test-path: ${{ fromJson(needs.pre-test.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Download prepared workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+          path: .
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Skip checkout the project and run `go mod tidy` for each integration test. This PR runs it once and uploads it as an artifact for the CI to use for each integration test.