### PR TITLE
fix(docs): wrap x/<module> paths in backticks to fix MDX build

### DIFF
--- a/docs/docs/03-CLI-Commands/01-cli-commands.md
+++ b/docs/docs/03-CLI-Commands/01-cli-commands.md
@@ -1784,9 +1784,9 @@ Module migration boilerplate
 
 Scaffold no-op migration boilerplate for an existing Cosmos SDK module.
 
-This command creates a new migration file in "x/<module>/migrations/vN/",
+This command creates a new migration file in `x/<module>/migrations/vN/`,
 increments the module consensus version, and registers the new migration handler
-inside "x/<module>/module/module.go".
+inside `x/<module>/module/module.go`.
 
 ```
 ignite scaffold migration [module] [flags]

--- a/docs/versioned_docs/version-v29/03-CLI-Commands/01-cli-commands.md
+++ b/docs/versioned_docs/version-v29/03-CLI-Commands/01-cli-commands.md
@@ -1784,9 +1784,9 @@ Module migration boilerplate
 
 Scaffold no-op migration boilerplate for an existing Cosmos SDK module.
 
-This command creates a new migration file in "x/<module>/migrations/vN/",
+This command creates a new migration file in `x/<module>/migrations/vN/`,
 increments the module consensus version, and registers the new migration handler
-inside "x/<module>/module/module.go".
+inside `x/<module>/module/module.go`.
 
 ```
 ignite scaffold migration [module] [flags]


### PR DESCRIPTION
## Problem

`yarn build` (Docusaurus) fails with:

```
SyntaxError: Expected corresponding JSX closing tag for <module>. (1215:43)
```

MDX parses the unquoted `<module>` in plain-text prose as an unclosed JSX tag, aborting the client bundle compile.

## Fix

Wrap the affected file-path snippets in inline code backticks so MDX treats them as text, not JSX:

- `"x/<module>/migrations/vN/"` → `` `x/<module>/migrations/vN/` ``
- `"x/<module>/module/module.go"` → `` `x/<module>/module/module.go` ``

Applied in both the current docs and the `version-v29` copy of `03-CLI-Commands/01-cli-commands.md`.

## Verification

`yarn build` now completes: `[SUCCESS] Generated static files in "build".`

🤖 Generated with [Claude Code](https://claude.com/claude-code)