### PR TITLE
fix: replace broken `bytedance/sonic` version in the `go.mod`

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ ubuntu-latest, macos-latest ]
         test-path: ${{fromJson(needs.pre-test.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +39,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "stable"
+
+      - name: Run Go Mod Tidy
+        run: go mod tidy
 
       - name: Run Integration Tests
         env:

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- [#4793](https://github.com/ignite/cli/pull/4793) Replace broken `bytedance/sonic` version in the `go.mod`.
+- [#4793](https://github.com/ignite/cli/pull/4793) Use latest `bytedance/sonic` version to support Go 1.25.
 
 ## [`v29.3.0`](https://github.com/ignite/cli/releases/tag/v29.3.0)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#4793](https://github.com/ignite/cli/pull/4793) Replace broken `bytedance/sonic` version in the `go.mod`.
+
 ## [`v29.3.0`](https://github.com/ignite/cli/releases/tag/v29.3.0)
 
 ### Features

--- a/ignite/templates/app/files/go.mod.plush
+++ b/ignite/templates/app/files/go.mod.plush
@@ -9,7 +9,7 @@ replace (
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	// replace broken vanity url
 	nhooyr.io/websocket => github.com/coder/websocket v1.8.7
-	// replace broken sonic version
+	// force latest sonic version for Go 1.25 support
 	github.com/bytedance/sonic => github.com/bytedance/sonic v1.14.0
 )
 

--- a/ignite/templates/app/files/go.mod.plush
+++ b/ignite/templates/app/files/go.mod.plush
@@ -10,7 +10,7 @@ replace (
 	// replace broken vanity url
 	nhooyr.io/websocket => github.com/coder/websocket v1.8.7
 	// replace broken sonic version
-	github.com/bytedance/sonic => github.com/bytedance/sonic v1.13.2
+	github.com/bytedance/sonic => github.com/bytedance/sonic v1.14.0
 )
 
 require (

--- a/ignite/templates/app/files/go.mod.plush
+++ b/ignite/templates/app/files/go.mod.plush
@@ -9,6 +9,8 @@ replace (
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	// replace broken vanity url
 	nhooyr.io/websocket => github.com/coder/websocket v1.8.7
+	// replace broken sonic version
+	github.com/bytedance/sonic => github.com/bytedance/sonic v1.13.2
 )
 
 require (


### PR DESCRIPTION
 replace the broken `github.com/bytedance/sonic` version in the `go.mod` 

Sometimes the `go.mod` downloads the `v1.14`:
https://github.com/ignite/cli/actions/runs/16953585035/job/48051162243?pr=4791#step:4:100

but the `cosmossdk.io/log` uses the `v1.13`
https://github.com/ignite/cli/actions/runs/16953585035/job/48051162243?pr=4791#step:4:224