### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/ignite/services/chain/chain.go
+++ b/ignite/services/chain/chain.go
@@ -587,8 +587,8 @@ func (c *Chain) parseAddressPrefix() (string, error) {
 	}
 
 	// try to find the AccountAddressPrefix constant
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(content), "\n")
+	for line := range lines {
 		// match both formats:
 		// AccountAddressPrefix = "cosmos"
 		// AccountAddressPrefix string = "cosmos"
@@ -631,8 +631,8 @@ func (c *Chain) parseCoinType() (uint32, error) {
 	}
 
 	// try to find the ChainCoinType constant
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(content), "\n")
+	for line := range lines {
 		if strings.Contains(line, "ChainCoinType") && strings.Contains(line, "=") {
 			parts := strings.Split(line, "=")
 			if len(parts) < 2 {


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901