### PR TITLE
fix: delete msg type in singleton simulation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#4931](https://github.com/ignite/cli/pull/4931) Fix faucet default denom in generated app config.
+- [#4940](https://github.com/ignite/cli/pull/4940) Fix generated typed singleton delete simulations to use `MsgDelete`.
 
 ## [`v29.10.0`](https://github.com/ignite/cli/releases/tag/v29.10.0)
 

--- a/ignite/templates/typed/singleton/files/simapp/x/{{moduleName}}/simulation/{{typeName}}.go.plush
+++ b/ignite/templates/typed/singleton/files/simapp/x/{{moduleName}}/simulation/{{typeName}}.go.plush
@@ -107,7 +107,7 @@ func SimulateMsgDelete<%= TypeName.PascalCase %>(
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		var (
 			simAccount = simtypes.Account{}
-			msg = &types.MsgUpdate<%= TypeName.PascalCase %>{}
+			msg = &types.MsgDelete<%= TypeName.PascalCase %>{}
 		)
 
 		<%= TypeName.LowerCamel %>, err := k.<%= TypeName.UpperCamel %>.Get(ctx)


### PR DESCRIPTION
change msg type from `&types.MsgUpdate` to `&types.MsgDelete` in singleton `SimulateMsgDelete`