### PR TITLE
fix(ci): use ubuntu-latest in test coverage workflow

### DIFF
--- a/.github/workflows/test-cov.yml
+++ b/.github/workflows/test-cov.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: $ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What this changes

Fixes the runner label in the test coverage workflow from `$ubuntu-latest` to `ubuntu-latest`.

## Why

`ubuntu-latest` is the expected GitHub-hosted runner label. The previous value prevents the workflow from being assigned to a matching runner, leaving the job queued until it times out.
