### PR TITLE
fix(config): faucet default denom

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#4931](https://github.com/ignite/cli/pull/4931) Fix faucet default denom in generated app config.
+
 ## [`v29.10.0`](https://github.com/ignite/cli/releases/tag/v29.10.0)
 
 ## Features

--- a/ignite/templates/app/files/config.yml.plush
+++ b/ignite/templates/app/files/config.yml.plush
@@ -17,7 +17,7 @@ faucet:
   name: bob
   coins:
   - 5token
-  - 100000stake
+  - 100000<%= DefaultDenom %>
 validators:
 - name: alice
   bonded: 100000000<%= DefaultDenom %>


### PR DESCRIPTION
Minor fix for the initialized `config.yml`, correct the faucet default denom using configured default value